### PR TITLE
Feature/537 docs improvements

### DIFF
--- a/documentation/src/docbkx/chapter41-configuration-file.xml
+++ b/documentation/src/docbkx/chapter41-configuration-file.xml
@@ -372,9 +372,62 @@
 
 	<section id="configuration_file_reference_data">
 		<title>Reference data</title>
-		<para>Reference data are defined in the configuration file in the
-			element &lt;reference-data-catalog&gt;.</para>
-	</section>
+		<para>Reference data items (dictionaries, synonym catalogs and string patterns) are defined
+		in the configuration file in the element &lt;reference-data-catalog&gt;. Below some examples:</para>
+		
+		<section>
+			<title>Dictionaries</title>
+			<para>Dictionaries are stored within the &lt;dictionaries&gt; element within the reference data section. Three types of dictionaries can be added.</para>
+			
+			<para>
+				<emphasis>Datastore dictionaries</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;dictionaries&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;datastore-dictionary&#160;name="Lastnames"&#160;description="My&#160;datastore&#160;based&#160;dictionary"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;datastore-name&gt;orderdb&lt;/datastore-name&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;column-path&gt;EMPLOYEES.LASTNAME&lt;/column-path&gt;
+				&#160;&#160;&#160;&#160;&lt;/datastore-dictionary&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/dictionaries&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+			<para>
+				<emphasis>Text file dictionaries</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;dictionaries&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;text-file-dictionary&#160;name="Firstnames"&#160;description="My&#160;file&#160;based&#160;dictionary"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;filename&gt;/path/to/first.txt&lt;/filename&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
+				&#160;&#160;&#160;&#160;&lt;/text-file-dictionary&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/dictionaries&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+			<para>
+				<emphasis>Value list dictionaries</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;dictionaries&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;value-list-dictionary&#160;name="Greetings"&#160;description="My&#160;simple&#160;value&#160;list"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;value&gt;hello&lt;/value&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;value&gt;hi&lt;/value&gt;	
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;value&gt;greetings&lt;/value&gt;
+				&#160;&#160;&#160;&#160;&lt;value&gt;godday&lt;/value&gt;
+				&#160;&#160;&#160;&#160;&lt;/value-list-dictionary&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/dictionaries&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+		</section>
+		</section>
 
 	<section id="configuration_file_task_runner">
 		<title>Task runner</title>
@@ -403,11 +456,8 @@
 		<para>The storage provider is used for storing temporary data used
 			while executing an analysis job. There are two types of storage:
 			Large collections of (single) values and
-			"annotated rows", ie. rows
-			that have been marked with a specific
-			category which
-			will be of
-			interest to the user.
+			"annotated rows", ie. rows that have been sampled or marked with
+			a specific category which will be of interest to the user to inspect.
 		</para>
 		<para>To explain the storage provider configuration let's look at the
 			default element:
@@ -419,7 +469,7 @@
 			&#160;&#160;&#160;&lt;berkeley-db/&gt;
 			&#160;&#160;&lt;/collections-storage&gt;
 			&#160;&#160;&lt;row-annotation-storage&gt;
-			&#160;&#160;&#160;&lt;in-memory&#160;max-rows-threshold="1000"/&gt;
+			&#160;&#160;&#160;&lt;in-memory&#160;max-rows-threshold="1000"&#160;max-sets-threshold="200"/&gt;
 			&#160;&#160;&lt;/row-annotation-storage&gt;
 			&#160;&lt;/combined&gt;
 			&lt;/storage-provider&gt; </programlisting>
@@ -432,9 +482,11 @@
 		</para>
 		<para>
 			Row annotations are stored in memory. There's a threshold of
-			1000 rows which means that if more than 1000 records are annotated
+			1000 rows in maximum 200 sets. This means that if more than 1000 records are annotated
 			with the same category then additional records will not be saved (and
-			thus is not viewable by the user). Most user scenarios will not
+			thus is not viewable by the user). Furthermore it means that only up until 200 sample
+			sets will be saved. Further annotations will not be sampled, but metrics still be counted.
+			Most user scenarios will not
 			require more than max. 1000 annotated records for inspection, but if
 			this is really neccessary a different strategy can be pursued:
 		</para>

