### PR TITLE
Issue #406: Fixed (and also a few icon references)

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/IconUtils.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/IconUtils.java
@@ -134,6 +134,7 @@ public final class IconUtils {
     public static final String ACTION_STOP = "images/actions/stop.png";
     public static final String ACTION_LOG = "images/actions/log.png";
     public static final String ACTION_DRILL_TO_DETAIL = "images/actions/drill-to-detail.png";
+    public static final String ACTION_DOWNLOAD = "images/actions/download.png";
 
     public static final String APPLICATION_ICON = "images/window/app-icon.png";
     public static final String WEBSITE = "images/actions/website.png";

--- a/desktop/api/src/main/java/org/datacleaner/util/LookAndFeelManager.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/LookAndFeelManager.java
@@ -172,6 +172,7 @@ public final class LookAndFeelManager {
         // Input fields
         UIManager.put("TextField.border", WidgetUtils.BORDER_INPUT);
         UIManager.put("TextField.background", WidgetUtils.BG_COLOR_BRIGHTEST);
+        UIManager.put("TextField.disabledBackground", WidgetUtils.BG_COLOR_BRIGHT);
 
         UIManager.put("TextArea.border", WidgetUtils.BORDER_INPUT);
         UIManager.put("TextArea.background", WidgetUtils.BG_COLOR_BRIGHTEST);
@@ -231,7 +232,6 @@ public final class LookAndFeelManager {
         UIManager.put("ScrollBar.trackHighlightForeground", WidgetUtils.COLOR_DEFAULT_BACKGROUND);
         UIManager.put("ScrollBarUI", DCScrollBarUI.class.getName());
 
-      
         // progressbar color
         UIManager.put("ProgressBar.foreground", WidgetUtils.BG_COLOR_BLUE_BRIGHT);
 

--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
@@ -101,7 +101,7 @@ public final class WidgetFactory {
         final ImageIcon icon = ImageManager.get().getImageIcon(imagePath, IconUtils.ICON_SIZE_BUTTON);
         return icon;
     }
-    
+
     public static PopupButton createDarkPopupButton(String text, String imagePath) {
         PopupButton b = new PopupButton(text, getButtonIcon(imagePath));
         b.setFocusPainted(false);
@@ -267,7 +267,7 @@ public final class WidgetFactory {
         DCTaskPaneContainer taskPaneContainer = new DCTaskPaneContainer();
         return taskPaneContainer;
     }
-    
+
     public static JXTaskPane createTaskPane(String title, String imagePath) {
         final ImageIcon icon;
         if (Strings.isNullOrEmpty(imagePath)) {

--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
@@ -132,14 +132,14 @@ public final class WidgetUtils {
     public static final Color BG_COLOR_ORANGE_DARK = slightlyDarker(BG_COLOR_ORANGE_MEDIUM);
 
     // white with 10% alpha/opacity
-    public static final Color BG_SEMI_TRANSPARENT = new Color(0.0f, 0.0f, 0.0f, 0.05f);
+    public static final Color BG_SEMI_TRANSPARENT = new ColorUIResource(new Color(0.0f, 0.0f, 0.0f, 0.05f));
 
     // pale yellow color which work fine for information/help text fields.
     // #f4f4d3
     public static final Color BG_COLOR_PALE_YELLOW = new ColorUIResource(244, 244, 211);
 
     // white
-    public static final Color BG_COLOR_BRIGHTEST = ColorUIResource.WHITE;
+    public static final Color BG_COLOR_BRIGHTEST = new ColorUIResource(Color.WHITE);
 
     // #e1e1e1 (silver-ish)
     public static final Color BG_COLOR_BRIGHT = new ColorUIResource(245, 245, 245);
@@ -154,7 +154,7 @@ public final class WidgetUtils {
 
     public static final Color BG_COLOR_DARK = new ColorUIResource(33, 33, 33);
 
-    public static final Color BG_COLOR_DARKEST = ColorUIResource.BLACK;
+    public static final Color BG_COLOR_DARKEST = new ColorUIResource(Color.BLACK);
 
     public static final Color COLOR_DEFAULT_BACKGROUND = BG_COLOR_BRIGHTEST;
     public static final Color COLOR_WELL_BACKGROUND = BG_COLOR_BRIGHT;

--- a/desktop/ui/src/main/java/org/datacleaner/panels/DatabaseDriversPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DatabaseDriversPanel.java
@@ -112,7 +112,7 @@ public class DatabaseDriversPanel extends DCPanel {
         final JPopupMenu addDriverMenu = addDriverButton.getMenu();
 
         final JMenu automaticDownloadAndInstallMenu = new JMenu("Automatic download and install");
-        automaticDownloadAndInstallMenu.setIcon(imageManager.getImageIcon("images/actions/download.png"));
+        automaticDownloadAndInstallMenu.setIcon(imageManager.getImageIcon(IconUtils.ACTION_DOWNLOAD, IconUtils.ICON_SIZE_MENU_ITEM));
 
         final List<DatabaseDriverDescriptor> drivers = _databaseDriverCatalog.getDatabaseDrivers();
         for (DatabaseDriverDescriptor dd : drivers) {
@@ -192,7 +192,7 @@ public class DatabaseDriversPanel extends DCPanel {
                     final DCPanel buttonPanel = new DCPanel();
                     buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 4, 0));
 
-                    final JButton downloadButton = WidgetFactory.createSmallButton("images/actions/download.png");
+                    final JButton downloadButton = WidgetFactory.createSmallButton(IconUtils.ACTION_DOWNLOAD);
                     downloadButton.setToolTipText("Download and install the driver for " + dd.getDisplayName());
 
                     downloadButton.addActionListener(createDownloadActionListener(dd));

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/database/OracleDatabaseConnectionPresenter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/database/OracleDatabaseConnectionPresenter.java
@@ -71,6 +71,9 @@ public class OracleDatabaseConnectionPresenter extends UrlTemplateDatabaseConnec
                 updateTextFieldsAfterRadioButtonChange();
             }
         };
+        
+        updateTextFieldsAfterRadioButtonChange();
+        
         _radioServiceName.addActionListener(radioActionListener);
         _radioSid.addActionListener(radioActionListener);
     }


### PR DESCRIPTION
Fixes #406 
(The trick was to add a UIManager property and to make sure our colors are ColorUIResources which are apparently needed in the TextFieldUI classes).

Here's an example dialog with a disabled text field:

![image](https://cloud.githubusercontent.com/assets/291450/7471838/11349484-f32c-11e4-97e0-30fffcbfe87d.png)
