### PR TITLE
Protect delegates of CompositeAnalysisListener from each others exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.classpath
 /target
 /.DS_Store
+.idea
+*.iml

--- a/engine/core/src/main/java/org/datacleaner/job/runner/CompositeAnalysisListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/CompositeAnalysisListener.java
@@ -1,15 +1,21 @@
 /**
- * DataCleaner (community edition) Copyright (C) 2014 Neopost - Customer Information Management
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
  *
- * This copyrighted material is made available to anyone wishing to use, modify, copy, or redistribute it subject to the
- * terms and conditions of the GNU Lesser General Public License, as published by the Free Software Foundation.
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
- * details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with this distribution; if not, write
- * to: Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor Boston, MA  02110-1301  USA
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
  */
 package org.datacleaner.job.runner;
 

--- a/engine/core/src/main/java/org/datacleaner/job/runner/CompositeAnalysisListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/CompositeAnalysisListener.java
@@ -1,21 +1,15 @@
 /**
- * DataCleaner (community edition)
- * Copyright (C) 2014 Neopost - Customer Information Management
+ * DataCleaner (community edition) Copyright (C) 2014 Neopost - Customer Information Management
  *
- * This copyrighted material is made available to anyone wishing to use, modify,
- * copy, or redistribute it subject to the terms and conditions of the GNU
- * Lesser General Public License, as published by the Free Software Foundation.
+ * This copyrighted material is made available to anyone wishing to use, modify, copy, or redistribute it subject to the
+ * terms and conditions of the GNU Lesser General Public License, as published by the Free Software Foundation.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this distribution; if not, write to:
- * Free Software Foundation, Inc.
- * 51 Franklin Street, Fifth Floor
- * Boston, MA  02110-1301  USA
+ * You should have received a copy of the GNU Lesser General Public License along with this distribution; if not, write
+ * to: Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor Boston, MA  02110-1301  USA
  */
 package org.datacleaner.job.runner;
 
