### PR TITLE
Restricted input length, and removed buttons after next click on Job Name page.

### DIFF
--- a/extensions/copy-data-wizard/src/test/scala/org/eobjects/datacleaner/monitor/jobwizard/movedata/CopyDataWizardTest.scala
+++ b/extensions/copy-data-wizard/src/test/scala/org/eobjects/datacleaner/monitor/jobwizard/movedata/CopyDataWizardTest.scala
@@ -398,7 +398,7 @@ class CopyDataWizardTest extends AssertionsForJUnit {
 	<div>
 		<label>Please provide a name for the new job </label>
 		<div>
-			<input type="text" size="30" value="Copy data" name="name" />
+			<input type="text" maxlength="64" size="30" value="Copy data" name="name" />
 		</div>
 	</div>
 </div>"""), normalize(page6.getFormInnerHtml()));

--- a/monitor/services/src/main/resources/org/eobjects/datacleaner/monitor/server/wizard/JobNameWizardPage.html
+++ b/monitor/services/src/main/resources/org/eobjects/datacleaner/monitor/server/wizard/JobNameWizardPage.html
@@ -9,7 +9,7 @@
 	<div>
 		<label>Please provide a name for the new job </label>
 		<div>
-			<input type="text" size="30" value="${name?html}" name="name" />
+			<input type="text" maxlength="64" size="30" value="${name?html}" name="name" />
 		</div>
 	</div>
 </div>

--- a/monitor/widgets/src/main/java/org/eobjects/datacleaner/monitor/wizard/AbstractWizardController.java
+++ b/monitor/widgets/src/main/java/org/eobjects/datacleaner/monitor/wizard/AbstractWizardController.java
@@ -197,6 +197,7 @@ public abstract class AbstractWizardController<S extends WizardNavigationService
             public void onSuccess(final WizardPage page) {
                 final String wizardDisplayName = _wizardIdentifier.getDisplayName();
                 if (page.isFinished()) {
+                	_wizardPanel.getButtonPanel().removeAllButtons();
                     final String resultEntityName = page.getWizardResult();
                     JavaScriptCallbacks.onWizardFinished(wizardDisplayName, resultEntityName);
                     wizardFinished(resultEntityName);


### PR DESCRIPTION
Restricted maximum input length of Job Name to 64 characters. Also wrote code to make Previous, Next and Cacel buttons to disappear when Next button is clicked after entering the job name in a wizard. This was done to prevent a click on either of the 3 buttons in the short timeframe between clicking of the Next button on the Job name page, and appearance of the next page.
