### PR TITLE
Fix for bug#538

### DIFF
--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/CaptureChangedRecordsFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/CaptureChangedRecordsFilter.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * recorded and picked up successively by the next run.
  */
 @Named("Capture changed records")
-@Description("Include only records that have changed since the last time you ran the job. This filter assumes a field containing the timestamp of the latest change for each record, and stores the greatest encountered value in order to update the filter's future state.")
+@Description("Include only records that have changed since the last time you ran the job. This filter assumes a field containing the timestamp or a number field of the latest change for each record, and stores the greatest encountered value in order to update the filter's future state.")
 @Distributed(false)
 @Categorized({ FilterCategory.class, DateAndTimeCategory.class })
 @Optimizeable(removeableUponOptimization = false)
@@ -68,7 +68,7 @@ public class CaptureChangedRecordsFilter implements QueryOptimizedFilter<Validat
     private static final Logger logger = LoggerFactory.getLogger(CaptureChangedRecordsFilter.class);
 
     @Configured
-    @Description("Column containing the last modification timestamp or date.")
+    @Description("Column containing the last modification timestamp or date or number.")
     InputColumn<Object> lastModifiedColumn;
 
     @Configured
@@ -148,12 +148,12 @@ public class CaptureChangedRecordsFilter implements QueryOptimizedFilter<Validat
             if (lastModifiedColumn.isPhysicalColumn()) {
                 Table table = lastModifiedColumn.getPhysicalColumn().getTable();
                 if (table != null && !StringUtils.isNullOrEmpty(table.getName())) {
-                    return table.getName() + "." + lastModifiedColumn.getName() + ".GreatestLastModifiedTimestamp";
+                    return table.getName() + "." + lastModifiedColumn.getName() + ".GreatestLastModifiedValue";
                 }
             }
-            return lastModifiedColumn.getName() + ".GreatestLastModifiedTimestamp";
+            return lastModifiedColumn.getName() + ".GreatestLastModifiedValue";
         }
-        return captureStateIdentifier.trim() + ".GreatestLastModifiedTimestamp";
+        return captureStateIdentifier.trim() + ".GreatestLastModifiedValue";
     }
 
     private Properties loadProperties() throws IOException {

--- a/components/basic-filters/src/test/java/org/datacleaner/beans/filter/CaptureChangedRecordsFilterTest.java
+++ b/components/basic-filters/src/test/java/org/datacleaner/beans/filter/CaptureChangedRecordsFilterTest.java
@@ -22,13 +22,13 @@ package org.datacleaner.beans.filter;
 import java.io.File;
 import java.util.Date;
 
+import junit.framework.TestCase;
+
+import org.apache.metamodel.util.FileHelper;
+import org.apache.metamodel.util.FileResource;
 import org.datacleaner.components.convert.ConvertToDateTransformer;
 import org.datacleaner.data.MockInputColumn;
 import org.datacleaner.data.MockInputRow;
-import org.apache.metamodel.util.FileHelper;
-import org.apache.metamodel.util.FileResource;
-
-import junit.framework.TestCase;
 
 public class CaptureChangedRecordsFilterTest extends TestCase {
 
@@ -63,7 +63,7 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // timestamp
         Date benchmarkDate = ConvertToDateTransformer.getInternalInstance().transformValue("2013-01-03");
 
-        assertEquals("Foo\\ LastModified.GreatestLastModifiedTimestamp=" + benchmarkDate.getTime(), lines[1]);
+        assertEquals("Foo\\ LastModified.GreatestLastModifiedValue=" + benchmarkDate.getTime(), lines[1]);
 
         filter = new CaptureChangedRecordsFilter();
 
@@ -90,7 +90,7 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // timestamp
         benchmarkDate = ConvertToDateTransformer.getInternalInstance().transformValue("2013-01-08");
 
-        assertEquals("Foo\\ LastModified.GreatestLastModifiedTimestamp=" + benchmarkDate.getTime(), lines[1]);
+        assertEquals("Foo\\ LastModified.GreatestLastModifiedValue=" + benchmarkDate.getTime(), lines[1]);
 
         // create a new session with a custom capture state identifier
         filter = new CaptureChangedRecordsFilter();
@@ -99,8 +99,9 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         filter.lastModifiedColumn = column;
         filter.captureStateIdentifier = "my_id";
         filter.initialize();
-        assertEquals(ValidationCategory.VALID, filter.categorize(new MockInputRow().put(column, "2013-01-08")));
+        assertEquals(ValidationCategory.VALID, filter.categorize(new MockInputRow().put(column, "2013-06-08")));
 
+        Date newBenchmarkDate = ConvertToDateTransformer.getInternalInstance().transformValue("2013-06-08");
         filter.close();
 
         lines = FileHelper.readFileAsString(file).split("\n");
@@ -108,11 +109,10 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // the first line is a comment with a date of writing
         assertEquals(3, lines.length);
 
-        assertEquals("my_id.GreatestLastModifiedTimestamp=" + benchmarkDate.getTime(), lines[1]);
-        assertEquals("Foo\\ LastModified.GreatestLastModifiedTimestamp=" + benchmarkDate.getTime(), lines[2]);
+        assertEquals("Foo\\ LastModified.GreatestLastModifiedValue=" + benchmarkDate.getTime(), lines[1]);
+        assertEquals("my_id.GreatestLastModifiedValue=" + newBenchmarkDate.getTime(), lines[2]);
     }
-    
-    
+
     public void testFilterOnNumber() throws Exception {
         File file = new File("target/test_capture_changed_records_filter.properties");
         file.delete();
@@ -140,8 +140,7 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // the first line is a comment with a date of writing
         assertEquals(2, lines.length);
 
-
-        assertEquals("Foo\\ LastId.GreatestLastModifiedTimestamp=564738" , lines[1]);
+        assertEquals("Foo\\ LastId.GreatestLastModifiedValue=564738", lines[1]);
 
         filter = new CaptureChangedRecordsFilter();
 
@@ -164,7 +163,7 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // the first line is a comment with a date of writing
         assertEquals(2, lines.length);
 
-        assertEquals("Foo\\ LastId.GreatestLastModifiedTimestamp=564739" , lines[1]);
+        assertEquals("Foo\\ LastId.GreatestLastModifiedValue=564739", lines[1]);
 
         // create a new session with a custom capture state identifier
         filter = new CaptureChangedRecordsFilter();
@@ -182,7 +181,7 @@ public class CaptureChangedRecordsFilterTest extends TestCase {
         // the first line is a comment with a date of writing
         assertEquals(3, lines.length);
 
-        assertEquals("my_id.GreatestLastModifiedTimestamp=83627834" , lines[1]);
-        assertEquals("Foo\\ LastId.GreatestLastModifiedTimestamp=564739" , lines[2]);
+        assertEquals("my_id.GreatestLastModifiedValue=83627834", lines[1]);
+        assertEquals("Foo\\ LastId.GreatestLastModifiedValue=564739", lines[2]);
     }
 }


### PR DESCRIPTION
Refactored the CaptureChangedRecordsFilter to name the state field as XXX.GreatestLastModifiedValue instead of XXX.GreatestLastModifiedTimestamp. The filter also works with ID fields which contain numbers. 