### PR TITLE
Feature/395 documentation links in docs

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/documentation/ComponentDocumentationWrapper.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/ComponentDocumentationWrapper.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.ComponentCategory;
 import org.datacleaner.api.Concurrent;
+import org.datacleaner.api.ExternalDocumentation;
 import org.datacleaner.api.HasAnalyzerResult;
 import org.datacleaner.api.QueryOptimizedFilter;
 import org.datacleaner.descriptors.AnalyzerDescriptor;
@@ -74,6 +75,15 @@ public class ComponentDocumentationWrapper {
 
     public boolean isQueryOptimizable() {
         return ReflectionUtils.is(_componentDescriptor.getComponentClass(), QueryOptimizedFilter.class);
+    }
+
+    public ExternalDocumentation.DocumentationLink[] getDocumentationLinks() {
+        final ExternalDocumentation externalDocumentation = _componentDescriptor
+                .getAnnotation(ExternalDocumentation.class);
+        if (externalDocumentation == null) {
+            return new ExternalDocumentation.DocumentationLink[0];
+        }
+        return externalDocumentation.value();
     }
 
     public String[] getAliases() {

--- a/desktop/ui/src/main/resources/org/datacleaner/documentation/template.html
+++ b/desktop/ui/src/main/resources/org/datacleaner/documentation/template.html
@@ -78,7 +78,18 @@ h3 {
 					<h1>
 						<img src="${icon}" alt="" /> <span>${component.name}</span>
 					</h1>
-					${component.description}
+					<div>${component.description}</div>
+					
+					<#list component.documentationLinks as link>
+					<div>
+						<#if link.type().name() == 'VIDEO'>
+						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
+						<#else>
+						<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+						</#if>
+						<a href="${link.url()}">${link.title()}</a>
+					</div>
+					</#list>
 				</div>
 
 				<div>

--- a/desktop/ui/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
@@ -29,6 +29,7 @@ import org.datacleaner.beans.CompletenessAnalyzer;
 import org.datacleaner.beans.filter.EqualsFilter;
 import org.datacleaner.beans.stringpattern.PatternFinderAnalyzer;
 import org.datacleaner.beans.transform.ConcatenatorTransformer;
+import org.datacleaner.beans.transform.SynonymLookupTransformer;
 import org.datacleaner.components.tablelookup.TableLookupTransformer;
 import org.datacleaner.descriptors.ComponentDescriptor;
 import org.datacleaner.descriptors.Descriptors;
@@ -49,6 +50,20 @@ public class ComponentDocumentationBuilderTest {
         final File benchmarkFile = new File("src/test/resources/documentation/pattern_finder.html");
         final File outputFile = new File("target/documentation_pattern_finder.html");
         final ComponentDescriptor<?> descriptor = Descriptors.ofAnalyzer(PatternFinderAnalyzer.class);
+
+        runBenchmarkTest(descriptor, benchmarkFile, outputFile);
+    }
+
+    /**
+     * Test of an component with video link
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testBuildSynonymLookupDocs() throws Exception {
+        final File benchmarkFile = new File("src/test/resources/documentation/synonym_lookup.html");
+        final File outputFile = new File("target/documentation_synonym_lookup.html");
+        final ComponentDescriptor<?> descriptor = Descriptors.ofTransformer(SynonymLookupTransformer.class);
 
         runBenchmarkTest(descriptor, benchmarkFile, outputFile);
     }

--- a/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
+++ b/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
@@ -74,7 +74,8 @@ h3 {
 					<h1>
 						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAB/0lEQVR42u2XXUvCUBjHdx1+tS6DIqhb6aIvYQVdCVFEuezNXGXRdE3TnKUWUUl0IWZUXkVE1IU191LEac/OVtO2XuZ0Nw5+MJ9t5//bmedshyDc3hY36aGF2C45H00FgjGdZCBIJwNzUY2tL0h655PAFsZYA4znw/VqeypfGfPMLhmiY14iks7nhql75Abx/EkaBDgXBRLEeirnosAxCGS5arWKeL6GqWFqdQgYQUCCIGJEjFiHhJEkJH1DxsgykuVXBJmqwFoyy8lwgnKgWCy1BciCG4tnNQFJsdcFGrdW1CCL5/mOQEfAXKBdo8C6B1aJOqxqFEXVYVUzu7Yj8KOASHWh/GI3Gpsh0cDUOeqfvlb3oQbHWipAcWXUM3nzIyDiuAC8SEKHD7+G60wwl46MgsTBCRbIFJ/+HP7ZE5cvzswDy/HcvrFhfWsMNKuL8nvzAqNrhaJZkDHMrNbYC7YFvGTp0epus+VnFateGWPumhfonbp6M3vGxmDYNztnYKbirgDMEXZHAXymqaOgmUcwQt8iQfm0sstO/jRBjG+cXdj9Ey7tVZoSSB0VOGI2wnrtDkOSzkwuM2m/Tji+5zf+bjwWZjP+0DanssJy/tUoM6guz5TG+v47EcE1jq4RlQZ9/wj3tWSh+see6GvpalkJ8GgirEJVg9VqHqfzPgDo18EOfGy5wwAAAABJRU5ErkJggg==" alt="" /> <span>Completeness analyzer</span>
 					</h1>
-					<p>Asserts the completeness of your data by ensuring that all required fields are filled.</p>
+					<div><p>Asserts the completeness of your data by ensuring that all required fields are filled.</p></div>
+					
 				</div>
 
 				<div>

--- a/desktop/ui/src/test/resources/documentation/equals_filter.html
+++ b/desktop/ui/src/test/resources/documentation/equals_filter.html
@@ -74,7 +74,8 @@ h3 {
 					<h1>
 						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACkUlEQVR42mNgGCrgAAMD8xcZhvavMgwT3wgz8KDLfZNhqP8qyzD5nRIDH00c8FmGIfCbLMN/EAZatP+ZJAMnSHwVAwMTkL8YLifDUEITBwANng6zBGrRrscyDBxA9ix0cYotey7BIPJQjkEAxQGyDDeRLYKGxCMsYl9vqzCwwfS9EmXgfiPLIEm05Z+kGcyBvvgONOgvEB8Dsms/yTF4o1uEDwP1JAPTSzGQ3gPEP0FmfZFlCCcurmUZ0kixjFgMdEAncQ6QZFCnhQOAIetFSoK7R03LQVEKyzXEOUCWYQqVQ2A7Tsv+//9fD8J/nz3p+3Nw5/pfy+ec/zW59dOv3vr/VMMTm7/9Wjzjyu+9Wzb/fXBnMsxOEAY7AGwpNS0khOdOvP/v9+9GhAMmNH8nRqOxsTFBTJQD+ur//X3zqgvugD8Hd60DCdLLAb83r9qHEgXEOmJqfARBTIrlKA4AO+LQ7rW0jHt0y1Ec8O/v34ZfK+aeo2nimz/5zr9vX1swHAC2fNnsC3RJA/Mm3UV2BNgBv1fNP03XXAAKCaCnkbJh0w9iNFIjEcLw39cvulGz4fSuV3QphKa0v/+9dc0eeBQgg9dyDBLAejwSWBccoHJdcAlYISV9kGNQJLY2XElVB8gwnCGp9QvU8I6q1bEsw7+XigxixLaIbGjRIAE6Ip4oBwDTQDYWzV9ItOwLlkbJBKIcAGrBAhUfAeKjoM4GsCll9kCBgR9o6G9iHfBOhkEHhIFmlIIapkCx8x+kGPQp6xfIMhzH4qvlQPE/aAnuJU06JsCoaUGzvA4sLs0QDWp2IzuKJg4ARQW8iQ10DFq2TQKldKhcBM06qF/kGJw+yjB44Mg91sD+Y0ADAwMjw1ACAOtLcYBa7VwmAAAAAElFTkSuQmCC" alt="" /> <span>Equals</span>
 					</h1>
-					<p>A filter that excludes values that are not equal (=) to specific set of valid values</p>
+					<div><p>A filter that excludes values that are not equal (=) to specific set of valid values</p></div>
+					
 				</div>
 
 				<div>

--- a/desktop/ui/src/test/resources/documentation/pattern_finder.html
+++ b/desktop/ui/src/test/resources/documentation/pattern_finder.html
@@ -74,7 +74,12 @@ h3 {
 					<h1>
 						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABRUlEQVR42mNgGAyg+rza/4HAow7AcMCK+4X/QQBED4gDLrzd/P/6h31AehOKwkMvZv//8uvt/++/P/8/+2YdQXGyHFBzTuP/519v/ndfcQLSb8F8dA0Trnn+//v3L9HiWC3DlQtm34r+jwxAfJjm+beT/197v/f/ux+PwXKExMlywOEXc/9vfdwGVgyiD72YA9f89feH/8vvFfxf/7AGxSJc4mQ54NX3e/97r7qCFYPoV9/uwjWD4vf7709gRyJbhEucLAfQLcUPSgcYGxv/pwTfuXMHKya6Lhh1AMiQlStX/v/8+fP/T58+/V+wYAHccFziNAuB5ubm/zdu3MCwBJc4VR3Q39////jx4/8dHR1RLMAlTnUHgILZwcEBwwJ0cVwWkmQpJYmQZg4AAWwWoosP3xAYdQAhw6lm4agDRh0w6oDBBAA6bKn5UjgQFgAAAABJRU5ErkJggg==" alt="" /> <span>Pattern finder</span>
 					</h1>
-					<p>The Pattern Finder will inspect your String values and generate and match string patterns that suit your data.</p><p>It can be used for a lot of purposes but is excellent for verifying or getting ideas about the format of the string-values in a column.</p>
+					<div><p>The Pattern Finder will inspect your String values and generate and match string patterns that suit your data.</p><p>It can be used for a lot of purposes but is excellent for verifying or getting ideas about the format of the string-values in a column.</p></div>
+					
+					<div>
+						<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+						<a href="http://kasper.eobjects.org/2010/09/pattern-finder-20-latest-feature-in.html">Kasper's Source: Pattern Finder 2.0</a>
+					</div>
 				</div>
 
 				<div>

--- a/desktop/ui/src/test/resources/documentation/synonym_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/synonym_lookup.html
@@ -66,16 +66,24 @@ h3 {
 					<li><a href="index.html">Library</a></li>
 
 					<!-- categorization -->
-					<li>Transform</li> 					<li>String manipulation</li>
+					<li>Improve</li> 
 
-					<li class="active">Concatenator</li>
+					<li class="active">Synonym lookup</li>
 				</ol>
 				<div class="jumbotron">
 					<h1>
-						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAB1UlEQVR42u2VPUvDYBDH/w7q4svmoIKDjqJDQT+Fg6iTjg6OuunUgrMgvoEUpdK0yeAgdhEd+gmELkXxBXURFFta0Lb21Tu5FBrypBFBO+TgkkDu7v977rk8ATzzzDPPWt0qOhZqBmrslSjm7WLM96ZXdRTI78g3MiH0/gqAilzUCxs4dwNggTlxFJjbufer3uUPMUiiFfIXKvTKzzkNAyoAfg4E0PZ2gK6KgSWBzjtq06WmgqD2r8kqNsm3v7dBx6oTgGkpDd2S+6QSZ20TwBaCkq+5SEmHr6RhUlZ01QyAxatRrAvwokrcCtAAURfUkawDGbgRoAk3M0C5l7kj9KvE7QDY47L6PWvLCcAvhXddD6GBdDGCcRGPW/VsO/AYQicn8tDxIJpChTCGBSB1u4UO1RYkA2gvhDBEcUGJP3PTgXr7yxHMOq2KvaxjxmkI2dL76BGATLMZ8FuGL9YMgGJOmwFw92Qbsk5fQYP4exB9VLxE/sHfszWRTzb+tjmGY+0AeHuKYYxx6wU25voMouN2RZJ0h9PxWAZ02cUQZosaRn9y9CZkj6dUMTQj0wKZUPwLyiT8THftM4oR74/qaD6fr/af3hIAcfIHuf+1+70Z9Ozf7Qs3CrvZsKowsAAAAABJRU5ErkJggg==" alt="" /> <span>Concatenator</span>
+						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACY0lEQVR42u2Xy2sTURTG82+4r/jEVyqoCK4VBBeioCiu/AMUwbcuXbnRjWhjO1oLWiomjcUi1SYRimLVTCapaRI1mVbz6jTTvCaZ4XPujaYZ7CPz0gr94CzuZeZ+v9w5954Th2Mlyel0rvkbsSQA23EPdsYqgOoxrIZnhQOs70L82CASp4Y0ET/hRXh3L9iNLsSOuNW555g89BTBtRYDiKNJLCZFUSB4Ygjv6UX69jgdS1Mivpx+YR0AWXQ5FT+kEdraDf6Knz6v1GUkz4xYA/Bb5Yk8ogf6ET8+iPps5U+I9z8Q2tICIStInn1lHQB/2d98Mf94YsGdmHs7DXbzfS3EudfWAAjeOIIdd6lBOZpf9HPMjU2B3eSiwBRCjdT5UfMARNVkAbVcedmcEAM8PR0aiAs+g0koyTAi0ZcCu6ELqUvzEK2fsW0AkuFGVRj5Ru8RDcTVgD4AcqbNqPDyK9h1KsRFX/NI89ff6LuKp2+MmYKYHUrQdfhrAc2p0lULvt98Zwri8/5+uo6ULtJxvVDVX4zSt8YNmdeyJYS2dSOyrw9ytd5IUn/KWDXM3Pmoy7wuVBA9OIDwroeoJAQ6VwpmVKAe4+U46wq2Z65uM6mQ3M4HqERnGuZsBtz2HvP9QJYJLW0uSpg8/AxcJ0PrCDUPZcHtYKxpSMi1nOuLLGguFyXaI5BfSkxpMeO05pZ0RAQi/0RbmORyjVZMknSlT5mGeTgHzsnY05KRDmhmINo0T5z00nnBHZs372Ts7wljR92I7H3UHJMdIDtBitJ/3pT+S4CWGLYxPO38T/TYGY5V/dJPzntMmDtub7AAAAAASUVORK5CYII=" alt="" /> <span>Synonym lookup</span>
 					</h1>
-					<div><p>Concatenate several column values into one.</p></div>
+					<div><p>Replaces strings with their synonyms</p></div>
 					
+					<div>
+						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
+						<a href="https://www.youtube.com/watch?v=iy-j5s-uHz4">Segmenting customers on messy data</a>
+					</div>
+					<div>
+						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
+						<a href="https://www.youtube.com/watch?v=_YiPaA8bFt4">Understanding and using Synonyms</a>
+					</div>
 				</div>
 
 				<div>
@@ -90,7 +98,8 @@ h3 {
 						execution possible</span>
 
 					<!-- aliases -->
-					
+					 <span class="label label-info">Alias:
+						Synonym replacement</span> 
 				</div>
 			</div>
 		</div>
@@ -113,21 +122,39 @@ h3 {
 						<h3>
 							 <span
 								class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-							 Columns
+							 Column
 						</h3>  <!-- type --> <span
-						class="label label-primary">List of InputColumn&lt;Object&gt;</span>  
+						class="label label-primary">InputColumn&lt;String&gt;</span>  
 
 						<!-- required/optional -->  <span
 						class="label label-info">Required</span> 
 					</li> 					<li class="list-group-item">
 						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-							 Separator
-						</h3> <p>A string to separate the concatenated values</p> <!-- type --> <span
-						class="label label-primary">String</span>  
+							 Look up every token
+						</h3> <p>Tokenize and look up every token of the input, rather than looking up the complete input string?</p> <!-- type --> <span
+						class="label label-primary">boolean</span>  
 
 						<!-- required/optional -->  <span
-						class="label label-info">Optional</span> 
+						class="label label-info">Required</span> 
+					</li> 					<li class="list-group-item">
+						<h3>
+							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+							 Retain original value
+						</h3> <p>Retain original value in case no synonym is found (otherwise null)</p> <!-- type --> <span
+						class="label label-primary">boolean</span>  
+
+						<!-- required/optional -->  <span
+						class="label label-info">Required</span> 
+					</li> 					<li class="list-group-item">
+						<h3>
+							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+							 Synonym catalog
+						</h3>  <!-- type --> <span
+						class="label label-primary">SynonymCatalog</span>  
+
+						<!-- required/optional -->  <span
+						class="label label-info">Required</span> 
 					</li> 
 				</ul>
 

--- a/desktop/ui/src/test/resources/documentation/table_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/table_lookup.html
@@ -74,7 +74,8 @@ h3 {
 					<h1>
 						<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACG0lEQVR42u2XSU/CQBSA+wP8eyYSE70SD/4Jl8RTE6MxSl1BEZdYqGWTooDGuJ4IatwuxqiRQ7WUVkLGvk4HC1JBKOKBSb7AvA7zvk77Soei2t0WN9mBhcAOM++PuuYChIhrjo24Zv0GW18wbLiEawtjjgHm8fB7fT6drxzz3A7jYQNOaj2WSg56n1A7CKaOYyAgtFEgRK1Fk20UOAKBhCCKIpKkHCaHyZUhY2QZyXIek8fky1AwioKUb6gYVUWq+oEgpy7giyQEFQZoB9LpzJ8AueDEgglDQNHsiUBl+1VslSrDKga5JEnqCHQEqgv8VRV0LsH/FcirRZS6ekej3CPqm75DvVM3+neIwbGWCniFS9Q9cfsjIGK7APyReA5eaiYnjHNXtlRBaP8YC8TT2dLkI4FHlJUK+lnBJ/StVsKWFXAHk3vm5KRBnzQrCXJPNCUw4jtNkwnJmVcKQLzWKjQs4GQyr2RCkrgSqzhUR9MCPZPXhUZXAMrUVgGre+DsPldVAJ4RjVYBvKbpVWC+BNWqIHH5htRCEfmOst8EhtkHJGuvVo0STp2EqLGN84tadQ/Jq0ks7d41JRA9PBWomXXeWc/Dh0hMxp5LMYaNT7i5GE1YCe7S5n7lsRU+Tnu2BZ1lXqBX/Vy/vj3TJnPUIwHJn8UP0nfYukfUJhyq91EMY1uyUa1zJRwt3S1rCboMEV5DNOCNWJfd+T4Bag+Lk1UWi94AAAAASUVORK5CYII=" alt="" /> <span>Table lookup</span>
 					</h1>
-					<p>Perform a lookup based on a table in any of your registered datastore (like a LEFT join).</p>
+					<div><p>Perform a lookup based on a table in any of your registered datastore (like a LEFT join).</p></div>
+					
 				</div>
 
 				<div>


### PR DESCRIPTION
Fixes another aspect of #395: The external links to documentation. A few screenshots:

![image](https://cloud.githubusercontent.com/assets/291450/7612244/d2d5c564-f989-11e4-89c3-cddfcd8240fa.png)

![image](https://cloud.githubusercontent.com/assets/291450/7612252/decdbcd2-f989-11e4-986d-ba1e929c295c.png)
