### PR TITLE
Added XML externalization for ElasticSearch, MongoDb, CouchDb and SFDC

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
@@ -36,10 +36,6 @@ import org.datacleaner.util.ws.NaiveTrustManager;
  */
 public class SecurityUtils {
 
-    protected static final char[] SECRET = "cafelattebabemlobhat".toCharArray();
-    protected static final byte[] SALT = { (byte) 0xde, (byte) 0x33, (byte) 0x12, (byte) 0x10, (byte) 0x33,
-            (byte) 0x10, (byte) 0x12, (byte) 0xde };
-
     private SecurityUtils() {
         // prevent instantiation
     }
@@ -80,9 +76,24 @@ public class SecurityUtils {
         if (password == null) {
             return null;
         }
-        EncodedStringConverter converter = new EncodedStringConverter();
-        String encodedPassword = converter.toString(new String(password));
+        final EncodedStringConverter converter = new EncodedStringConverter();
+        final String encodedPassword = converter.toString(new String(password));
         return encodedPassword;
+    }
+    
+    /**
+     * Encodes/obfuscates a password. Although this does not prevent actual
+     * hacking of password, it does remove the obvious threats of having
+     * passwords stored as clear text.
+     * 
+     * @param password
+     * @return a String containing the encoded password
+     */
+    public static String encodePassword(String password) {
+        if (password == null) {
+            return null;
+        }
+        return encodePassword(password.toCharArray());
     }
 
     /**
@@ -99,8 +110,8 @@ public class SecurityUtils {
         if (encodedPassword == null) {
             return null;
         }
-        EncodedStringConverter converter = new EncodedStringConverter();
-        String password = converter.fromString(String.class, encodedPassword);
+        final EncodedStringConverter converter = new EncodedStringConverter();
+        final String password = converter.fromString(String.class, encodedPassword);
         return password;
     }
 

--- a/engine/core/src/test/java/org/datacleaner/util/SecurityUtilsTest.java
+++ b/engine/core/src/test/java/org/datacleaner/util/SecurityUtilsTest.java
@@ -24,18 +24,19 @@ import junit.framework.TestCase;
 public class SecurityUtilsTest extends TestCase {
 
     public void testNullValues() throws Exception {
-        assertNull(SecurityUtils.encodePassword(null));
+        assertNull(SecurityUtils.encodePassword((char[]) null));
+        assertNull(SecurityUtils.encodePassword((String) null));
         assertNull(SecurityUtils.decodePassword(null));
     }
-    
+
     public void testEmptyStringValues() throws Exception {
         String encoded = SecurityUtils.encodePassword("".toCharArray());
         assertNotNull(encoded);
-        
+
         String decoded = SecurityUtils.decodePassword(encoded);
         assertNotNull(decoded);
         assertEquals("", decoded);
-        
+
         assertNotNull(SecurityUtils.decodePassword(""));
     }
 

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
@@ -210,6 +210,12 @@ public class DatastoreXmlExternalizer {
             elem = toElement((JdbcDatastore) datastore);
         } else if (datastore instanceof ElasticSearchDatastore) {
             elem = toElement((ElasticSearchDatastore) datastore);
+        } else if (datastore instanceof MongoDbDatastore) {
+            elem = toElement((MongoDbDatastore) datastore);
+        } else if (datastore instanceof CouchDbDatastore) {
+            elem = toElement((CouchDbDatastore) datastore);
+        } else if (datastore instanceof SalesforceDatastore) {
+            elem = toElement((SalesforceDatastore) datastore);
         } else {
             throw new UnsupportedOperationException("Non-supported datastore: " + datastore);
         }

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
@@ -41,6 +41,7 @@ import org.datacleaner.connection.ExcelDatastore;
 import org.datacleaner.connection.JdbcDatastore;
 import org.datacleaner.connection.MongoDbDatastore;
 import org.datacleaner.connection.SalesforceDatastore;
+import org.datacleaner.util.SecurityUtils;
 import org.datacleaner.util.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -271,7 +272,7 @@ public class DatastoreXmlExternalizer {
             appendElement(ds, "url", datastore.getJdbcUrl());
             appendElement(ds, "driver", datastore.getDriverClass());
             appendElement(ds, "username", datastore.getUsername());
-            appendElement(ds, "password", datastore.getPassword());
+            appendElement(ds, "password", encodePassword(datastore.getPassword()));
             appendElement(ds, "multiple-connections", datastore.isMultipleConnections() + "");
         } else {
             appendElement(ds, "datasource-jndi-url", jndiUrl);
@@ -293,6 +294,20 @@ public class DatastoreXmlExternalizer {
         }
 
         return ds;
+    }
+
+    private String encodePassword(String password) {
+        if (password == null) {
+            return null;
+        }
+        return JaxbConfigurationReader.ENCODED_PASSWORD_PREFIX + SecurityUtils.encodePassword(password);
+    }
+
+    private String encodePassword(char[] password) {
+        if (password == null) {
+            return null;
+        }
+        return JaxbConfigurationReader.ENCODED_PASSWORD_PREFIX + SecurityUtils.encodePassword(password);
     }
 
     /**
@@ -333,7 +348,7 @@ public class DatastoreXmlExternalizer {
         appendElement(ds, "port", datastore.getPort());
         appendElement(ds, "database-name", datastore.getDatabaseName());
         appendElement(ds, "username", datastore.getUsername());
-        appendElement(ds, "password", datastore.getPassword());
+        appendElement(ds, "password", encodePassword(datastore.getPassword()));
 
         return ds;
     }
@@ -354,7 +369,7 @@ public class DatastoreXmlExternalizer {
         appendElement(ds, "hostname", datastore.getHostname());
         appendElement(ds, "port", datastore.getPort());
         appendElement(ds, "username", datastore.getUsername());
-        appendElement(ds, "password", datastore.getPassword());
+        appendElement(ds, "password", encodePassword(datastore.getPassword()));
         appendElement(ds, "ssl", datastore.isSslEnabled());
 
         return ds;
@@ -374,7 +389,7 @@ public class DatastoreXmlExternalizer {
         }
 
         appendElement(ds, "username", datastore.getUsername());
-        appendElement(ds, "password", datastore.getPassword());
+        appendElement(ds, "password", encodePassword(datastore.getPassword()));
         appendElement(ds, "security-token", datastore.getSecurityToken());
 
         return ds;

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DatastoreXmlExternalizer.java
@@ -25,18 +25,23 @@ import java.util.Arrays;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.datacleaner.connection.CsvDatastore;
-import org.datacleaner.connection.Datastore;
-import org.datacleaner.connection.DatastoreCatalog;
-import org.datacleaner.connection.ExcelDatastore;
-import org.datacleaner.connection.JdbcDatastore;
-import org.datacleaner.util.StringUtils;
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.schema.TableType;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Func;
 import org.apache.metamodel.util.Resource;
+import org.apache.metamodel.util.SimpleTableDef;
 import org.apache.metamodel.xml.XmlDomDataContext;
+import org.datacleaner.connection.CouchDbDatastore;
+import org.datacleaner.connection.CsvDatastore;
+import org.datacleaner.connection.Datastore;
+import org.datacleaner.connection.DatastoreCatalog;
+import org.datacleaner.connection.ElasticSearchDatastore;
+import org.datacleaner.connection.ExcelDatastore;
+import org.datacleaner.connection.JdbcDatastore;
+import org.datacleaner.connection.MongoDbDatastore;
+import org.datacleaner.connection.SalesforceDatastore;
+import org.datacleaner.util.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -116,6 +121,31 @@ public class DatastoreXmlExternalizer {
             }
         }
 
+        if (datastore instanceof ElasticSearchDatastore) {
+            final SimpleTableDef[] tableDefs = ((ElasticSearchDatastore) datastore).getTableDefs();
+            if (tableDefs == null) {
+                return true;
+            }
+        }
+
+        if (datastore instanceof MongoDbDatastore) {
+            final SimpleTableDef[] tableDefs = ((MongoDbDatastore) datastore).getTableDefs();
+            if (tableDefs == null) {
+                return true;
+            }
+        }
+
+        if (datastore instanceof CouchDbDatastore) {
+            final SimpleTableDef[] tableDefs = ((CouchDbDatastore) datastore).getTableDefs();
+            if (tableDefs == null) {
+                return true;
+            }
+        }
+
+        if (datastore instanceof SalesforceDatastore) {
+            return true;
+        }
+
         return false;
     }
 
@@ -141,9 +171,9 @@ public class DatastoreXmlExternalizer {
                         if (datastoreName.equals(value)) {
                             // we have a match
                             datastoreCatalogElement.removeChild(element);
-                            
+
                             onDocumentChanged(getDocument());
-                            
+
                             return true;
                         }
                     }
@@ -178,6 +208,8 @@ public class DatastoreXmlExternalizer {
             elem = toElement((ExcelDatastore) datastore, filename);
         } else if (datastore instanceof JdbcDatastore) {
             elem = toElement((JdbcDatastore) datastore);
+        } else if (datastore instanceof ElasticSearchDatastore) {
+            elem = toElement((ElasticSearchDatastore) datastore);
         } else {
             throw new UnsupportedOperationException("Non-supported datastore: " + datastore);
         }
@@ -253,6 +285,91 @@ public class DatastoreXmlExternalizer {
         if (!Strings.isNullOrEmpty(catalogName)) {
             appendElement(ds, "catalog-name", catalogName);
         }
+
+        return ds;
+    }
+
+    /**
+     * Externalizes a {@link ElasticSearchDatastore} to a XML element
+     * 
+     * @param datastore
+     * @return
+     */
+    public Element toElement(ElasticSearchDatastore datastore) {
+        final Element ds = getDocument().createElement("elasticsearch-datastore");
+        ds.setAttribute("name", datastore.getName());
+        if (!StringUtils.isNullOrEmpty(datastore.getDescription())) {
+            ds.setAttribute("description", datastore.getDescription());
+        }
+
+        appendElement(ds, "hostname", datastore.getHostname());
+        appendElement(ds, "port", datastore.getPort());
+        appendElement(ds, "cluster-name", datastore.getClusterName());
+        appendElement(ds, "index-name", datastore.getIndexName());
+
+        return ds;
+    }
+
+    /**
+     * Externalizes a {@link MongoDbDatastore} to a XML element
+     * 
+     * @param datastore
+     * @return
+     */
+    public Element toElement(MongoDbDatastore datastore) {
+        final Element ds = getDocument().createElement("mongodb-datastore");
+        ds.setAttribute("name", datastore.getName());
+        if (!StringUtils.isNullOrEmpty(datastore.getDescription())) {
+            ds.setAttribute("description", datastore.getDescription());
+        }
+
+        appendElement(ds, "hostname", datastore.getHostname());
+        appendElement(ds, "port", datastore.getPort());
+        appendElement(ds, "database-name", datastore.getDatabaseName());
+        appendElement(ds, "username", datastore.getUsername());
+        appendElement(ds, "password", datastore.getPassword());
+
+        return ds;
+    }
+
+    /**
+     * Externalizes a {@link CouchDa} to a XML element
+     * 
+     * @param datastore
+     * @return
+     */
+    public Element toElement(CouchDbDatastore datastore) {
+        final Element ds = getDocument().createElement("couchdb-datastore");
+        ds.setAttribute("name", datastore.getName());
+        if (!StringUtils.isNullOrEmpty(datastore.getDescription())) {
+            ds.setAttribute("description", datastore.getDescription());
+        }
+
+        appendElement(ds, "hostname", datastore.getHostname());
+        appendElement(ds, "port", datastore.getPort());
+        appendElement(ds, "username", datastore.getUsername());
+        appendElement(ds, "password", datastore.getPassword());
+        appendElement(ds, "ssl", datastore.isSslEnabled());
+
+        return ds;
+    }
+
+    /**
+     * Externalizes a {@link CouchDa} to a XML element
+     * 
+     * @param datastore
+     * @return
+     */
+    public Element toElement(SalesforceDatastore datastore) {
+        final Element ds = getDocument().createElement("salesforce-datastore");
+        ds.setAttribute("name", datastore.getName());
+        if (!StringUtils.isNullOrEmpty(datastore.getDescription())) {
+            ds.setAttribute("description", datastore.getDescription());
+        }
+
+        appendElement(ds, "username", datastore.getUsername());
+        appendElement(ds, "password", datastore.getPassword());
+        appendElement(ds, "security-token", datastore.getSecurityToken());
 
         return ds;
     }
@@ -377,6 +494,10 @@ public class DatastoreXmlExternalizer {
     private void appendElement(Element parent, String elementName, Object value) {
         if (value == null) {
             return;
+        }
+
+        if (value instanceof char[]) {
+            value = new String((char[]) value);
         }
 
         String stringValue = value.toString();

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -1220,7 +1220,7 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
             return null;
         }
         if (possiblyEncodedPassword.startsWith(ENCODED_PASSWORD_PREFIX)) {
-            return SecurityUtils.decodePassword(possiblyEncodedPassword);
+            return SecurityUtils.decodePassword(possiblyEncodedPassword.substring(ENCODED_PASSWORD_PREFIX.length()));
         }
         return possiblyEncodedPassword;
     }


### PR DESCRIPTION
This will ensure that in most situations we can externalize datastores of these types to the conf.xml file, instead of saving them in userpreferences.dat.

While this is actually an independent improvement, I imagine that making XML externalization better will in turn make #402 much easier to fix because we can then focus on conf.xml and not on user preferences (more volatile and difficult to migrate)

Fixes #440