### PR TITLE
Use getClass() instead of class as is not allowed in EL

### DIFF
--- a/monitor/ui/src/main/webapp/login.xhtml
+++ b/monitor/ui/src/main/webapp/login.xhtml
@@ -56,7 +56,7 @@
 						</div>
 						<c:if test="#{not empty param.debug}">
 							<div class="warning">
-								#{SPRING_SECURITY_LAST_EXCEPTION.class.simpleName}:
+ 								#{SPRING_SECURITY_LAST_EXCEPTION.getClass().simpleName}:
 								#{SPRING_SECURITY_LAST_EXCEPTION.message}
 							</div>
 						</c:if>


### PR DESCRIPTION
This will make the monitor actually show the error message instead of the raw text.