### PR TITLE
Modify the "columns" variable to include the "column to be sorted on" in case we do not include it in the input columns

### DIFF
--- a/core/src/main/java/org/eobjects/datacleaner/extension/output/CreateCsvFileAnalyzer.java
+++ b/core/src/main/java/org/eobjects/datacleaner/extension/output/CreateCsvFileAnalyzer.java
@@ -136,7 +136,6 @@ public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implemen
 
     @Override
     public OutputWriter createOutputWriter() {
-        InputColumn<?>[] inputColumns = columns ;
         List<String> headers = new ArrayList<String>() ;
         for (int i = 0; i < columns.length; i++) {
             String columnName = columns[i].getName();
@@ -158,12 +157,12 @@ public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implemen
                     newColumns[i] = columns[i] ;
                 }
                 newColumns[columns.length]  = columnToBeSortedOn ;
-                inputColumns = newColumns ;
+                columns = newColumns ;
             }
         }
        
         
-        return CsvOutputWriterFactory.getWriter(_targetFile.getPath(), headers.toArray(new String[0]), separatorChar, quoteChar, escapeChar, includeHeader, inputColumns);
+        return CsvOutputWriterFactory.getWriter(_targetFile.getPath(), headers.toArray(new String[0]), separatorChar, quoteChar, escapeChar, includeHeader, columns);
     }
 
     @Override


### PR DESCRIPTION
Updated code to modify the "columns" variable to include the "column to be sorted on" in case we do not include it in the input columns.

This was done as the "columns" variable was being used to write the rows to the temp file, and thus if a column to be sorted on was selected, then its value would be null in the row written to the temp file (thereby leading to a potential incorrect sorted order in the final file).