### PR TITLE
Issue #224: Updated the job.xsd file

### DIFF
--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
@@ -43,27 +43,28 @@ import org.datacleaner.connection.Datastore;
 import org.datacleaner.connection.DatastoreConnection;
 import org.datacleaner.connection.SchemaNavigator;
 import org.datacleaner.data.MutableInputColumn;
+import org.datacleaner.descriptors.ComponentDescriptor;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.jaxb.AnalysisType;
-import org.datacleaner.job.jaxb.AnalyzerDescriptorType;
 import org.datacleaner.job.jaxb.AnalyzerType;
 import org.datacleaner.job.jaxb.ColumnType;
 import org.datacleaner.job.jaxb.ColumnsType;
+import org.datacleaner.job.jaxb.ComponentType;
 import org.datacleaner.job.jaxb.ConfiguredPropertiesType;
 import org.datacleaner.job.jaxb.ConfiguredPropertiesType.Property;
 import org.datacleaner.job.jaxb.DataContextType;
-import org.datacleaner.job.jaxb.FilterDescriptorType;
+import org.datacleaner.job.jaxb.DescriptorType;
 import org.datacleaner.job.jaxb.FilterType;
 import org.datacleaner.job.jaxb.InputType;
 import org.datacleaner.job.jaxb.Job;
 import org.datacleaner.job.jaxb.JobMetadataType;
+import org.datacleaner.job.jaxb.JobType;
 import org.datacleaner.job.jaxb.MetadataProperties;
 import org.datacleaner.job.jaxb.ObjectFactory;
 import org.datacleaner.job.jaxb.OutcomeType;
 import org.datacleaner.job.jaxb.OutputType;
 import org.datacleaner.job.jaxb.SourceType;
 import org.datacleaner.job.jaxb.TransformationType;
-import org.datacleaner.job.jaxb.TransformerDescriptorType;
 import org.datacleaner.job.jaxb.TransformerType;
 import org.datacleaner.util.JaxbValidationEventHandler;
 import org.datacleaner.util.convert.StringConverter;
@@ -482,7 +483,7 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
         return id;
     }
 
