### PR TITLE
Removed unnecessary WebappLifecycleListener to fix deployment on JBoss/Wildfly

### DIFF
--- a/monitor/ui/src/main/webapp/WEB-INF/web.xml
+++ b/monitor/ui/src/main/webapp/WEB-INF/web.xml
@@ -40,9 +40,6 @@
 	<listener>
 		<listener-class>com.sun.faces.config.ConfigureListener</listener-class>
 	</listener>
-	<listener>
-		<listener-class>com.sun.faces.application.WebappLifecycleListener</listener-class>
-	</listener>
 
 	<!-- Spring listener -->
 	<listener>


### PR DESCRIPTION
The WebappLifecycleListener has no Methods which can be accessed by any Java Application Server. Listener Classes without any declared Listener Interfaces cannot be declared in a web.xml. While Tomcat ignores this, Wildfly and JBoss AS both won't deploy the war. Because the WebappLifecycleListener does not implement any compatible Listener Interface, removing it should not have any impact.