### PR TITLE
Using mapPartitions() instead of flatMap() to create ConsumeRowHandler

### DIFF
--- a/spark/src/main/java/org/datacleaner/spark/SparkJobLauncher.java
+++ b/spark/src/main/java/org/datacleaner/spark/SparkJobLauncher.java
@@ -85,7 +85,7 @@ public class SparkJobLauncher implements Serializable {
                     
                     JavaRDD<String> inputRDD = sc.textFile(datastoreFilePath);
                     JavaRDD<InputRow> inputRowRDD = inputRDD.map(new CsvInputRowMapper(sparkDataCleanerContext));
-                    JavaRDD<InputRow> transformationRDD = inputRowRDD.flatMap(new TransformationAction(sparkDataCleanerContext));
+                    JavaRDD<InputRow> transformationRDD = inputRowRDD.mapPartitions(new TransformationAction(sparkDataCleanerContext));
                     List<InputRow> transformedRows = transformationRDD.collect();
                     logger.info("Transformed rows (limit 10): ");
                     int counter = 0;


### PR DESCRIPTION
once per worker and operate on the iterator of rows instead of a single
row at a time.

@kaspersorensen RDD.mapPartitions() is essentially the same as RDD.glom().flatMap(), but it is a preferrable way in some cases.