### PR TITLE
Bug/356 uppercase extensions

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
@@ -57,7 +57,7 @@ public class DatastoreCreationUtil {
             final String extension = FilenameUtils.getExtension(file.getName());
 
             for (FileDatastoreEnum datastoreType : EnumSet.allOf(FileDatastoreEnum.class)) {
-                if (datastoreType._extensions.contains(extension)) {
+                if (datastoreType._extensions.contains(extension.toLowerCase())) {
                     return datastoreType;
                 }
             }

--- a/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
@@ -96,8 +96,12 @@ public class DatastoreCreationUtil {
 
     public static Datastore createDatastoreFromEnum(FileDatastoreEnum fileDatastore, File file, String datastoreName) {
         final String filename = file.getAbsolutePath();
+        if (fileDatastore == null) {
+            throw new IllegalArgumentException("Illegal file type for: " + filename);
+        }
         final FileResource resource = new FileResource(file);
 
+        
         switch (fileDatastore) {
         case CSV:
             final CsvConfigurationDetection detection = new CsvConfigurationDetection(resource);

--- a/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
@@ -97,7 +97,7 @@ public class DatastoreCreationUtil {
     public static Datastore createDatastoreFromEnum(FileDatastoreEnum fileDatastore, File file, String datastoreName) {
         final String filename = file.getAbsolutePath();
         if (fileDatastore == null) {
-            throw new IllegalArgumentException("Illegal file type for: " + filename);
+            throw new IllegalArgumentException("Unrecognized file type for: " + filename);
         }
         final FileResource resource = new FileResource(file);
 


### PR DESCRIPTION
Fixes #356

Also showing an "Unrecognized file type" pop-up when an unsupported file is chosen in the file dialog (it caused an NPE; dropping does not react at all for unknown files). An unsupported file is for example a JPG or no extension at all (despite being a properly formatted CSV file wrt the contents).