### PR TITLE
Keeping amount of dialogs reasonable.

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
@@ -67,6 +67,7 @@ import org.datacleaner.util.LabelUtils;
 import org.datacleaner.util.ReflectionUtils;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.windows.ComponentConfigurationDialog;
+import org.datacleaner.windows.SourceTableConfigurationDialog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +94,8 @@ public final class JobGraph {
     private static final ImageManager imageManager = ImageManager.get();
     private static final Logger logger = LoggerFactory.getLogger(JobGraph.class);
 
-    private final Map<ComponentBuilder, ComponentConfigurationDialog> _configurationDialogs;
+    private final Map<ComponentBuilder, ComponentConfigurationDialog> _componentConfigurationDialogs;
+    private final Map<Table, SourceTableConfigurationDialog> _tableConfigurationDialogs;    
     private final Set<Object> _highlighedVertexes;
     private final AnalysisJobBuilder _analysisJobBuilder;
     private final RendererFactory _presenterRendererFactory;
@@ -111,8 +113,9 @@ public final class JobGraph {
         _analysisJobBuilder = analysisJobBuilder;
         _windowContext = windowContext;
         _usageLogger = usageLogger;
-        _configurationDialogs = new IdentityHashMap<>();
-
+        _componentConfigurationDialogs = new IdentityHashMap<>();
+        _tableConfigurationDialogs = new IdentityHashMap<>();
+        
         if (presenterRendererFactory == null) {
             _presenterRendererFactory = new RendererFactory(analysisJobBuilder.getConfiguration());
         } else {
@@ -331,7 +334,7 @@ public final class JobGraph {
         }
 
         final JobGraphMouseListener graphMouseListener = new JobGraphMouseListener(graphContext, linkPainter,
-                _presenterRendererFactory, _windowContext, _usageLogger, _configurationDialogs);
+                _presenterRendererFactory, _windowContext, _usageLogger, _componentConfigurationDialogs, _tableConfigurationDialogs);
 
         visualizationViewer.addGraphMouseListener(graphMouseListener);
         visualizationViewer.addMouseListener(graphMouseListener);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
@@ -132,7 +132,7 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
         if (renderer != null) {
             final ComponentBuilderPresenter presenter = renderer.render(componentBuilder);
 
-            final ComponentConfigurationDialog dialog = new ComponentConfigurationDialog(componentBuilder,
+            final ComponentConfigurationDialog dialog = new ComponentConfigurationDialog(_windowContext, componentBuilder,
                     _graphContext.getAnalysisJobBuilder(), presenter);
             dialog.addWindowListener(new WindowAdapter() {
                 @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
@@ -54,6 +54,7 @@ import org.datacleaner.job.HasFilterOutcomes;
 import org.datacleaner.job.InputColumnSourceJob;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.job.builder.ComponentRemovalListener;
 import org.datacleaner.job.builder.TransformerComponentBuilder;
 import org.datacleaner.metadata.HasMetadataProperties;
 import org.datacleaner.panels.ComponentBuilderPresenter;
@@ -131,6 +132,12 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
 
             final ComponentConfigurationDialog dialog = new ComponentConfigurationDialog(componentBuilder,
                     _graphContext.getAnalysisJobBuilder(), presenter);
+            componentBuilder.addRemovalListener(new ComponentRemovalListener<ComponentBuilder>() {
+                @Override
+                public void onRemove(ComponentBuilder componentBuilder) {
+                    dialog.close();
+                }
+            });
             dialog.addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowClosed(WindowEvent e) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -29,6 +29,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -866,6 +867,22 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
                         windowsMenuItem.add(switchToWindowItem);
                     }
 
+                    windowsMenuItem.add(new JSeparator());
+                    
+                    JMenuItem closeAllWindowsItem = WidgetFactory.createMenuItem("Close all dialogs", (ImageIcon) null);
+                    closeAllWindowsItem.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            List<DCWindow> windows = new ArrayList<>(getWindowContext().getWindows());
+                            for(DCWindow window : windows){
+                                if(window instanceof AbstractDialog){
+                                    window.close();
+                                }
+                            }
+                        }
+                    });
+                    windowsMenuItem.add(closeAllWindowsItem);
+                    
                     popup.removeAll();
                     popup.add(dictionariesMenuItem);
                     popup.add(synonymCatalogsMenuItem);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
@@ -31,6 +31,7 @@ import javax.swing.JComponent;
 import org.datacleaner.actions.RenameComponentActionListener;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.job.builder.ComponentRemovalListener;
 import org.datacleaner.panels.ComponentBuilderPresenter;
 import org.datacleaner.panels.DCBannerPanel;
 import org.datacleaner.panels.DCPanel;
@@ -46,7 +47,7 @@ import org.datacleaner.widgets.visualization.JobGraph;
  * Dialog for configuring components that have been selected through the
  * {@link JobGraph}.
  */
-public class ComponentConfigurationDialog extends AbstractDialog {
+public class ComponentConfigurationDialog extends AbstractDialog implements ComponentRemovalListener<ComponentBuilder> {
 
     private static final long serialVersionUID = 1L;
 
@@ -60,7 +61,7 @@ public class ComponentConfigurationDialog extends AbstractDialog {
         super(null, getBannerImage(componentBuilder));
 
         _componentBuilder = componentBuilder;
-        
+        _componentBuilder.addRemovalListener(this);
         _presenter = presenter;
     }
 
@@ -136,5 +137,10 @@ public class ComponentConfigurationDialog extends AbstractDialog {
         panel.add(DCPanel.flow(Alignment.CENTER, closeButton), BorderLayout.SOUTH);
 
         return panel;
+    }
+
+    @Override
+    public void onRemove(ComponentBuilder componentBuilder) {
+        close();
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
@@ -60,6 +60,7 @@ public class ComponentConfigurationDialog extends AbstractDialog {
         super(null, getBannerImage(componentBuilder));
 
         _componentBuilder = componentBuilder;
+        
         _presenter = presenter;
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
@@ -29,6 +29,7 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 
 import org.datacleaner.actions.RenameComponentActionListener;
+import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.job.builder.ComponentRemovalListener;
@@ -54,11 +55,11 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
     private final ComponentBuilderPresenter _presenter;
     private final ComponentBuilder _componentBuilder;
 
-    public ComponentConfigurationDialog(ComponentBuilder componentBuilder, AnalysisJobBuilder analysisJobBuilder,
+    public ComponentConfigurationDialog(WindowContext windowContext, ComponentBuilder componentBuilder, AnalysisJobBuilder analysisJobBuilder,
             ComponentBuilderPresenter presenter) {
         // super(null,
         // ImageManager.get().getImage("images/window/banner-logo.png"));
-        super(null, getBannerImage(componentBuilder));
+        super(windowContext, getBannerImage(componentBuilder));
 
         _componentBuilder = componentBuilder;
         _componentBuilder.addRemovalListener(this);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SourceTableConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SourceTableConfigurationDialog.java
@@ -124,6 +124,10 @@ public class SourceTableConfigurationDialog extends AbstractDialog implements So
     @Override
     public void onRemove(InputColumn<?> column) {
         _columnListTable.removeColumn(column);
+        final boolean empty = _analysisJobBuilder.getSourceColumnsOfTable(_table).isEmpty();
+        if (empty) {
+            close();
+        }
     }
 
     @Override

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerChangeListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerChangeListener.java
@@ -22,17 +22,7 @@ package org.datacleaner.job.builder;
 /**
  * Listener interface for receiving notifications that analyzers are being added
  * or removed from a job that is being built.
- * 
- * 
  */
-public interface AnalyzerChangeListener {
-
-	public void onAdd(AnalyzerComponentBuilder<?> analyzerJobBuilder);
-	
-	public void onConfigurationChanged(AnalyzerComponentBuilder<?> analyzerJobBuilder);
-	
-	public void onRequirementChanged(AnalyzerComponentBuilder<?> analyzerJobBuilder);
-
-	public void onRemove(AnalyzerComponentBuilder<?> analyzerJobBuilder);
+public interface AnalyzerChangeListener extends ComponentChangeListener<AnalyzerComponentBuilder<?>> {
 	
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
@@ -344,7 +344,8 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
     /**
      * Notification method invoked when transformer is removed.
      */
-    protected void onRemoved() {
+    @Override
+    protected void onRemovedInternal() {
         List<AnalyzerChangeListener> listeners = getAllListeners();
         for (AnalyzerChangeListener listener : listeners) {
             listener.onRemove(this);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/ComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/ComponentBuilder.java
@@ -198,4 +198,21 @@ public interface ComponentBuilder extends HasMetadataProperties, InputColumnSink
      * @return a builder or null if none exist.
      */
     public AnalysisJobBuilder getAnalysisJobBuilder();
+
+    /**
+     * Adds a {@link ComponentRemovalListener} to this {@link ComponentBuilder}
+     * instance.
+     * 
+     * @param componentRemovalListener
+     */
+    public void addRemovalListener(ComponentRemovalListener<ComponentBuilder> componentRemovalListener);
+
+    /**
+     * Removes a {@link ComponentRemovalListener} from this
+     * {@link ComponentBuilder}.
+     * 
+     * @param componentRemovalListener
+     * @return true if the listener was found and removed.
+     */
+    public boolean removeRemovalListener(ComponentRemovalListener<ComponentBuilder> componentRemovalListener);
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/ComponentChangeListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/ComponentChangeListener.java
@@ -19,28 +19,29 @@
  */
 package org.datacleaner.job.builder;
 
-import java.util.List;
+import org.datacleaner.job.ComponentRequirement;
 
-import org.datacleaner.data.MutableInputColumn;
+public interface ComponentChangeListener<C extends ComponentBuilder> extends ComponentRemovalListener<C> {
+    
+    /**
+     * Invoked when a component is added to the {@link AnalysisJobBuilder}.
+     * 
+     * @param builder
+     */
+    public void onAdd(C builder);
 
-/**
- * Listener interface for receiving notifications when transformers are being
- * added, removed or modified in a way which changes their output.
- * 
- * 
- */
-public interface TransformerChangeListener extends ComponentChangeListener<TransformerComponentBuilder<?>> {
+    /**
+     * Invoked when the configuration of a {@link ComponentBuilder} is changed.
+     * 
+     * @param builder
+     */
+    public void onConfigurationChanged(C builder);
 
-	/**
-	 * This method will be invoked each time a change in a transformer's output
-	 * columns is observed.
-	 * 
-	 * Note that this method will also be invoked with an empty list if a
-	 * transformer is being removed. This is to make it easier for listeners to
-	 * handle updates on output columns using a single listening-method.
-	 * 
-	 * @param transformerJobBuilder
-	 * @param outputColumns
-	 */
-	public void onOutputChanged(TransformerComponentBuilder<?> transformerJobBuilder, List<MutableInputColumn<?>> outputColumns);
+    /**
+     * Invoked when the {@link ComponentRequirement} of a
+     * {@link ComponentBuilder} is changed.
+     * 
+     * @param builder
+     */
+    public void onRequirementChanged(C builder);
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/ComponentRemovalListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/ComponentRemovalListener.java
@@ -19,28 +19,16 @@
  */
 package org.datacleaner.job.builder;
 
-import java.util.List;
-
-import org.datacleaner.data.MutableInputColumn;
-
 /**
- * Listener interface for receiving notifications when transformers are being
- * added, removed or modified in a way which changes their output.
- * 
- * 
+ * Listener interface for removals of {@link ComponentBuilder}s.
  */
-public interface TransformerChangeListener extends ComponentChangeListener<TransformerComponentBuilder<?>> {
+public interface ComponentRemovalListener<C extends ComponentBuilder> {
 
-	/**
-	 * This method will be invoked each time a change in a transformer's output
-	 * columns is observed.
-	 * 
-	 * Note that this method will also be invoked with an empty list if a
-	 * transformer is being removed. This is to make it easier for listeners to
-	 * handle updates on output columns using a single listening-method.
-	 * 
-	 * @param transformerJobBuilder
-	 * @param outputColumns
-	 */
-	public void onOutputChanged(TransformerComponentBuilder<?> transformerJobBuilder, List<MutableInputColumn<?>> outputColumns);
+    /**
+     * Method invoked when a component is removed from a
+     * {@link AnalysisJobBuilder}
+     * 
+     * @param componentBuilder
+     */
+    public void onRemove(C componentBuilder);
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/FilterChangeListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/FilterChangeListener.java
@@ -19,21 +19,10 @@
  */
 package org.datacleaner.job.builder;
 
-
 /**
  * Listener interface for receiving notifications when filters are being added
  * or removed from an analysis job.
- * 
- * 
  */
-public interface FilterChangeListener {
-
-	public void onAdd(FilterComponentBuilder<?, ?> filterJobBuilder);
-	
-	public void onConfigurationChanged(FilterComponentBuilder<?, ?> filterJobBuilder);
-	
-	public void onRequirementChanged(FilterComponentBuilder<?, ?> filterJobBuilder);
-
-	public void onRemove(FilterComponentBuilder<?, ?> filterJobBuilder);
+public interface FilterChangeListener extends ComponentChangeListener<FilterComponentBuilder<?, ?>> {
 
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/FilterComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/FilterComponentBuilder.java
@@ -113,8 +113,8 @@ public final class FilterComponentBuilder<F extends Filter<C>, C extends Enum<C>
 
     @Override
     public String toString() {
-        return "FilterComponentBuilder[filter=" + getDescriptor().getDisplayName() + ",inputColumns=" + getInputColumns()
-                + "]";
+        return "FilterComponentBuilder[filter=" + getDescriptor().getDisplayName() + ",inputColumns="
+                + getInputColumns() + "]";
     }
 
     @Override
@@ -173,10 +173,8 @@ public final class FilterComponentBuilder<F extends Filter<C>, C extends Enum<C>
         return outcome;
     }
 
-    /**
-     * Notification method invoked when transformer is removed.
-     */
-    protected void onRemoved() {
+    @Override
+    protected void onRemovedInternal() {
         List<FilterChangeListener> listeners = getAllListeners();
         for (FilterChangeListener listener : listeners) {
             listener.onRemove(this);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
@@ -286,7 +286,8 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
     /**
      * Notification method invoked when transformer is removed.
      */
-    protected void onRemoved() {
+    @Override
+    protected void onRemovedInternal() {
         List<TransformerChangeListener> listeners = getAllListeners();
         for (TransformerChangeListener listener : listeners) {
             listener.onOutputChanged(this, new LinkedList<MutableInputColumn<?>>());


### PR DESCRIPTION
This will close dialogs along with nodes and jobs, and adds a way to close all dialogs in the window menu.

It also extends the previous "pull existing component configuration dialog to front" functionality to table configuration dialogs.