--- a/documentation/src/docbkx/chapter41-configuration-file.xml
+++ b/documentation/src/docbkx/chapter41-configuration-file.xml
@@ -427,7 +427,77 @@
 				&lt;/reference-data-catalog&gt;
 			</programlisting>
 		</section>
+		<section>
+			<title>Synonym catalogs</title>
+			<para>Synonym catalogs are stored within the &lt;synonym-catalogs&gt; element within the reference data section. Two types of dictionaries can be added.</para>
+			<para>
+				<emphasis>Text file synonym catalogs</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;synonym-catalogs&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;text-file-synonym-catalog name="textfile_syn" description="My text file synonyms"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;filename&gt;/path/to/synonyms.txt&lt;/filename&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;case-sensitive&gt;false&lt;/case-sensitive&gt;
+				&#160;&#160;&#160;&#160;&lt;/text-file-synonym-catalog&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/synonym-catalogs&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+			<para>
+				<emphasis>Datastore synonym catalogs</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;synonym-catalogs&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;datastore-synonym-catalog name="datastore_syn" description="My datastore synonyms"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;datastore-name&gt;orderdb&lt;/datastore-name&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;master-term-column-path&gt;CUSTOMERS.CUSTOMERNAME&lt;/master-term-column-path&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;synonym-column-path&gt;CUSTOMERS.CUSTOMERNUMBER&lt;/synonym-column-path&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;synonym-column-path&gt;CUSTOMERS.PHONE&lt;/synonym-column-path&gt;
+				&#160;&#160;&#160;&#160;&lt;/datastore-synonym-catalog&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/synonym-catalogs&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
 		</section>
+		<section>
+			<title>String patterns</title>
+			<para>Dictionaries are stored within the &lt;string-patterns&gt; element within the reference data section. Two types of string patterns can be added.</para>
+			<para>
+				<emphasis>Regular expression (regex) string patterns</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;string-patterns&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;regex-pattern name="regex danish email" description="Danish email addresses"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;expression&gt;[a-z]+@[a-z]+\.dk&lt;/expression&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;match-entire-string&gt;true&lt;/match-entire-string&gt;
+				&#160;&#160;&#160;&#160;&lt;/regex-pattern&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/string-patterns&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+			<para>
+				<emphasis>Simple string patterns</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;reference-data-catalog&gt;
+				&#160;&#160;&lt;string-patterns&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&#160;&#160;&lt;simple-pattern name="simple email" description="Simple email pattern"&gt;
+				&#160;&#160;&#160;&#160;&#160;&#160;&lt;expression&gt;aaaa@aaaaa.aa&lt;/expression&gt;
+				&#160;&#160;&#160;&#160;&lt;/simple-pattern&gt;
+				&#160;&#160;&#160;...
+				&#160;&#160;&lt;/string-patterns&gt;
+				&lt;/reference-data-catalog&gt;
+			</programlisting>
+		</section>
+	</section>
 
 	<section id="configuration_file_task_runner">
 		<title>Task runner</title>

--- a/documentation/src/docbkx/chapter41-configuration-file.xml
+++ b/documentation/src/docbkx/chapter41-configuration-file.xml
@@ -68,303 +68,306 @@
 			element &lt;datastore-catalog&gt;. The following sections will go
 			into further details with particular types of datastores.
 		</para>
-	</section>
 
-	<section id="configuration_file_datastore_jdbc">
-		<title>Database (JDBC) connections</title>
-
-		<para>Here are a few examples of common database types.</para>
-
-		<tip>
-			<para>The DataCleaner User Interface makes it a lot easier to figure
-				out the
-				url (connection string) and driver class part of the
-				connection
-				properties. It's a good place to start if you don't know
-				these
-				properties already.
+		<section id="configuration_file_datastore_jdbc">
+			<title>Database (JDBC) connections</title>
+	
+			<para>Here are a few examples of common database types.</para>
+	
+			<tip>
+				<para>The DataCleaner User Interface makes it a lot easier to figure
+					out the
+					url (connection string) and driver class part of the
+					connection
+					properties. It's a good place to start if you don't know
+					these
+					properties already.
+				</para>
+			</tip>
+	
+			<para>
+				<emphasis>MySQL</emphasis>
 			</para>