@@ -27,24 +21,27 @@ import org.datacleaner.api.ComponentMessage;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.ComponentJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link AnalysisListener} that wraps a list of inner listeners. Makes life
  * easier for the invokers of the listeners.
  */
 public final class CompositeAnalysisListener implements AnalysisListener {
+    private static final Logger logger = LoggerFactory.getLogger(CompositeAnalysisListener.class);
 
     private final List<AnalysisListener> _delegates;
 
     public CompositeAnalysisListener(AnalysisListener[] delegates) {
-        _delegates = new ArrayList<AnalysisListener>(delegates.length);
+        _delegates = new ArrayList<>(delegates.length);
         for (AnalysisListener analysisListener : delegates) {
             addDelegate(analysisListener);
         }
     }
 
     public CompositeAnalysisListener(AnalysisListener firstDelegate, AnalysisListener... delegates) {
-        _delegates = new ArrayList<AnalysisListener>(1 + delegates.length);
+        _delegates = new ArrayList<>(1 + delegates.length);
         addDelegate(firstDelegate);
         for (AnalysisListener analysisListener : delegates) {
             addDelegate(analysisListener);
@@ -53,7 +50,7 @@ public final class CompositeAnalysisListener implements AnalysisListener {
 
     /**
      * Adds a delegate to this {@link CompositeAnalysisListener}.
-     * 
+     *
      * @param analysisListener
      */
     public void addDelegate(AnalysisListener analysisListener) {
@@ -66,7 +63,7 @@ public final class CompositeAnalysisListener implements AnalysisListener {
     /**
      * Determines if this {@link CompositeAnalysisListener} is empty (i.e. has
      * no delegates)
-     * 
+     *
      * @return
      */
     public boolean isEmpty() {
@@ -75,7 +72,7 @@ public final class CompositeAnalysisListener implements AnalysisListener {
 
     /**
      * Gets the number of delegates
-     * 
+     *
      * @return
      */
     public int size() {
@@ -85,70 +82,110 @@ public final class CompositeAnalysisListener implements AnalysisListener {
     @Override
     public void jobBegin(AnalysisJob job, AnalysisJobMetrics metrics) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.jobBegin(job, metrics);
+            try {
+                delegate.jobBegin(job, metrics);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void onComponentMessage(AnalysisJob job, ComponentJob componentJob, ComponentMessage message) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.onComponentMessage(job, componentJob, message);
+            try {
+                delegate.onComponentMessage(job, componentJob, message);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void jobSuccess(AnalysisJob job, AnalysisJobMetrics metrics) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.jobSuccess(job, metrics);
+            try {
+                delegate.jobSuccess(job, metrics);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void rowProcessingBegin(AnalysisJob job, RowProcessingMetrics metrics) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.rowProcessingBegin(job, metrics);
+            try {
+                delegate.rowProcessingBegin(job, metrics);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void rowProcessingProgress(AnalysisJob job, RowProcessingMetrics metrics, InputRow row, int currentRow) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.rowProcessingProgress(job, metrics, row, currentRow);
+            try {
+                delegate.rowProcessingProgress(job, metrics, row, currentRow);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void rowProcessingSuccess(AnalysisJob job, RowProcessingMetrics metrics) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.rowProcessingSuccess(job, metrics);
+            try {
+                delegate.rowProcessingSuccess(job, metrics);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void componentBegin(AnalysisJob job, ComponentJob componentJob, ComponentMetrics metrics) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.componentBegin(job, componentJob, metrics);
+            try {
+                delegate.componentBegin(job, componentJob, metrics);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void componentSuccess(AnalysisJob job, ComponentJob componentJob, AnalyzerResult result) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.componentSuccess(job, componentJob, result);
+            try {
+                delegate.componentSuccess(job, componentJob, result);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void errorInComponent(AnalysisJob job, ComponentJob componentJob, InputRow row, Throwable throwable) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.errorInComponent(job, componentJob, row, throwable);
+            try {
+                delegate.errorInComponent(job, componentJob, row, throwable);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 
     @Override
     public void errorUnknown(AnalysisJob job, Throwable throwable) {
         for (AnalysisListener delegate : _delegates) {
-            delegate.errorUnknown(job, throwable);
+            try {
+                delegate.errorUnknown(job, throwable);
+            } catch (Exception e) {
+                logger.warn("Listener {} failed", delegate.getClass().getSimpleName(), e);
+            }
         }
     }
 }

--- a/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
@@ -1,15 +1,21 @@
 /**
- * DataCleaner (community edition) Copyright (C) 2014 Neopost - Customer Information Management
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
  *
- * This copyrighted material is made available to anyone wishing to use, modify, copy, or redistribute it subject to the
- * terms and conditions of the GNU Lesser General Public License, as published by the Free Software Foundation.
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
- * details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with this distribution; if not, write
- * to: Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor Boston, MA  02110-1301  USA
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
  */
 package org.datacleaner.job.runner;
 

--- a/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
@@ -1,0 +1,155 @@
+package org.datacleaner.job.runner;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import junit.framework.TestCase;
+
+import org.datacleaner.api.AnalyzerResult;
+import org.datacleaner.api.ComponentMessage;
+import org.datacleaner.api.InputRow;
+import org.datacleaner.job.AnalysisJob;
+import org.datacleaner.job.ComponentJob;
+
+public class CompositeAnalysisListenerTest extends TestCase {
+    public void testHandlingErrors() {
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        AnalysisListener faultyListener = new AnalysisListener() {
+            @Override
+            public void jobBegin(final AnalysisJob job, final AnalysisJobMetrics metrics) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void jobSuccess(final AnalysisJob job, final AnalysisJobMetrics metrics) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void rowProcessingBegin(final AnalysisJob job, final RowProcessingMetrics metrics) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void rowProcessingProgress(final AnalysisJob job, final RowProcessingMetrics metrics,
+                    final InputRow row, final int rowNumber) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void onComponentMessage(final AnalysisJob job, final ComponentJob componentJob,
+                    final ComponentMessage message) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void rowProcessingSuccess(final AnalysisJob job, final RowProcessingMetrics metrics) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void componentBegin(final AnalysisJob job, final ComponentJob componentJob,
+                    final ComponentMetrics metrics) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void componentSuccess(final AnalysisJob job, final ComponentJob componentJob,
+                    final AnalyzerResult result) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void errorInComponent(final AnalysisJob job, final ComponentJob componentJob, final InputRow row,
+                    final Throwable throwable) {
+                throw new RuntimeException("OUCH!");
+            }
+
+            @Override
+            public void errorUnknown(final AnalysisJob job, final Throwable throwable) {
+                throw new RuntimeException("OUCH!");
+            }
+        };
+
+        AnalysisListener goodListener = new AnalysisListener() {
+            @Override
+            public void jobBegin(final AnalysisJob job, final AnalysisJobMetrics metrics) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void jobSuccess(final AnalysisJob job, final AnalysisJobMetrics metrics) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void rowProcessingBegin(final AnalysisJob job, final RowProcessingMetrics metrics) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void rowProcessingProgress(final AnalysisJob job, final RowProcessingMetrics metrics,
+                    final InputRow row, final int rowNumber) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void onComponentMessage(final AnalysisJob job, final ComponentJob componentJob,
+                    final ComponentMessage message) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void rowProcessingSuccess(final AnalysisJob job, final RowProcessingMetrics metrics) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void componentBegin(final AnalysisJob job, final ComponentJob componentJob,
+                    final ComponentMetrics metrics) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void componentSuccess(final AnalysisJob job, final ComponentJob componentJob,
+                    final AnalyzerResult result) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void errorInComponent(final AnalysisJob job, final ComponentJob componentJob, final InputRow row,
+                    final Throwable throwable) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void errorUnknown(final AnalysisJob job, final Throwable throwable) {
+                counter.incrementAndGet();
+            }
+        };
+
+
+        final CompositeAnalysisListener compositeAnalysisListener = new CompositeAnalysisListener(faultyListener, goodListener);
+
+        compositeAnalysisListener.componentBegin(null, null , null);
+        assertEquals(1, counter.get());
+        compositeAnalysisListener.componentSuccess(null, null, null);
+        assertEquals(2, counter.get());
+        compositeAnalysisListener.errorInComponent(null, null, null, null);
+        assertEquals(3, counter.get());
+        compositeAnalysisListener.errorUnknown(null, null);
+        assertEquals(4, counter.get());
+        compositeAnalysisListener.jobBegin(null, null);
+        assertEquals(5, counter.get());
+        compositeAnalysisListener.jobSuccess(null, null);
+        assertEquals(6, counter.get());
+        compositeAnalysisListener.onComponentMessage(null, null, null);
+        assertEquals(7, counter.get());
+        compositeAnalysisListener.rowProcessingBegin(null, null);
+        assertEquals(8, counter.get());
+        compositeAnalysisListener.rowProcessingProgress(null, null, null, 0);
+        assertEquals(9, counter.get());
+        compositeAnalysisListener.rowProcessingSuccess(null, null);
+        assertEquals(10, counter.get());
+    }
+}

--- a/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/runner/CompositeAnalysisListenerTest.java
@@ -1,3 +1,16 @@
+/**
+ * DataCleaner (community edition) Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify, copy, or redistribute it subject to the
+ * terms and conditions of the GNU Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this distribution; if not, write
+ * to: Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.job.runner;
 
 import java.util.concurrent.atomic.AtomicInteger;


### PR DESCRIPTION
Wraps every call to a delegate in a try...catch block to assure that following listeners will also be called.

Fixes #504