### PR TITLE
Do not refresh  panel when checking size.

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
@@ -244,8 +244,8 @@ public final class JobGraph {
                     g.setColor(WidgetUtils.BG_COLOR_BRIGHT);
                 }
                 g.fillRect(0, 0, visualizationViewer.getWidth(), visualizationViewer.getHeight());
-
-                final Dimension size = getPanel().getSize();
+                
+                final Dimension size = _panel.getSize();
                 if (size.height < 300) {
                     // don't show the background hints - it will be too
                     // disturbing


### PR DESCRIPTION
The code used getPanel(), which refreshed and redrew the entrie panel.
As the result was only used for sizing, there should be no need.

Fixes #186