### PR TITLE
#136 Fixed exception when image not found in imported extension

### DIFF
--- a/desktop/src/main/java/org/eobjects/datacleaner/util/ImageManager.java
+++ b/desktop/src/main/java/org/eobjects/datacleaner/util/ImageManager.java
@@ -88,7 +88,7 @@ public final class ImageManager {
             URL url = resourceManager.getUrl(imagePath, classLoaders);
 
             if (url == null && classLoaders != null) {
-                getImage(imagePath, null);
+                return getImage(imagePath, null);
             }
             else if (url == null) {
                 logger.warn("Image path ({}) could not be resolved", imagePath);


### PR DESCRIPTION
When the URL is found to be null and classLoaders is not null, assuming an extension is at cause, null the classLoaders and try again.  This should result in trying the DataCleaner default provided images.  If the classLoaders were specific to DataCleaner, then this will cause one more attempt.  However, I expect this to be a rare case.
