### PR TITLE
Fixes an issue where two mouse listeners (JobGraphLinkPainter and

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
@@ -122,11 +122,13 @@ public class JobGraphLinkPainter {
         logger.debug("endLink({})", endVertex);
         boolean result = false;
         if (_startVertex != null && endVertex != null) {
-            final boolean created = createLink(_startVertex, endVertex, mouseEvent);
-            if (created && _graphContext.getVisualizationViewer().isVisible()) {
-                _graphContext.getJobGraph().refresh();
+            if (mouseEvent.getButton() == MouseEvent.BUTTON1) {
+                final boolean created = createLink(_startVertex, endVertex, mouseEvent);
+                if (created && _graphContext.getVisualizationViewer().isVisible()) {
+                    _graphContext.getJobGraph().refresh();
+                }
+                result = true;
             }
-            result = true;
         }
         stopDrawing();
         return result;


### PR DESCRIPTION
JobGraphMouseListener) both act on a right-click and causing an
exception because graph was refreshed inbetween actions.