### PR TITLE
Dropzone - use existing datastore

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
@@ -65,8 +65,8 @@ public class Dropzone extends DCPanel {
     private final DatastoreSelectedListener _datastoreSelectListener;
     private final UserPreferences _userPreferences;
 
-    public Dropzone(final DatastoreCatalog datastoreCatalog,
-            final DatastoreSelectedListener datastoreSelectListener, final UserPreferences userPreferences) {
+    public Dropzone(final DatastoreCatalog datastoreCatalog, final DatastoreSelectedListener datastoreSelectListener,
+            final UserPreferences userPreferences) {
         super(WidgetUtils.BG_SEMI_TRANSPARENT);
         _datastoreCatalog = datastoreCatalog;
         _datastoreSelectListener = datastoreSelectListener;
@@ -115,8 +115,13 @@ public class Dropzone extends DCPanel {
             final File file = fileChooser.getSelectedFile();
 
             if (file.exists()) {
-                final Datastore datastore = DatastoreCreationUtil.createAndAddUniqueDatastoreFromFile(
-                        _datastoreCatalog, file);
+                final Datastore datastore;
+                final String filename = file.getName();
+                if (_datastoreCatalog.containsDatastore(filename)) {
+                    datastore = _datastoreCatalog.getDatastore(filename);
+                } else {
+                    datastore = DatastoreCreationUtil.createAndAddUniqueDatastoreFromFile(_datastoreCatalog, file);
+                }
                 _datastoreSelectListener.datastoreSelected(datastore);
 
                 final File directory;

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
@@ -42,6 +42,7 @@ import javax.swing.border.EmptyBorder;
 
 import org.datacleaner.connection.Datastore;
 import org.datacleaner.connection.DatastoreCatalog;
+import org.datacleaner.connection.FileDatastore;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.DatastoreSelectedListener;
 import org.datacleaner.user.UserPreferences;
@@ -115,11 +116,21 @@ public class Dropzone extends DCPanel {
             final File file = fileChooser.getSelectedFile();
 
             if (file.exists()) {
-                final Datastore datastore;
+                Datastore datastore = null;
                 final String filename = file.getName();
-                if (_datastoreCatalog.containsDatastore(filename)) {
-                    datastore = _datastoreCatalog.getDatastore(filename);
-                } else {
+                final String filePath = file.getAbsolutePath();
+                final String[] datastoreNames = _datastoreCatalog.getDatastoreNames();
+                for (int i = 0; i < datastoreNames.length; i++) {
+                    final Datastore datastoreName = _datastoreCatalog.getDatastore(datastoreNames[i]);
+                    if (datastoreName instanceof FileDatastore) {
+                        FileDatastore fileDatastore = (FileDatastore) datastoreName;
+                        final String datastoreFilename = fileDatastore.getFilename();
+                        if (filename.equals(datastoreFilename) || filePath.equals(datastoreFilename)) {
+                            datastore = _datastoreCatalog.getDatastore(filename);
+                        }
+                    }
+                }
+                if (datastore == null) {
                     datastore = DatastoreCreationUtil.createAndAddUniqueDatastoreFromFile(_datastoreCatalog, file);
                 }
                 _datastoreSelectListener.datastoreSelected(datastore);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
@@ -121,9 +121,9 @@ public class Dropzone extends DCPanel {
                 final String filePath = file.getAbsolutePath();
                 final String[] datastoreNames = _datastoreCatalog.getDatastoreNames();
                 for (int i = 0; i < datastoreNames.length; i++) {
-                    final Datastore datastoreName = _datastoreCatalog.getDatastore(datastoreNames[i]);
-                    if (datastoreName instanceof FileDatastore) {
-                        FileDatastore fileDatastore = (FileDatastore) datastoreName;
+                    final Datastore existingDatastore = _datastoreCatalog.getDatastore(datastoreNames[i]);
+                    if (existingDatastore instanceof FileDatastore) {
+                        FileDatastore fileDatastore = (FileDatastore) existingDatastore;
                         final String datastoreFilename = fileDatastore.getFilename();
                         if (filename.equals(datastoreFilename) || filePath.equals(datastoreFilename)) {
                             datastore = _datastoreCatalog.getDatastore(filename);


### PR DESCRIPTION
Fixes #240  Check if the datastore catalog already contains the file. If so select the existing datastore. Otherwise create a new one