### PR TITLE
Do not put datastorepanel checkbox inside flowpanel

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/DatastorePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DatastorePanel.java
@@ -162,11 +162,12 @@ public class DatastorePanel extends DCPanel {
 
         setBorder(WidgetUtils.BORDER_LIST_ITEM_SUBTLE);
 
-        WidgetUtils.addToGridBag(DCPanel.flow(_checkBox, datastoreNameLabel), this, 0, 0, GridBagConstraints.WEST, 1.0,
+        WidgetUtils.addToGridBag(_checkBox, this, 0, 0, GridBagConstraints.WEST);
+        WidgetUtils.addToGridBag(DCPanel.flow(datastoreNameLabel), this, 1, 0, GridBagConstraints.WEST, 1.0,
                 1.0);
-        WidgetUtils.addToGridBag(editButton, this, 1, 0, GridBagConstraints.EAST);
-        WidgetUtils.addToGridBag(queryButton, this, 2, 0, GridBagConstraints.EAST);
-        WidgetUtils.addToGridBag(removeButton, this, 3, 0, GridBagConstraints.EAST);
+        WidgetUtils.addToGridBag(editButton, this, 2, 0, GridBagConstraints.EAST);
+        WidgetUtils.addToGridBag(queryButton, this, 3, 0, GridBagConstraints.EAST);
+        WidgetUtils.addToGridBag(removeButton, this, 4, 0, GridBagConstraints.EAST);
     }
 
     public Datastore getDatastore() {


### PR DESCRIPTION
This moves the checkbox out of the label's flow panel, avoiding the label flowing under the checkbox.

Fixes #263 
