### PR TITLE
Ensures that jobgraph rendering never has redundant lines

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphNodeBuilder.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphNodeBuilder.java
@@ -87,7 +87,15 @@ class JobGraphNodeBuilder {
             addNodes(graph, sourceColumnFinder, fjb, -1);
         }
 
-        removeUnnecesaryEdges(graph, sourceColumnFinder);
+        // This loop is not very pretty but it ensures that we don't prematurely
+        // stop looking for stuff to remove from the graph. The issue is that
+        // with the current design, the removeUnnecesaryEdges method may remove
+        // something which then should call for a re-evaluation of other edges
+        // to be removed.
+        boolean removedSomething = true;
+        while (removedSomething) {
+            removedSomething = removeUnnecesaryEdges(graph, sourceColumnFinder);
+        }
 
         return graph;
     }
@@ -103,8 +111,10 @@ class JobGraphNodeBuilder {
      * 
      * @param graph
      * @param sourceColumnFinder
+     * 
+     * @return whether or not any edges were removed
      */
-    private void removeUnnecesaryEdges(final DirectedGraph<Object, JobGraphLink> graph,
+    private boolean removeUnnecesaryEdges(final DirectedGraph<Object, JobGraphLink> graph,
             final SourceColumnFinder sourceColumnFinder) {
         final Collection<JobGraphLink> allLinks = graph.getEdges();
         final List<JobGraphLink> linksToRemove = new ArrayList<>();
@@ -149,6 +159,8 @@ class JobGraphNodeBuilder {
         for (JobGraphLink link : linksToRemove) {
             graph.removeEdge(link);
         }
+
+        return !linksToRemove.isEmpty();
     }
 
     private boolean isEdgeShortcutFor(DirectedGraph<Object, JobGraphLink> graph, JobGraphLink potentialShortcut,

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphNodeBuilder.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphNodeBuilder.java
@@ -87,15 +87,7 @@ class JobGraphNodeBuilder {
             addNodes(graph, sourceColumnFinder, fjb, -1);
         }
 
-        // This loop is not very pretty but it ensures that we don't prematurely
-        // stop looking for stuff to remove from the graph. The issue is that
-        // with the current design, the removeUnnecesaryEdges method may remove
-        // something which then should call for a re-evaluation of other edges
-        // to be removed.
-        boolean removedSomething = true;
-        while (removedSomething) {
-            removedSomething = removeUnnecesaryEdges(graph, sourceColumnFinder);
-        }
+        removeUnnecesaryEdges(graph, sourceColumnFinder);
 
         return graph;
     }
@@ -111,10 +103,30 @@ class JobGraphNodeBuilder {
      * 
      * @param graph
      * @param sourceColumnFinder
+     */
+    private void removeUnnecesaryEdges(DirectedGraph<Object, JobGraphLink> graph, SourceColumnFinder sourceColumnFinder) {
+        // This loop is not very pretty but it ensures that we don't prematurely
+        // stop looking for stuff to remove from the graph. The issue is that
+        // with the current design, the removeUnnecesaryEdges method may remove
+        // something which then should call for a re-evaluation of other edges
+        // to be removed.
+        boolean removedSomething = true;
+        while (removedSomething) {
+            removedSomething = removeUnnecesaryEdgesIfAny(graph, sourceColumnFinder);
+        }
+    }
+
+    /**
+     * Runs a single check through the graph to remove unnecesary edges (see
+     * {@link #removeUnnecesaryEdges(DirectedGraph, SourceColumnFinder)} if any
+     * are found.
+     * 
+     * @param graph
+     * @param sourceColumnFinder
      * 
      * @return whether or not any edges were removed
      */
-    private boolean removeUnnecesaryEdges(final DirectedGraph<Object, JobGraphLink> graph,
+    private boolean removeUnnecesaryEdgesIfAny(final DirectedGraph<Object, JobGraphLink> graph,
             final SourceColumnFinder sourceColumnFinder) {
         final Collection<JobGraphLink> allLinks = graph.getEdges();
         final List<JobGraphLink> linksToRemove = new ArrayList<>();


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/291450/7415799/6dac5e1a-ef5b-11e4-802a-71b89bb020fa.png)

After:

![image](https://cloud.githubusercontent.com/assets/291450/7415780/59f4162e-ef5b-11e4-8625-7c074fc5570c.png)
