### PR TITLE
Fixes #393 by only asserting on certain indexes in the events instead of absolute ordering.

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
@@ -22,6 +22,7 @@ package org.datacleaner.job.concurrent;
 import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.datacleaner.job.runner.AnalysisJobMetrics;
 import org.datacleaner.job.runner.AnalysisListener;
@@ -40,21 +41,25 @@ public final class JobCompletionTaskListener implements StatusAwareTaskListener 
 	private static final Logger logger = LoggerFactory.getLogger(ForkTaskListener.class);
 
 	private final CountDownLatch _countDownLatch;
+	private final AtomicInteger _successCountDown;
 	private final AnalysisListener _analysisListener;
 	private final AnalysisJobMetrics _analysisJobMetrics;
 	private Date _completionTime;
 
-	public JobCompletionTaskListener(AnalysisJobMetrics analysisJobMetrics, AnalysisListener analysisListener,
-			int callablesToWaitFor) {
+	public JobCompletionTaskListener(final AnalysisJobMetrics analysisJobMetrics, final AnalysisListener analysisListener,
+			final int callablesToWaitFor) {
 		_analysisJobMetrics = analysisJobMetrics;
 		_analysisListener = analysisListener;
 		_countDownLatch = new CountDownLatch(callablesToWaitFor);
+		_successCountDown = new AtomicInteger(callablesToWaitFor);
 	}
 
+	@Override
 	public void await() throws InterruptedException {
 		_countDownLatch.await();
 	}
 
+	@Override
 	public boolean isDone() {
 		return _countDownLatch.getCount() == 0;
 	}
@@ -72,7 +77,9 @@ public final class JobCompletionTaskListener implements StatusAwareTaskListener 
 	public void onComplete(Task task) {
 		logger.debug("onComplete(...)");
 		_countDownLatch.countDown();
-		if (_countDownLatch.getCount() == 0) {
+		
+		final int successCountDownStatus = _successCountDown.decrementAndGet();
+		if (successCountDownStatus == 0) {
 			_completionTime = new Date();
 			_analysisListener.jobSuccess(_analysisJobMetrics.getAnalysisJob(), _analysisJobMetrics);
 		}

--- a/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
@@ -38,62 +38,65 @@ import org.slf4j.LoggerFactory;
  */
 public final class JobCompletionTaskListener implements StatusAwareTaskListener {
 
-	private static final Logger logger = LoggerFactory.getLogger(ForkTaskListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(ForkTaskListener.class);
 
-	private final CountDownLatch _countDownLatch;
-	private final AtomicInteger _successCountDown;
-	private final AnalysisListener _analysisListener;
-	private final AnalysisJobMetrics _analysisJobMetrics;
-	private Date _completionTime;
+    private final CountDownLatch _countDownLatch;
+    private final AtomicInteger _successCountDown;
+    private final AnalysisListener _analysisListener;
+    private final AnalysisJobMetrics _analysisJobMetrics;
+    private Date _completionTime;
 
-	public JobCompletionTaskListener(final AnalysisJobMetrics analysisJobMetrics, final AnalysisListener analysisListener,
-			final int callablesToWaitFor) {
-		_analysisJobMetrics = analysisJobMetrics;
-		_analysisListener = analysisListener;
-		_countDownLatch = new CountDownLatch(callablesToWaitFor);
-		_successCountDown = new AtomicInteger(callablesToWaitFor);
-	}
+    public JobCompletionTaskListener(final AnalysisJobMetrics analysisJobMetrics,
+            final AnalysisListener analysisListener, final int callablesToWaitFor) {
+        _analysisJobMetrics = analysisJobMetrics;
+        _analysisListener = analysisListener;
+        _countDownLatch = new CountDownLatch(callablesToWaitFor);
+        _successCountDown = new AtomicInteger(callablesToWaitFor);
+    }
 
-	@Override
-	public void await() throws InterruptedException {
-		_countDownLatch.await();
-	}
+    @Override
+    public void await() throws InterruptedException {
+        _countDownLatch.await();
+    }
 
-	@Override
-	public boolean isDone() {
-		return _countDownLatch.getCount() == 0;
-	}
+    @Override
+    public boolean isDone() {
+        return _countDownLatch.getCount() == 0;
+    }
 
-	@Override
-	public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
-		_countDownLatch.await(timeout, timeUnit);
-	}
+    @Override
+    public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        _countDownLatch.await(timeout, timeUnit);
+    }
 
-	@Override
-	public void onBegin(Task task) {
-	}
+    @Override
+    public void onBegin(Task task) {
+    }
 
-	@Override
-	public void onComplete(Task task) {
-		logger.debug("onComplete(...)");
-		_countDownLatch.countDown();
-		
-		final int successCountDownStatus = _successCountDown.decrementAndGet();
-		if (successCountDownStatus == 0) {
-			_completionTime = new Date();
-			_analysisListener.jobSuccess(_analysisJobMetrics.getAnalysisJob(), _analysisJobMetrics);
-		}
-	}
+    @Override
+    public void onComplete(Task task) {
+        logger.debug("onComplete(...)");
 
-	@Override
-	public void onError(Task task, Throwable throwable) {
-		logger.debug("onError(...)");
-		_analysisListener.errorUknown(_analysisJobMetrics.getAnalysisJob(), throwable);
-		_countDownLatch.countDown();
-	}
+        final int successCountDownStatus = _successCountDown.decrementAndGet();
+        if (successCountDownStatus == 0) {
+            _completionTime = new Date();
+            _analysisListener.jobSuccess(_analysisJobMetrics.getAnalysisJob(), _analysisJobMetrics);
+        }
 
-	@Override
-	public Date getCompletionTime() {
-		return _completionTime;
-	}
+        // as the last thing we need to call countDown() to unlock any waiting
+        // threads on await()
+        _countDownLatch.countDown();
+    }
+
+    @Override
+    public void onError(Task task, Throwable throwable) {
+        logger.debug("onError(...)");
+        _analysisListener.errorUknown(_analysisJobMetrics.getAnalysisJob(), throwable);
+        _countDownLatch.countDown();
+    }
+
+    @Override
+    public Date getCompletionTime() {
+        return _completionTime;
+    }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/concurrent/StatusAwareTaskListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/concurrent/StatusAwareTaskListener.java
@@ -25,8 +25,6 @@ import java.util.concurrent.TimeUnit;
 /**
  * A task listener that has the ability to block (using the await(...) methods)
  * and to tell if it has finished or not (using the isDone() method):
- * 
- * 
  */
 public interface StatusAwareTaskListener extends TaskListener {
 

--- a/engine/core/src/test/java/org/datacleaner/test/full/scenarios/AnalyzerResultFutureAndAnalysisListenerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/test/full/scenarios/AnalyzerResultFutureAndAnalysisListenerTest.java
@@ -210,7 +210,12 @@ public class AnalyzerResultFutureAndAnalysisListenerTest extends TestCase {
 
     private int getIndexAndVerifyExists(List<String> messagesList, String string) {
         final int index = messagesList.indexOf(string);
-        assertTrue(messagesList.toString(), index != -1);
+        if (index == -1) {
+            // use a good message because hunting down the cause of this can be
+            // pretty tough.
+            final String message = "Failed to find '" + string + "' in messages: " + messagesList.toString();
+            assertTrue(message, index != -1);
+        }
         return index;
     }
 }


### PR DESCRIPTION
Fixes #393 .... The level of readability in the test is decreased I am affraid. But it will no longer fail because of race conditions among certain events in the listeners.