### PR TITLE
Initialize consumers in output datastream as part of parent consumer

### DIFF
--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -115,8 +115,6 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     private final AtomicInteger _rowCount;
     private OutputRowCollector _completeRowCollector;
     private OutputRowCollector _incompleteRowCollector;
-    private SimpleDataSetHeader _simpleDataSetHeader;
-
     public CompletenessAnalyzer() {
         _rowCount = new AtomicInteger();
     }
@@ -141,7 +139,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
             if (_evaluationMode == EvaluationMode.ANY_FIELD && !valid) {
                 _annotationFactory.annotate(row, distinctCount, _invalidRecords);
                 if(_incompleteRowCollector != null) {
-                    _incompleteRowCollector.putRow(new DefaultRow(_simpleDataSetHeader, row.getValues(_valueColumns).toArray()));
+                    _incompleteRowCollector.putValues(row.getValues(_valueColumns).toArray());
                 }
                 return;
             }
@@ -153,13 +151,13 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
         if (_evaluationMode == EvaluationMode.ALL_FIELDS && allInvalid) {
             _annotationFactory.annotate(row, distinctCount, _invalidRecords);
             if(_incompleteRowCollector != null) {
-                _incompleteRowCollector.putRow(new DefaultRow(_simpleDataSetHeader, row.getValues(_valueColumns).toArray()));
+                _incompleteRowCollector.putValues(row.getValues(_valueColumns).toArray());
             }
             return;
         }
 
         if(_completeRowCollector != null) {
-            _completeRowCollector.putRow(new DefaultRow(_simpleDataSetHeader, row.getValues(_valueColumns).toArray()));
+            _completeRowCollector.putValues(row.getValues(_valueColumns).toArray());
         }
     }
 
