### PR TITLE
Avoid creating a derby.log file

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/database/DatabaseDriverCatalog.java
+++ b/engine/core/src/main/java/org/datacleaner/database/DatabaseDriverCatalog.java
@@ -27,9 +27,9 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.datacleaner.user.UserPreferences;
 import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.Predicate;
+import org.datacleaner.user.UserPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,7 +140,7 @@ public class DatabaseDriverCatalog implements Serializable {
                 "org.pentaho.di.jdbc.KettleDriver", null, "jdbc:kettle:file://<filename>");
         add(DATABASE_NAME_JDBC_ODBC_BRIDGE, "images/datastore-types/databases/odbc.png",
                 "sun.jdbc.odbc.JdbcOdbcDriver", null, "jdbc:odbc:<data-source-name>");
-        add(DATABASE_NAME_HIVE, "images/datastore-types/databases/hive.png", "org.apache.hive.jdbc.HiveDriver",
+        add(DATABASE_NAME_HIVE, "images/datastore-types/databases/hive.png", new HiveDriverPreparer(), "org.apache.hive.jdbc.HiveDriver",
                 "http://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/1.2.1/hive-jdbc-1.2.1.jar",
                 "jdbc:hive://<hostname>:10000/<database>");
 
@@ -185,8 +185,19 @@ public class DatabaseDriverCatalog implements Serializable {
         } else {
             urls = new String[] { downloadUrl };
         }
-        _databaseDrivers.add(new DatabaseDescriptorImpl(databaseName, iconImagePath, driverClassName, urls,
-                urlTemplates));
+        add(databaseName, iconImagePath, driverClassName, urls, urlTemplates);
+    }
+
+    private static void add(String databaseName, String iconImagePath, DriverPreparer driverPreparer,
+            String driverClassName, String downloadUrl, String... urlTemplates) {
+        if (driverPreparer != null) {
+            try {
+                driverPreparer.prepare();
+            } catch (Exception e) {
+                logger.warn("Could not run driver preparation", e);
+            }
+        }
+        add(databaseName, iconImagePath, driverClassName, downloadUrl, urlTemplates);
     }
 
     public DatabaseDriverState getState(DatabaseDriverDescriptor databaseDescriptor) {

--- a/engine/core/src/main/java/org/datacleaner/database/DriverPreparer.java
+++ b/engine/core/src/main/java/org/datacleaner/database/DriverPreparer.java
@@ -1,0 +1,27 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.database;
+
+/**
+ * Simple interface to allow preparing for the driver (i.e. set properties) before loading it.
+ */
+public interface DriverPreparer {
+    void prepare();
+}

--- a/engine/core/src/main/java/org/datacleaner/database/HiveDriverPreparer.java
+++ b/engine/core/src/main/java/org/datacleaner/database/HiveDriverPreparer.java
@@ -1,0 +1,33 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.database;
+
+import java.io.OutputStream;
+
+public class HiveDriverPreparer implements DriverPreparer {
+    public static final OutputStream DEV_NULL = new OutputStream() {
+        public void write(int b) {}
+    };
+
+    @Override
+    public void prepare() {
+        System.setProperty("derby.stream.error.field", "org.datacleaner.database.HiveDriverPreparer.DEV_NULL");
+    }
+}


### PR DESCRIPTION
This forces Derby to use a dummy OutputStream instead of dumping logs to a file.

Fixes #528