### PR TITLE
Add Elastic Search extension package to DC "scannedPackages" list.

### DIFF
--- a/monitor/ui/src/main/resources/context/application-context.xml
+++ b/monitor/ui/src/main/resources/context/application-context.xml
@@ -14,6 +14,7 @@
 				<value>org.eobjects.datacleaner.output.beans</value>
 				<value>org.eobjects.datacleaner.panels</value>
 				<value>org.eobjects.datacleaner.widgets.result</value>
+				<value>org.eobjects.datacleaner.extension.elasticsearch</value>
 				<value>com.hi</value>
 				<value>com.neopost.cim</value>
 			</list>


### PR DESCRIPTION
This will allow usage of the extension without having to modify the application-context.xml
