### PR TITLE
Connection prefix jdbc:hive: seems wrong. Driver expects jdbc:hive2:

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/database/HiveDatabaseConnectionPresenter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/database/HiveDatabaseConnectionPresenter.java
@@ -22,7 +22,7 @@ package org.datacleaner.widgets.database;
 public class HiveDatabaseConnectionPresenter extends UrlTemplateDatabaseConnectionPresenter {
 
     public HiveDatabaseConnectionPresenter() {
-        super("jdbc:hive://HOSTNAME:PORT/DATABASE");
+        super("jdbc:hive2://HOSTNAME:PORT/DATABASE");
     }
 
     @Override
@@ -34,7 +34,7 @@ public class HiveDatabaseConnectionPresenter extends UrlTemplateDatabaseConnecti
     @Override
     protected String getJdbcUrl(String hostname, int port, String database, String param1, String param2,
             String param3, String param4) {
-        return "jdbc:hive://" + hostname + ":" + port + "/" + database;
+        return "jdbc:hive2://" + hostname + ":" + port + "/" + database;
     }
 
 }

--- a/engine/core/src/main/java/org/datacleaner/database/DatabaseDriverCatalog.java
+++ b/engine/core/src/main/java/org/datacleaner/database/DatabaseDriverCatalog.java
@@ -142,7 +142,7 @@ public class DatabaseDriverCatalog implements Serializable {
                 "sun.jdbc.odbc.JdbcOdbcDriver", null, "jdbc:odbc:<data-source-name>");
         add(DATABASE_NAME_HIVE, "images/datastore-types/databases/hive.png", "org.apache.hive.jdbc.HiveDriver",
                 "http://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/1.2.1/hive-jdbc-1.2.1.jar",
-                "jdbc:hive://<hostname>:10000/<database>");
+                "jdbc:hive2://<hostname>:10000/<database>");
 
         Collections.sort(_databaseDrivers);
     }


### PR DESCRIPTION
Hive support currently does not work, as the connection string prefix is not accepted by the driver, which expects "jdbc:hive2:". We provide "jdbc:hive:" as the prefix.