### PR TITLE
Fixes #264

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
@@ -139,11 +139,16 @@ public class OpenAnalysisJobAsTemplateDialog extends AbstractDialog {
         _sourceColumnComboBoxes = new HashMap<String, List<SourceColumnComboBox>>();
         for (String columnPath : columnPaths) {
             int columnDelim = columnPath.lastIndexOf('.');
-            assert columnDelim != -1;
-
-            // this tablePath will be used to group together columns from the
-            // same original table
-            final String tablePath = columnPath.substring(0, columnDelim);
+            final String tablePath;
+            if (columnDelim == -1) {
+                // some column path contain only the column name
+                tablePath = _metadata.getDatastoreName();
+            } else {
+                // this tablePath will be used to group together columns from
+                // the same original table
+                // The column's path contains also the table name in the path
+                tablePath = columnPath.substring(0, columnDelim);
+            }
 
             final SourceColumnComboBox comboBox = new SourceColumnComboBox();
             comboBox.setEnabled(false);
@@ -291,7 +296,8 @@ public class OpenAnalysisJobAsTemplateDialog extends AbstractDialog {
         WidgetUtils.addToGridBag(DCLabel.bright("<html><b>New/mapped value:</b></html>"), panel, 2, row);
 
         row++;
-        WidgetUtils.addToGridBag(new JLabel(imageManager.getImageIcon(IconUtils.GENERIC_DATASTORE_IMAGEPATH)), panel, 0, row);
+        WidgetUtils.addToGridBag(new JLabel(imageManager.getImageIcon(IconUtils.GENERIC_DATASTORE_IMAGEPATH)), panel,
+                0, row);
         WidgetUtils.addToGridBag(DCLabel.bright(_metadata.getDatastoreName()), panel, 1, row, GridBagConstraints.WEST);
 
         DCPanel datastoreButtonPanel = new DCPanel();

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -71,8 +71,8 @@ public class JaxbJobReaderTest extends TestCase {
 
     public void testReadComponentNames() throws Exception {
         JobReader<InputStream> reader = new JaxbJobReader(conf);
-        AnalysisJob job = reader
-                .read(new FileInputStream(new File("src/test/resources/example-job-component-names.xml")));
+        AnalysisJob job = reader.read(new FileInputStream(
+                new File("src/test/resources/example-job-component-names.xml")));
 
         assertEquals(1, job.getAnalyzerJobs().size());
         assertEquals("analyzer_1", job.getAnalyzerJobs().iterator().next().getName());
@@ -82,6 +82,18 @@ public class JaxbJobReaderTest extends TestCase {
 
         assertEquals(1, job.getTransformerJobs().size());
         assertEquals("email_std_1", job.getTransformerJobs().iterator().next().getName());
+    }
+
+    public void testReadOnlyColumnNamePaths() throws Exception {
+        JobReader<InputStream> reader = new JaxbJobReader(conf);
+        final FileInputStream source = new FileInputStream(new File(
+                "src/test/resources/example-job-only-columns-names-paths.analysis.xml"));
+        final AnalysisJobMetadata metadata = reader.readMetadata(source);
+        assertNotNull(metadata);
+        assertEquals("UKContactData.csv", metadata.getDatastoreName());
+        assertEquals(
+                "[RecordId, Company, FirstName, LastName, AddressLine1, AddressLine2, AddressLine3, AddressLine4, City, State, Country, Postcode]",
+                metadata.getSourceColumnPaths().toString());
     }
 
     public void testReadMetadataFull() throws Exception {
@@ -95,7 +107,7 @@ public class JaxbJobReaderTest extends TestCase {
         assertEquals("An example job with complete metadata", metadata.getJobDescription());
         assertEquals("1.1", metadata.getJobVersion());
         assertEquals("[PUBLIC.PERSONS.FIRSTNAME, PUBLIC.PERSONS.LASTNAME]", metadata.getSourceColumnPaths().toString());
-        assertEquals("propertyValue", metadata.getProperties().get("propertyName")) ;
+        assertEquals("propertyValue", metadata.getProperties().get("propertyName"));
 
         assertNotNull(metadata.getCreatedDate());
         assertNotNull(metadata.getUpdatedDate());

--- a/engine/xml-config/src/test/resources/example-job-only-columns-names-paths.analysis.xml
+++ b/engine/xml-config/src/test/resources/example-job-only-columns-names-paths.analysis.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+	<job-metadata>
+		<job-description>Created with DataCleaner Community edition UNKNOWN
+		</job-description>
+		<author>claudiap</author>
+		<updated-date>2015-02-18+01:00</updated-date>
+		<metadata-properties>
+			<property name="CoordinatesY.UKSuppression Test Files.UKContactData.csv">83</property>
+			<property name="CoordinatesX.UKSuppression Test Files.UKContactData.csv">136</property>
+		</metadata-properties>
+	</job-metadata>
+	<source>
+		<data-context ref="UKContactData.csv" />
+		<columns>
+			<column id="col_0" path="RecordId" type="STRING" />
+			<column id="col_1" path="Company" type="STRING" />
+			<column id="col_2" path="FirstName" type="STRING" />
+			<column id="col_3" path="LastName" type="STRING" />
+			<column id="col_4" path="AddressLine1" type="STRING" />
+			<column id="col_5" path="AddressLine2" type="STRING" />
+			<column id="col_6" path="AddressLine3" type="STRING" />
+			<column id="col_7" path="AddressLine4" type="STRING" />
+			<column id="col_8" path="City" type="STRING" />
+			<column id="col_9" path="State" type="STRING" />
+			<column id="col_10" path="Country" type="STRING" />
+			<column id="col_11" path="Postcode" type="STRING" />
+		</columns>
+	</source>
+	<transformation />
+	<analysis>
+		<analyzer>
+			<descriptor ref="Create CSV file" />
+			<metadata-properties>
+				<property name="CoordinatesY">209</property>
+				<property name="CoordinatesX">409</property>
+			</metadata-properties>
+			<properties>
+				<property name="File" value="cleo.txt" />
+				<property name="Separator char" value="&amp;#44;" />
+				<property name="Quote char" value="&amp;quot;" />
+				<property name="Escape char" value="\" />
+				<property name="Include header" value="true" />
+				<property name="Overwrite file if exists" value="true" />
+			</properties>
+			<input ref="col_0" name="Columns" />
+			<input ref="col_1" name="Columns" />
+			<input ref="col_2" name="Columns" />
+			<input ref="col_3" name="Columns" />
+			<input ref="col_4" name="Columns" />
+			<input ref="col_5" name="Columns" />
+			<input ref="col_6" name="Columns" />
+			<input ref="col_7" name="Columns" />
+			<input ref="col_8" name="Columns" />
+			<input ref="col_9" name="Columns" />
+			<input ref="col_10" name="Columns" />
+			<input ref="col_11" name="Columns" />
+		</analyzer>
+	</analysis>
+</job>


### PR DESCRIPTION
Fixes #264.  In connection with https://github.com/datacleaner/AnalyzerBeans/issues/58


The dialog for opening as template was prepared to handle column paths that contain the name of the table. However if there is one table as datastore the column path will contain only the column names, which will throw an exception if it doesn't find the table name separated by "." when trying to open the job as a template.