### PR TITLE
Changed default logging directory to ${user.home}/.datacleaner/log

### DIFF
--- a/desktop/ui/src/main/resources/org/datacleaner/log4j-default.xml
+++ b/desktop/ui/src/main/resources/org/datacleaner/log4j-default.xml
@@ -13,7 +13,7 @@
 	</appender>
 
 	<appender name="fileAppender" class="org.apache.log4j.DailyRollingFileAppender">
-		<param name="File" value="log/datacleaner.log" />
+		<param name="File" value="${user.home}/.datacleaner/log/datacleaner.log" />
 		<param name="DatePattern" value="'.'yyyy-MM-dd'.log'" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%-5p %d{HH:mm:ss.SSS} [%t] %c{1} - %m%n" />

--- a/desktop/ui/src/main/resources/org/datacleaner/log4j-jnlp.xml
+++ b/desktop/ui/src/main/resources/org/datacleaner/log4j-jnlp.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="fileAppender" class="org.apache.log4j.FileAppender">
-		<param name="File" value="${user.home}/datacleaner.log" />
+		<param name="File" value="${user.home}/.datacleaner/datacleaner.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%-5p %d{HH:mm:ss.SSS} [%t] %c{1} - %m%n" />

--- a/desktop/ui/src/main/resources/org/datacleaner/log4j-jnlp.xml
+++ b/desktop/ui/src/main/resources/org/datacleaner/log4j-jnlp.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="fileAppender" class="org.apache.log4j.FileAppender">
-		<param name="File" value="${user.home}/.datacleaner/datacleaner.log" />
+		<param name="File" value="${user.home}/.datacleaner/log/datacleaner.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%-5p %d{HH:mm:ss.SSS} [%t] %c{1} - %m%n" />


### PR DESCRIPTION
instead of ./log

Fixes #351 

Changed it to ${user.home}/.datacleaner/log/datacleaner.log however it would be perfect to have ${user.home}/.datacleaner/DATACLEANER.VERSION/log/datacleaner.log, but the version of DC is not available from System properties. 

JNLP already logged to user directory, but for consistency I changed it to .datacleaner subdirectory.