@@ -212,7 +210,6 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     @Override
     public void initializeOutputDataStream(final OutputDataStream outputDataStream, final Query query,
             final OutputRowCollector outputRowCollector) {
-        _simpleDataSetHeader = new SimpleDataSetHeader(query.getSelectClause().getItems());
         if(outputDataStream.getName().equals(OUTPUT_STREAM_COMPLETE)){
             _completeRowCollector = outputRowCollector;
         } else {

--- a/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublishers.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublishers.java
@@ -35,7 +35,6 @@ import org.datacleaner.api.Filter;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.api.Transformer;
-import org.datacleaner.connection.Datastore;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.AnalyzerJob;
 import org.datacleaner.job.ComponentJob;
@@ -53,7 +52,6 @@ import org.datacleaner.util.SourceColumnFinder;
  * {@link RowProcessingPublisher}s.
  */
 public final class RowProcessingPublishers {
-
     private final AnalysisJob _analysisJob;
     private final AnalysisListener _analysisListener;
     private final TaskRunner _taskRunner;
@@ -261,26 +259,11 @@ public final class RowProcessingPublishers {
         return _sourceColumnFinder;
     }
 
-    @Deprecated
-    protected AnalysisJob getAnalysisJob() {
-        return _analysisJob;
-    }
-
     protected AnalysisListener getAnalysisListener() {
         return _analysisListener;
     }
 
     protected LifeCycleHelper getLifeCycleHelper() {
         return _lifeCycleHelper;
-    }
-
-    /**
-     * 
-     * @return
-     * @deprecated use {@link RowProcessingPublisher#getDatastore()} instead
-     */
-    @Deprecated
-    public Datastore getDatastore() {
-        return _analysisJob.getDatastore();
     }
 }

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -29,9 +29,14 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
+import org.apache.metamodel.util.Resource;
 import org.apache.metamodel.util.ToStringComparator;
+import org.apache.metamodel.util.UrlResource;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.OutputDataStream;
+import org.datacleaner.beans.CompletenessAnalyzer;
+import org.datacleaner.beans.CompletenessAnalyzerResult;
 import org.datacleaner.beans.StringAnalyzerResult;
 import org.datacleaner.beans.dategap.DateGapAnalyzerResult;
 import org.datacleaner.beans.dategap.DateGapTextRenderer;
@@ -40,6 +45,7 @@ import org.datacleaner.beans.valuedist.ValueDistributionAnalyzerResult;
 import org.datacleaner.components.convert.ConvertToDateTransformer;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
+import org.datacleaner.configuration.DataCleanerEnvironment;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.configuration.SourceColumnMapping;
 import org.datacleaner.connection.CsvDatastore;
@@ -54,11 +60,14 @@ import org.datacleaner.descriptors.DescriptorProvider;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.job.builder.TransformerComponentBuilder;
+import org.datacleaner.job.concurrent.MultiThreadedTaskRunner;
 import org.datacleaner.job.runner.AnalysisResultFuture;
 import org.datacleaner.job.runner.AnalysisRunner;
 import org.datacleaner.job.runner.AnalysisRunnerImpl;
 import org.datacleaner.result.CrosstabResult;
+import org.datacleaner.result.ListResult;
 import org.datacleaner.result.renderer.CrosstabTextRenderer;
+import org.datacleaner.test.MockAnalyzer;
 import org.datacleaner.test.TestHelper;
 
 public class JaxbJobReaderTest extends TestCase {
@@ -367,7 +376,7 @@ public class JaxbJobReaderTest extends TestCase {
         assertEquals(0, jobBuilder.getTransformerComponentBuilders().size());
     }
     
-    public void testReadOutputDataStreams() throws Throwable {
+    public void testReadAndExecuteOutputDataStreams() throws Throwable {
         JobReader<InputStream> reader = new JaxbJobReader(conf);
         AnalysisJob job = reader.read(new FileInputStream(
                 new File("src/test/resources/example-job-output-dataset.analysis.xml")));
@@ -403,5 +412,40 @@ public class JaxbJobReaderTest extends TestCase {
         assertEquals("Number analyzer", incompleteNumberAnalyzer.getDescriptor().getDisplayName());
         assertEquals(1, incompleteNumberAnalyzer.getInput().length);
         assertEquals("REPORTSTO", incompleteNumberAnalyzer.getInput()[0].getName());
+
+        final MultiThreadedTaskRunner taskRunner = new MultiThreadedTaskRunner(16);
+        final DataCleanerEnvironment environment = new DataCleanerEnvironmentImpl()
+                .withTaskRunner(taskRunner);
+        final Datastore datastore = TestHelper.createSampleDatabaseDatastore("testoutputdatastream");
+        final DataCleanerConfiguration configuration = new DataCleanerConfigurationImpl().withDatastores(datastore)
+                .withEnvironment(environment);
+
+        final OutputDataStreamJob[] outputDataStreamJobs = analyzerJob.getOutputDataStreamJobs();
+        final AnalyzerJob analyzerJob2 = outputDataStreamJobs[0].getJob().getAnalyzerJobs().get(0);
+        final AnalyzerJob analyzerJob3 = outputDataStreamJobs[1].getJob().getAnalyzerJobs().get(0);
+
+        // now run the job(s)
+        final AnalysisRunnerImpl runner = new AnalysisRunnerImpl(configuration);
+        final AnalysisResultFuture resultFuture = runner.run(job);
+        resultFuture.await();
+
+        if (resultFuture.isErrornous()) {
+            throw resultFuture.getErrors().get(0);
+        }
+
+        assertEquals(5, resultFuture.getResults().size());
+
+        final CompletenessAnalyzerResult result1 = (CompletenessAnalyzerResult) resultFuture.getResult(analyzerJob);
+        assertNotNull(result1);
+        assertEquals(23, result1.getValidRowCount());
+        assertEquals(0, result1.getInvalidRowCount());
+        final StringAnalyzerResult result2 = (StringAnalyzerResult) resultFuture.getResult(analyzerJob2);
+        assertNotNull(result2);
+        assertEquals(23, result2.getRowCount(result2.getColumns()[0]));
+        assertEquals(0, result2.getNullCount(result2.getColumns()[0]));
+
+        final StringAnalyzerResult result3 = (StringAnalyzerResult) resultFuture.getResult(analyzerJob3);
+        assertNotNull(result3);
+        assertEquals(0, result3.getRowCount(result3.getColumns()[0]));
     }
 }


### PR DESCRIPTION
This should avoid races between initializers and row processing.

This also extends testing of the reader to ensure that a built job is also runnable. This tests more than the reader, so it might not be the optimal place, but I'm not really sure where it would be, as it is more of an "internal" integration test, testing that the parts assembling and running a job work properly together.

I'll also be lazy and put a small fix of CompletenessAnalyzer on here: There was absolutely no need to create a dataset header, and it actually introduced a bug.

Fixes #563 