### PR TITLE
Fix pop-under issue

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -39,6 +39,7 @@ import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.metamodel.schema.Table;
@@ -537,14 +538,20 @@ public final class ResultWindow extends AbstractWindow {
         };
     }
 
-    protected void updateButtonVisibility(boolean running) {
-        _cancelButton.setVisible(running);
+    protected void updateButtonVisibility(final boolean running) {
+        SwingUtilities.invokeLater(new Runnable() {
+            
+            @Override
+            public void run() {
+                _cancelButton.setVisible(running);
 
-        for (JComponent pluggableButton : _pluggableButtons) {
-            pluggableButton.setVisible(!running);
-        }
-        _saveButton.setVisible(!running);
-        _publishButton.setVisible(!running);
-        _exportButton.setVisible(!running);
+                for (JComponent pluggableButton : _pluggableButtons) {
+                    pluggableButton.setVisible(!running);
+                }
+                _saveButton.setVisible(!running);
+                _publishButton.setVisible(!running);
+                _exportButton.setVisible(!running);
+            }
+        });
     }
 }


### PR DESCRIPTION
This should fix the ResultWindows, at least simple ones. We've decided to leave component dialogs alone for now, as the pop-under is much less annoying, especially after the change that does not open new dialogs on an extra click. Also, it doesn't seem to affect all component dialogs (i.e. I couldn't trigger the String Analyzer at all), so we might want to do them on a case-by-case basis.

Fixes #325 