-    private void addComponents(final Job jobType, final AnalysisJob analysisJob,
+    private void addComponents(final JobType jobType, final AnalysisJob analysisJob,
             final Map<TransformerJob, TransformerType> transformerMappings,
             final Map<FilterJob, FilterType> filterMappings, final Map<AnalyzerJob, AnalyzerType> analyzerMappings) {
         final TransformationType transformationType = new TransformationType();
@@ -496,9 +497,7 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
         for (TransformerJob transformerJob : transformerJobs) {
             TransformerType transformerType = new TransformerType();
             transformerType.setName(transformerJob.getName());
-            TransformerDescriptorType descriptorType = new TransformerDescriptorType();
-            descriptorType.setRef(transformerJob.getDescriptor().getDisplayName());
-            transformerType.setDescriptor(descriptorType);
+            setDescriptor(transformerType, transformerJob.getDescriptor());
             transformationType.getTransformerOrFilter().add(transformerType);
             transformerMappings.put(transformerJob, transformerType);
         }
@@ -508,9 +507,7 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
         for (FilterJob filterJob : filterJobs) {
             FilterType filterType = new FilterType();
             filterType.setName(filterJob.getName());
-            FilterDescriptorType descriptorType = new FilterDescriptorType();
-            descriptorType.setRef(filterJob.getDescriptor().getDisplayName());
-            filterType.setDescriptor(descriptorType);
+            setDescriptor(filterType, filterJob.getDescriptor());
             transformationType.getTransformerOrFilter().add(filterType);
             filterMappings.put(filterJob, filterType);
         }
@@ -520,12 +517,16 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
         for (AnalyzerJob analyzerJob : analyzerJobs) {
             AnalyzerType analyzerType = new AnalyzerType();
             analyzerType.setName(analyzerJob.getName());
-            AnalyzerDescriptorType descriptorType = new AnalyzerDescriptorType();
-            descriptorType.setRef(analyzerJob.getDescriptor().getDisplayName());
-            analyzerType.setDescriptor(descriptorType);
+            setDescriptor(analyzerType, analyzerJob.getDescriptor());
             analysisType.getAnalyzer().add(analyzerType);
             analyzerMappings.put(analyzerJob, analyzerType);
         }
+    }
+
+    private void setDescriptor(ComponentType componentType, ComponentDescriptor<?> descriptor) {
+        DescriptorType descriptorType = new DescriptorType();
+        descriptorType.setRef(descriptor.getDisplayName());
+        componentType.setDescriptor(descriptorType);
     }
 
     private static String getId(InputColumn<?> inputColumn, Map<InputColumn<?>, String> columnMappings) {

--- a/engine/xml-config/src/main/resources/job.xsd
+++ b/engine/xml-config/src/main/resources/job.xsd
@@ -5,18 +5,25 @@
 
 	<element name="job">
 		<complexType>
-			<sequence>
-				<element name="job-metadata" type="ab:jobMetadataType"
-					minOccurs="0" maxOccurs="1" />
-				<element name="source" type="ab:sourceType" minOccurs="0"
-					maxOccurs="1" />
-				<element name="transformation" type="ab:transformationType"
-					minOccurs="0" maxOccurs="1" />
-				<element name="analysis" type="ab:analysisType" minOccurs="1"
-					maxOccurs="1" />
-			</sequence>
+			<complexContent>
+				<extension base="ab:jobType">
+				</extension>
+			</complexContent>
 		</complexType>
 	</element>
+
+	<complexType name="jobType">
+		<sequence>
+			<element name="job-metadata" type="ab:jobMetadataType"
+				minOccurs="0" maxOccurs="1" />
+			<element name="source" type="ab:sourceType" minOccurs="0"
+				maxOccurs="1" />
+			<element name="transformation" type="ab:transformationType"
+				minOccurs="0" maxOccurs="1" />
+			<element name="analysis" type="ab:analysisType" minOccurs="0"
+				maxOccurs="1" />
+		</sequence>
+	</complexType>
 
 	<complexType name="jobMetadataType">
 		<all>
@@ -129,9 +136,9 @@
 		</attribute>
 	</complexType>
 
-	<complexType name="transformerType">
+	<complexType name="componentType">
 		<sequence>
-			<element name="descriptor" type="ab:transformerDescriptorType"
+			<element name="descriptor" type="ab:descriptorType"
 				minOccurs="1" maxOccurs="1" />
 			<element name="metadata-properties" type="ab:metadataProperties"
 				minOccurs="0" maxOccurs="1" />
@@ -139,16 +146,18 @@
 				minOccurs="0" maxOccurs="1" />
 			<element name="input" type="ab:inputType" minOccurs="0"
 				maxOccurs="unbounded" />
-			<element name="output" type="ab:outputType" minOccurs="1"
-				maxOccurs="unbounded" />
+			<element name="output-data-stream" type="ab:outputDataStreamType"
+				minOccurs="0" maxOccurs="unbounded" />
 		</sequence>
 		<attribute name="requires" type="token" use="optional">
 			<annotation>
 				<documentation>
-					The ID of a filter outcome that should function as a
-					requirement for execution of this component. Requirements are
-					applied transitively to successive components. Use the keyword
-					'_all_' to override transitive behaviour and don't apply any
+					The description of the component requirement for
+					execution of this component. Requirements are
+					applied transitively
+					to successive components. Use the keyword
+					'_all_' to override
+					transitive behaviour and don't apply any
 					requirements
 				</documentation>
 			</annotation>
@@ -156,35 +165,46 @@
 		<attribute name="name" type="string" use="optional" />
 	</complexType>
 
-	<complexType name="transformerDescriptorType">
+	<complexType name="descriptorType">
 		<attribute name="ref" type="token" use="required" />
 	</complexType>
 
-	<complexType name="filterType">
+	<complexType name="outputDataStreamType">
 		<sequence>
-			<element name="descriptor" type="ab:filterDescriptorType"
-				minOccurs="1" maxOccurs="1" />
-			<element name="metadata-properties" type="ab:metadataProperties"
-				minOccurs="0" maxOccurs="1" />
-			<element name="properties" type="ab:configuredPropertiesType"
-				minOccurs="0" maxOccurs="1" />
-			<element name="input" type="ab:inputType" minOccurs="0"
-				maxOccurs="unbounded" />
-			<element name="outcome" type="ab:outcomeType" minOccurs="1"
-				maxOccurs="unbounded" />
+			<element name="job" type="ab:jobType" minOccurs="1"
+				maxOccurs="1" />
 		</sequence>
-		<attribute name="requires" type="token" use="optional">
-			<annotation>
-				<documentation>
-					The ID of a filter outcome that should function as a
-					requirement for execution of this component. Requirements are
-					applied transitively to successive components. Use the keyword
-					'_all_' to override transitive behaviour and don't apply any
-					requirements
-				</documentation>
-			</annotation>
-		</attribute>
+		<attribute name="id" type="string" use="required" />
 		<attribute name="name" type="string" use="optional" />
+	</complexType>
+
+	<complexType name="transformerType">
+		<complexContent>
+			<extension base="ab:componentType">
+				<sequence>
+					<element name="output" type="ab:outputType" minOccurs="1"
+						maxOccurs="unbounded" />
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+
+	<complexType name="filterType">
+		<complexContent>
+			<extension base="ab:componentType">
+				<sequence>
+					<element name="outcome" type="ab:outcomeType" minOccurs="1"
+						maxOccurs="unbounded" />
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+
+	<complexType name="analyzerType">
+		<complexContent>
+			<extension base="ab:componentType">
+			</extension>
+		</complexContent>
 	</complexType>
 
 	<complexType name="inputType">
@@ -211,39 +231,6 @@
 		<attribute name="id" type="token" use="required" />
 		<attribute name="name" type="string" use="optional" />
 		<attribute name="hidden" type="boolean" use="optional"></attribute>
-	</complexType>
-
-	<complexType name="analyzerType">
-		<sequence>
-			<element name="descriptor" type="ab:analyzerDescriptorType"
-				minOccurs="1" maxOccurs="1" />
-			<element name="metadata-properties" type="ab:metadataProperties"
-				minOccurs="0" maxOccurs="1" />
-			<element name="properties" type="ab:configuredPropertiesType"
-				minOccurs="0" maxOccurs="1" />
-			<element name="input" type="ab:inputType" minOccurs="0"
-				maxOccurs="unbounded" />
-		</sequence>
-		<attribute name="requires" type="token" use="optional">
-			<annotation>
-				<documentation>
-					The ID of a filter outcome that should function as a
-					requirement for execution of this component. Requirements are
-					applied transitively to successive components. Use the keyword
-					'_all_' to override transitive behaviour and don't apply any
-					requirements
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="name" type="string" use="optional" />
-	</complexType>
-
-	<complexType name="analyzerDescriptorType">
-		<attribute name="ref" type="token" use="required" />
-	</complexType>
-
-	<complexType name="filterDescriptorType">
-		<attribute name="ref" type="token" use="required" />
 	</complexType>
 
 	<complexType name="outcomeType">


### PR DESCRIPTION
This is the Job XML Schema part of the greater story #224. To make review easier and incremental this bit is pushed. It's actual origin is in PR #417 (which I do not want to have merged yet) from which also #419 was separated out as a "child PR".

This particular part is only about the change pertaining to the XSD (and the generated java classes from this). It is NOT about adapting the job reader+writer to actually support reading+writing output data stream jobs. That part is pending still.