-		</tip>
-
-		<para>
-			<emphasis>MySQL</emphasis>
-		</para>
-		<programlisting lang="xml">
-			&lt;jdbc-datastore&#160;name="MySQL&#160;datastore"&gt;
-			&#160;&lt;url&gt;jdbc:mysql://hostname:3306/database?defaultFetchSize=-2147483648&lt;/url&gt;
-			&#160;&lt;driver&gt;com.mysql.jdbc.Driver&lt;/driver&gt;
-			&#160;&lt;username&gt;username&lt;/username&gt;
-			&#160;&lt;password&gt;password&lt;/password&gt;
-			&lt;/jdbc-datastore&gt; </programlisting>
-
-		<para>
-			<emphasis>Oracle</emphasis>
-		</para>
-		<programlisting lang="xml">
-			&lt;jdbc-datastore&#160;name="Oracle&#160;datastore"&gt;
-			&#160;&lt;url&gt;jdbc:oracle:thin:@hostname:1521:sid&lt;/url&gt;
-			&#160;&lt;driver&gt;oracle.jdbc.OracleDriver&lt;/driver&gt;
-			&#160;&lt;username&gt;username&lt;/username&gt;
-			&#160;&lt;password&gt;password&lt;/password&gt;
-			&lt;/jdbc-datastore&gt; </programlisting>
-
-		<para>
-			<emphasis>Microsoft SQL Server</emphasis>
-		</para>
-		<para>A typical connection to Microsoft SQL server will look like
-			this:
-		</para>
-		<programlisting lang="xml">
-			&lt;jdbc-datastore&#160;name="MS&#160;SQL&#160;Server&#160;datastore"&gt;
-			&#160;&lt;url&gt;jdbc:jtds:sqlserver://hostname/database;useUnicode=true;characterEncoding=UTF-8&lt;/url&gt;
-			&#160;&lt;driver&gt;net.sourceforge.jtds.jdbc.Driver&lt;/driver&gt;
-			&#160;&lt;username&gt;username&lt;/username&gt;
-			&#160;&lt;password&gt;password&lt;/password&gt;
-			&lt;/jdbc-datastore&gt; </programlisting>
-		<para>However, if you want to use an instance name based connection,
-			then the SQL Server Browser service MUST BE RUNNING and then you can
-			include the instance parameter: Here's an example for connecting to a
-			SQLEXPRESS instance:
-		</para>
-		<programlisting lang="xml">
-			&#160;&lt;url&gt;jdbc:jtds:sqlserver://hostname/database;instance=SQLEXPRESS;useUnicode=true;characterEncoding=UTF-8&lt;/url&gt;
-		</programlisting>
-	</section>
-
-	<section id="configuration_file_datastore_csv">
-		<title>Comma-Separated Values (CSV) files</title>
-		<para>This is an example of a CSV file datastore</para>
-		<programlisting>
-			&lt;csv-datastore&#160;name="my_csv_file"&gt;
-			&#160;&lt;filename&gt;/path/to/file.csv&lt;/filename&gt;
-			&#160;&lt;quote-char&gt;"&lt;/quote-char&gt;
-			&#160;&lt;separator-char&gt;;&lt;/separator-char&gt;
-			&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
-			&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
-			&#160;&lt;header-line-number&gt;1&lt;/header-line-number&gt;
-			&lt;/csv-datastore&gt; </programlisting>
-	</section>
-
-	<section id="configuration_file_datastore_fixed_width">
-		<title>Fixed width value files</title>
-		<para>Files with fixed width values can be registered in two ways -
-			either with a single fixed-width size for all columns, or with
-			individual value-widths.
-		</para>
-		<para>Here's an example with a fixed width specification for all
-			columns:
-		</para>
-		<programlisting>
-			&lt;fixed-width-datastore&#160;name="My&#160;file"&gt;
-			&#160;&lt;filename&gt;foobar.txt&lt;/filename&gt;
-			&#160;&lt;width-specification&gt;
-			&#160;&#160;&lt;fixed-value-width&gt;20&lt;/fixed-value-width&gt;
-			&#160;&lt;/width-specification&gt;
-			&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
-			&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
-			&lt;/fixed-width-datastore&gt; </programlisting>
-		<para>Here's an example with individual (3 columns) width
-			specifications:
-		</para>
-		<programlisting>
-			&lt;fixed-width-datastore&#160;name="My&#160;file"&gt;
-			&#160;&lt;filename&gt;foobar.txt&lt;/filename&gt;
-			&#160;&lt;width-specification&gt;
-			&#160;&#160;&lt;value-width&gt;4&lt;/value-width&gt;
-			&#160;&#160;&lt;value-width&gt;17&lt;/value-width&gt;
-			&#160;&#160;&lt;value-width&gt;19&lt;/value-width&gt;
-			&#160;&lt;/width-specification&gt;
-			&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
-			&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
-			&lt;/fixed-width-datastore&gt; </programlisting>
-	</section>
-
-	<section id="configuration_file_datastore_excel">
-		<title>Excel spreadsheets</title>
-		<para>This is an example of an Excel spreadsheet datastore</para>
-		<programlisting>
-			&lt;excel-datastore&#160;name="my_excel_spreadsheet"&gt;
-			&#160;&lt;filename&gt;/path/to/file.xls&lt;/filename&gt;
-			&lt;/excel-datastore&gt; </programlisting>
-	</section>
-
-	<section id="configuration_file_datastore_xml">
-		<title>XML file datastores</title>
-		<para>Defining XML datastores can be done in both a simple
-			(automatically mapped) way, or an advanced (and more performant and
-			memory effective way).
-		</para>
-		<para>The simple way is just to define a xml-datastore with a
-			filename, like this:
-		</para>
-		<programlisting>
-			&lt;xml-datastore&#160;name="my_xml_datastore"&gt;
-			&#160;&lt;filename&gt;/path/to/file.xml&lt;/filename&gt;
-			&lt;/xml-datastore&gt; </programlisting>
-		<para>This kind of XML datastore works find when the file size is
-			small and the hierarchy is not too complex. The downside to it is
-			that it tries to automatically detect a table structure that is
-			fitting to represent the XML contents (which is a tree structure, not
-			really a table).
-		</para>
-		<para>To get around this problem you can also define your own table
-			structure in which you specify the XPaths that make up your rows and
-			the values within your rows. Here's an example:
-		</para>
-		<programlisting>
-			&lt;xml-datastore&#160;name="my_xml_datastore"&gt;
-			&#160;&lt;filename&gt;/path/to/file.xml&lt;/filename&gt;
-			&#160;&lt;table-def&gt;
-			&#160;&#160;&#160;&lt;rowXpath&gt;/greetings/greeting&lt;/rowXpath&gt;
-			&#160;&#160;&#160;&lt;valueXpath&gt;/greetings/greeting/how&lt;/valueXpath&gt;
-			&#160;&#160;&#160;&lt;valueXpath&gt;/greetings/greeting/what&lt;/valueXpath&gt;
-			&#160;&lt;/table-def&gt;
-			&lt;/xml-datastore&gt; </programlisting>
-		<para>The datastore defines a single table, where each record is
-			defined as the element which matches the XPath "/greetings/greeting".
-			The table has two columns, which are represented by the "how" and
-			"what" elements that are child elements to the row's path.
-		</para>
-		<para>
-			For more details on the XPath expressions that define the table model
-			of XML datastores, please refer to
-			<link xl:href="http://metamodel.eobjects.org/example_xml_mapping.html">MetaModel's tutorial on the topic</link>
-			(MetaModel is the data access library used to read data in
-			DataCleaner).
-		</para>
-	</section>
-
-	<section id="configuration_file_datastore_elasticsearch">
-		<title>ElasticSearch index</title>
-		<para>This is an example of an ElasticSearch index datastore</para>
-		<programlisting>
-			&lt;elasticsearch-datastore&#160;name="my_elastic_search_index"&gt;
-			&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
-			&#160;&lt;port&gt;9300&lt;/port&gt;
-			&#160;&lt;cluster-name&gt;my_es_cluster&lt;/cluster-name&gt;
-			&#160;&lt;index-name&gt;my_index&lt;/index-name&gt;
-			&lt;/elasticsearch-datastore&gt; </programlisting>
-	</section>
-
-	<section id="configuration_file_datastore_mongodb">
-		<title>MongoDB databases</title>
-		<para>This is an example of a fully specified MongoDB datastore, with
-			an example table structure based on two collections.
-		</para>
-		<programlisting>
-			&lt;mongodb-datastore&#160;name="my_mongodb_datastore"&gt;
-			&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
-			&#160;&lt;port&gt;27017&lt;/port&gt;
-			&#160;&lt;database-name&gt;my_database&lt;/database-name&gt;
-			&#160;&lt;username&gt;user&lt;/username&gt;
-			&#160;&lt;password&gt;pass&lt;/password&gt;
-			&#160;&lt;table-def&gt;
-			&#160;&#160;&#160;&lt;collection&gt;company_collection&lt;/collection&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;company_name&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;customer&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;BOOLEAN&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;num_employees&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;INTEGER&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;address_details&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;MAP&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&lt;/table-def&gt;
-			&#160;&lt;table-def&gt;
-			&#160;&#160;&#160;&lt;collection&gt;person_collection&lt;/collection&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;person_name&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;birthdate&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;DATE&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&#160;&#160;&lt;property&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;emails&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;LIST&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/property&gt;
-			&#160;&lt;/table-def&gt;
-			&lt;/mongodb-datastore&gt; </programlisting>
-		<para>If the hostname and port elements are left out, localhost:27017
-			will be assumed.
-		</para>
-		<para>If the username and password elements are left out, an anonymous
-			connection will be made.
-		</para>
-		<para>If there are no table-def elements, the database will be
-			inspected and table definitions will be auto-detected based on the
-			first 1000 documents of each collection.
-		</para>
-	</section>
-
-	<section id="configuration_file_datastore_couchdb">
-		<title>CouchDB databases</title>
-		<para>This is an example of a fully specified CouchDB datastore, with
-			an example table structure based on two CouchDB databases.
-		</para>
-		<programlisting>
-			&lt;couchdb-datastore&#160;name="my_couchdb_datastore"&gt;
-			&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
-			&#160;&lt;port&gt;5984&lt;/port&gt;
-			&#160;&lt;username&gt;user&lt;/username&gt;
-			&#160;&lt;password&gt;pass&lt;/password&gt;
-			&#160;&lt;ssl&gt;true&lt;/ssl&gt;
-			&#160;&lt;table-def&gt;
-			&#160;&#160;&#160;&lt;database&gt;company_collection&lt;/database&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;company_name&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;customer&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;BOOLEAN&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;num_employees&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;INTEGER&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;address_details&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;MAP&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&lt;/table-def&gt;
-			&#160;&lt;table-def&gt;
-			&#160;&#160;&#160;&lt;database&gt;person_collection&lt;/database&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;person_name&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;birthdate&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;DATE&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&#160;&#160;&lt;field&gt;
-			&#160;&#160;&#160;&#160;&lt;name&gt;emails&lt;/name&gt;
-			&#160;&#160;&#160;&#160;&lt;type&gt;LIST&lt;/type&gt;
-			&#160;&#160;&#160;&lt;/field&gt;
-			&#160;&lt;/table-def&gt;
-			&lt;/couchdb-datastore&gt; </programlisting>
-		<para>If the hostname and port elements are left out, localhost:5984
-			will be assumed.
-		</para>
-		<para>If the username and password elements are left out, an anonymous
-			connection will be made.
-		</para>
-		<para>If the "ssl" element is false or left out, a regular HTTP
-			connection will be used.
-		</para>
-		<para>If there are no table-def elements, the database will be
-			inspected and table definitions will be auto-detected based on the
-			first 1000 documents of each database.
-		</para>
+			<programlisting lang="xml">
+				&lt;jdbc-datastore&#160;name="MySQL&#160;datastore"&gt;
+				&#160;&lt;url&gt;jdbc:mysql://hostname:3306/database?defaultFetchSize=-2147483648&lt;/url&gt;
+				&#160;&lt;driver&gt;com.mysql.jdbc.Driver&lt;/driver&gt;
+				&#160;&lt;username&gt;username&lt;/username&gt;
+				&#160;&lt;password&gt;password&lt;/password&gt;
+				&#160;&lt;multiple-connections&gt;true&lt;/multiple-connections&gt;
+				&lt;/jdbc-datastore&gt; </programlisting>
+	
+			<para>
+				<emphasis>Oracle</emphasis>
+			</para>
+			<programlisting lang="xml">
+				&lt;jdbc-datastore&#160;name="Oracle&#160;datastore"&gt;
+				&#160;&lt;url&gt;jdbc:oracle:thin:@hostname:1521:sid&lt;/url&gt;
+				&#160;&lt;driver&gt;oracle.jdbc.OracleDriver&lt;/driver&gt;
+				&#160;&lt;username&gt;username&lt;/username&gt;
+				&#160;&lt;password&gt;password&lt;/password&gt;
+				&#160;&lt;multiple-connections&gt;true&lt;/multiple-connections&gt;
+				&lt;/jdbc-datastore&gt; </programlisting>
+	
+			<para>
+				<emphasis>Microsoft SQL Server</emphasis>
+			</para>
+			<para>A typical connection to Microsoft SQL server will look like
+				this:
+			</para>
+			<programlisting lang="xml">
+				&lt;jdbc-datastore&#160;name="MS&#160;SQL&#160;Server&#160;datastore"&gt;
+				&#160;&lt;url&gt;jdbc:jtds:sqlserver://hostname/database;useUnicode=true;characterEncoding=UTF-8&lt;/url&gt;
+				&#160;&lt;driver&gt;net.sourceforge.jtds.jdbc.Driver&lt;/driver&gt;
+				&#160;&lt;username&gt;username&lt;/username&gt;
+				&#160;&lt;password&gt;password&lt;/password&gt;
+				&#160;&lt;multiple-connections&gt;true&lt;/multiple-connections&gt;
+				&lt;/jdbc-datastore&gt; </programlisting>
+			<para>However, if you want to use an instance name based connection,
+				then the SQL Server Browser service MUST BE RUNNING and then you can
+				include the instance parameter: Here's an example for connecting to a
+				SQLEXPRESS instance:
+			</para>
+			<programlisting lang="xml">
+				&#160;&lt;url&gt;jdbc:jtds:sqlserver://hostname/database;instance=SQLEXPRESS;useUnicode=true;characterEncoding=UTF-8&lt;/url&gt;
+			</programlisting>
+		</section>
+	
+		<section id="configuration_file_datastore_csv">
+			<title>Comma-Separated Values (CSV) files</title>
+			<para>This is an example of a CSV file datastore</para>
+			<programlisting>
+				&lt;csv-datastore&#160;name="my_csv_file"&gt;
+				&#160;&lt;filename&gt;/path/to/file.csv&lt;/filename&gt;
+				&#160;&lt;quote-char&gt;"&lt;/quote-char&gt;
+				&#160;&lt;separator-char&gt;;&lt;/separator-char&gt;
+				&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
+				&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
+				&#160;&lt;header-line-number&gt;1&lt;/header-line-number&gt;
+				&lt;/csv-datastore&gt; </programlisting>
+		</section>
+	
+		<section id="configuration_file_datastore_fixed_width">
+			<title>Fixed width value files</title>
+			<para>Files with fixed width values can be registered in two ways -
+				either with a single fixed-width size for all columns, or with
+				individual value-widths.
+			</para>
+			<para>Here's an example with a fixed width specification for all
+				columns:
+			</para>
+			<programlisting>
+				&lt;fixed-width-datastore&#160;name="My&#160;file"&gt;
+				&#160;&lt;filename&gt;foobar.txt&lt;/filename&gt;
+				&#160;&lt;width-specification&gt;
+				&#160;&#160;&lt;fixed-value-width&gt;20&lt;/fixed-value-width&gt;
+				&#160;&lt;/width-specification&gt;
+				&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
+				&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
+				&lt;/fixed-width-datastore&gt; </programlisting>
+			<para>Here's an example with individual (3 columns) width
+				specifications:
+			</para>
+			<programlisting>
+				&lt;fixed-width-datastore&#160;name="My&#160;file"&gt;
+				&#160;&lt;filename&gt;foobar.txt&lt;/filename&gt;
+				&#160;&lt;width-specification&gt;
+				&#160;&#160;&lt;value-width&gt;4&lt;/value-width&gt;
+				&#160;&#160;&lt;value-width&gt;17&lt;/value-width&gt;
+				&#160;&#160;&lt;value-width&gt;19&lt;/value-width&gt;
+				&#160;&lt;/width-specification&gt;
+				&#160;&lt;encoding&gt;UTF-8&lt;/encoding&gt;
+				&#160;&lt;fail-on-inconsistencies&gt;true&lt;/fail-on-inconsistencies&gt;
+				&lt;/fixed-width-datastore&gt; </programlisting>
+		</section>
+	
+		<section id="configuration_file_datastore_excel">
+			<title>Excel spreadsheets</title>
+			<para>This is an example of an Excel spreadsheet datastore</para>
+			<programlisting>
+				&lt;excel-datastore&#160;name="my_excel_spreadsheet"&gt;
+				&#160;&lt;filename&gt;/path/to/file.xls&lt;/filename&gt;
+				&lt;/excel-datastore&gt; </programlisting>
+		</section>
+	
+		<section id="configuration_file_datastore_xml">
+			<title>XML file datastores</title>
+			<para>Defining XML datastores can be done in both a simple
+				(automatically mapped) way, or an advanced (and more performant and
+				memory effective way).
+			</para>
+			<para>The simple way is just to define a xml-datastore with a
+				filename, like this:
+			</para>
+			<programlisting>
+				&lt;xml-datastore&#160;name="my_xml_datastore"&gt;
+				&#160;&lt;filename&gt;/path/to/file.xml&lt;/filename&gt;
+				&lt;/xml-datastore&gt; </programlisting>
+			<para>This kind of XML datastore works find when the file size is
+				small and the hierarchy is not too complex. The downside to it is
+				that it tries to automatically detect a table structure that is
+				fitting to represent the XML contents (which is a tree structure, not
+				really a table).
+			</para>
+			<para>To get around this problem you can also define your own table
+				structure in which you specify the XPaths that make up your rows and
+				the values within your rows. Here's an example:
+			</para>
+			<programlisting>
+				&lt;xml-datastore&#160;name="my_xml_datastore"&gt;
+				&#160;&lt;filename&gt;/path/to/file.xml&lt;/filename&gt;
+				&#160;&lt;table-def&gt;
+				&#160;&#160;&#160;&lt;rowXpath&gt;/greetings/greeting&lt;/rowXpath&gt;
+				&#160;&#160;&#160;&lt;valueXpath&gt;/greetings/greeting/how&lt;/valueXpath&gt;
+				&#160;&#160;&#160;&lt;valueXpath&gt;/greetings/greeting/what&lt;/valueXpath&gt;
+				&#160;&lt;/table-def&gt;
+				&lt;/xml-datastore&gt; </programlisting>
+			<para>The datastore defines a single table, where each record is
+				defined as the element which matches the XPath "/greetings/greeting".
+				The table has two columns, which are represented by the "how" and
+				"what" elements that are child elements to the row's path.
+			</para>
+			<para>
+				For more details on the XPath expressions that define the table model
+				of XML datastores, please refer to
+				<link xl:href="http://metamodel.eobjects.org/example_xml_mapping.html">MetaModel's tutorial on the topic</link>
+				(MetaModel is the data access library used to read data in
+				DataCleaner).
+			</para>
+		</section>
+	
+		<section id="configuration_file_datastore_elasticsearch">
+			<title>ElasticSearch index</title>
+			<para>This is an example of an ElasticSearch index datastore</para>
+			<programlisting>
+				&lt;elasticsearch-datastore&#160;name="my_elastic_search_index"&gt;
+				&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
+				&#160;&lt;port&gt;9300&lt;/port&gt;
+				&#160;&lt;cluster-name&gt;my_es_cluster&lt;/cluster-name&gt;
+				&#160;&lt;index-name&gt;my_index&lt;/index-name&gt;
+				&lt;/elasticsearch-datastore&gt; </programlisting>
+		</section>
+	
+		<section id="configuration_file_datastore_mongodb">
+			<title>MongoDB databases</title>
+			<para>This is an example of a fully specified MongoDB datastore, with
+				an example table structure based on two collections.
+			</para>
+			<programlisting>
+				&lt;mongodb-datastore&#160;name="my_mongodb_datastore"&gt;
+				&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
+				&#160;&lt;port&gt;27017&lt;/port&gt;
+				&#160;&lt;database-name&gt;my_database&lt;/database-name&gt;
+				&#160;&lt;username&gt;user&lt;/username&gt;
+				&#160;&lt;password&gt;pass&lt;/password&gt;
+				&#160;&lt;table-def&gt;
+				&#160;&#160;&#160;&lt;collection&gt;company_collection&lt;/collection&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;company_name&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;customer&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;BOOLEAN&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;num_employees&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;INTEGER&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;address_details&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;MAP&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&lt;/table-def&gt;
+				&#160;&lt;table-def&gt;
+				&#160;&#160;&#160;&lt;collection&gt;person_collection&lt;/collection&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;person_name&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;birthdate&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;DATE&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&#160;&#160;&lt;property&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;emails&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;LIST&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/property&gt;
+				&#160;&lt;/table-def&gt;
+				&lt;/mongodb-datastore&gt; </programlisting>
+			<para>If the hostname and port elements are left out, localhost:27017
+				will be assumed.
+			</para>
+			<para>If the username and password elements are left out, an anonymous
+				connection will be made.
+			</para>
+			<para>If there are no table-def elements, the database will be
+				inspected and table definitions will be auto-detected based on the
+				first 1000 documents of each collection.
+			</para>
+		</section>
+	
+		<section id="configuration_file_datastore_couchdb">
+			<title>CouchDB databases</title>
+			<para>This is an example of a fully specified CouchDB datastore, with
+				an example table structure based on two CouchDB databases.
+			</para>
+			<programlisting>
+				&lt;couchdb-datastore&#160;name="my_couchdb_datastore"&gt;
+				&#160;&lt;hostname&gt;localhost&lt;/hostname&gt;
+				&#160;&lt;port&gt;5984&lt;/port&gt;
+				&#160;&lt;username&gt;user&lt;/username&gt;
+				&#160;&lt;password&gt;pass&lt;/password&gt;
+				&#160;&lt;ssl&gt;true&lt;/ssl&gt;
+				&#160;&lt;table-def&gt;
+				&#160;&#160;&#160;&lt;database&gt;company_collection&lt;/database&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;company_name&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;customer&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;BOOLEAN&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;num_employees&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;INTEGER&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;address_details&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;MAP&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&lt;/table-def&gt;
+				&#160;&lt;table-def&gt;
+				&#160;&#160;&#160;&lt;database&gt;person_collection&lt;/database&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;person_name&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;VARCHAR&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;birthdate&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;DATE&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&#160;&#160;&lt;field&gt;
+				&#160;&#160;&#160;&#160;&lt;name&gt;emails&lt;/name&gt;
+				&#160;&#160;&#160;&#160;&lt;type&gt;LIST&lt;/type&gt;
+				&#160;&#160;&#160;&lt;/field&gt;
+				&#160;&lt;/table-def&gt;
+				&lt;/couchdb-datastore&gt; </programlisting>
+			<para>If the hostname and port elements are left out, localhost:5984
+				will be assumed.
+			</para>
+			<para>If the username and password elements are left out, an anonymous
+				connection will be made.
+			</para>
+			<para>If the "ssl" element is false or left out, a regular HTTP
+				connection will be used.
+			</para>
+			<para>If there are no table-def elements, the database will be
+				inspected and table definitions will be auto-detected based on the
+				first 1000 documents of each database.
+			</para>
+		</section>
 	</section>
 
 	<section id="configuration_file_reference_data">

--- a/documentation/src/docbkx/resources/style.css
+++ b/documentation/src/docbkx/resources/style.css
@@ -159,9 +159,12 @@ body>div {
 	text-decoration: underline !important;
 }
 
+.chapter .toc dd dl dd dl dt .section, .part .toc dd dl dd dl dt .section {
+	padding: 7px 20px 7px 60px;
+}
+
 .chapter .toc dd .section, .book .toc dd dd dd .section {
-	display: none;
-	visibility: hidden;
+	padding: 7px 20px 7px 60px;
 }
 
 .toc .section a {


### PR DESCRIPTION
Fixes #537 and adds a few other minor documentation improvements as well.

Regarding the datastores (many red and green lines in the diff viewer) - no content has changed, except the addition of the <multiple-connections> tags. The diffs are there because of an indentation change (moved JDBC datastore, Excel datastore etc. to a subsection of "Datastores").