### PR TITLE
Possibility to get the top-level builder and all available builders

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeButton.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeButton.java
@@ -1,0 +1,123 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.widgets.visualization;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+
+import org.datacleaner.job.ComponentRequirement;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.ImageManager;
+import org.datacleaner.util.LabelUtils;
+import org.datacleaner.util.WidgetUtils;
+import org.datacleaner.widgets.ChangeRequirementMenuBuilder;
+import org.datacleaner.windows.AbstractDialog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A button that displays the {@link AnalysisJobBuilder} of a particular
+ * component that is being built.
+ */
+public class ComponentScopeButton extends JButton implements ActionListener {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger logger = LoggerFactory.getLogger(ComponentScopeButton.class);
+    private static final ImageManager imageManager = ImageManager.get();
+    private static final Icon scopeIcon = imageManager.getImageIcon(IconUtils.OUTPUT_DATA_STREAM_PATH,
+            IconUtils.ICON_SIZE_MEDIUM);
+
+    private final ComponentBuilder _componentBuilder;
+    private final AnalysisJobBuilder _topLevelJobBuilder;
+    private final ComponentScopeMenuBuilder _menuBuilder;
+
+    public ComponentScopeButton(final ComponentBuilder componentBuilder,
+            final ComponentScopeMenuBuilder menuBuilder) {
+        super(ChangeRequirementMenuBuilder.NO_REQUIREMENT_TEXT, scopeIcon);
+        _componentBuilder = componentBuilder;
+        _menuBuilder = menuBuilder;
+        _topLevelJobBuilder = componentBuilder.getAnalysisJobBuilder().getTopLevelJobBuilder();
+        addActionListener(this);
+        updateText();
+        WidgetUtils.setDefaultButtonStyle(this);
+    }
+
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        final JPopupMenu popup = new JPopupMenu();
+
+        final List<JMenuItem> menuItems = _menuBuilder.createMenuItems();
+        for (JMenuItem menuItem : menuItems) {
+            popup.add(menuItem);
+        }
+
+        popup.show(this, 0, getHeight());
+    }
+
+    public void updateText() {
+        logger.debug("updateText()");
+
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                final AnalysisJobBuilder analysisJobBuilder = _componentBuilder.getAnalysisJobBuilder();
+                if (analysisJobBuilder == _topLevelJobBuilder) {
+                    setText(ComponentScopeMenuBuilder.DEFAULT_SCOPE_TEXT);
+                } else {
+                    setText(analysisJobBuilder.getDatastore().getName());
+                }
+            }
+        };
+        try {
+            if (SwingUtilities.isEventDispatchThread()) {
+                runnable.run();
+            } else {
+                SwingUtilities.invokeAndWait(runnable);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to update ComponentScopeButton", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ComponentScopeMenuBuilder[componentBuilder=" + LabelUtils.getLabel(_componentBuilder) + "]";
+    }
+
+    /**
+     * Determines if changing scope is relevant or not. If only the top-level scope exist, it is
+     * not relevant to even show the ability to set scope.
+     *
+     */
+    public boolean isRelevant() {
+        return _topLevelJobBuilder.getDescendants().size() > 0;
+    }
+}

--- a/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeButton.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeButton.java
@@ -29,7 +29,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
-import org.datacleaner.job.ComponentRequirement;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.util.IconUtils;
@@ -37,7 +36,6 @@ import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.LabelUtils;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.ChangeRequirementMenuBuilder;
-import org.datacleaner.windows.AbstractDialog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,9 +61,9 @@ public class ComponentScopeButton extends JButton implements ActionListener {
         super(ChangeRequirementMenuBuilder.NO_REQUIREMENT_TEXT, scopeIcon);
         _componentBuilder = componentBuilder;
         _menuBuilder = menuBuilder;
-        _topLevelJobBuilder = componentBuilder.getAnalysisJobBuilder().getTopLevelJobBuilder();
+        _topLevelJobBuilder = componentBuilder.getAnalysisJobBuilder().getRootJobBuilder();
         addActionListener(this);
-        updateText();
+        updateText(_componentBuilder.getAnalysisJobBuilder(), _menuBuilder.findComponentBuilder(_componentBuilder.getAnalysisJobBuilder()));
         WidgetUtils.setDefaultButtonStyle(this);
     }
 
@@ -82,17 +80,16 @@ public class ComponentScopeButton extends JButton implements ActionListener {
         popup.show(this, 0, getHeight());
     }
 
-    public void updateText() {
+    public void updateText(final AnalysisJobBuilder osJobBuilder, final ComponentBuilder osComponentBuilder) {
         logger.debug("updateText()");
 
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
-                final AnalysisJobBuilder analysisJobBuilder = _componentBuilder.getAnalysisJobBuilder();
-                if (analysisJobBuilder == _topLevelJobBuilder) {
+                if (osJobBuilder == _topLevelJobBuilder) {
                     setText(ComponentScopeMenuBuilder.DEFAULT_SCOPE_TEXT);
                 } else {
-                    setText(analysisJobBuilder.getDatastore().getName());
+                    setText(LabelUtils.getLabel(osComponentBuilder) + ": " + osJobBuilder.getDatastore().getName());
                 }
             }
         };
@@ -118,6 +115,6 @@ public class ComponentScopeButton extends JButton implements ActionListener {
      *
      */
     public boolean isRelevant() {
-        return _topLevelJobBuilder.getDescendants().size() > 0;
+        return _menuBuilder.getComponentBuildersWithOutputDataStreams(_topLevelJobBuilder).size() > 0;
     }
 }

--- a/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeMenuBuilder.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/visualization/ComponentScopeMenuBuilder.java
@@ -1,0 +1,113 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.widgets.visualization;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.Icon;
+import javax.swing.JMenuItem;
+
+import org.datacleaner.job.ComponentRequirement;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.ImageManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Object capable of building a menu for changing a component's
+ * {@link ComponentRequirement}.
+ */
+public class ComponentScopeMenuBuilder {
+
+    public static final String DEFAULT_SCOPE_TEXT = "Default scope";
+    private static final Logger logger = LoggerFactory.getLogger(ComponentScopeMenuBuilder.class);
+    private static final ImageManager imageManager = ImageManager.get();
+
+    private static final Icon selectedScopeIcon = imageManager.getImageIcon(IconUtils.STATUS_VALID,
+            IconUtils.ICON_SIZE_SMALL);
+
+    private final ComponentBuilder _componentBuilder;
+    private final AnalysisJobBuilder _topLevelJobBuilder;
+
+    public ComponentScopeMenuBuilder(ComponentBuilder componentBuilder) {
+        _componentBuilder = componentBuilder;
+        _topLevelJobBuilder = _componentBuilder.getAnalysisJobBuilder().getTopLevelJobBuilder();
+    }
+
+    public List<JMenuItem> createMenuItems() {
+        final ComponentRequirement currentComponentRequirement = _componentBuilder.getComponentRequirement();
+        logger.info("Current requirement: {}", currentComponentRequirement);
+
+        final List<JMenuItem> popup = new ArrayList<>();
+        final JMenuItem topLevelMenuItem = new JMenuItem(DEFAULT_SCOPE_TEXT);
+        topLevelMenuItem
+                .setToolTipText("Use the top level scope for this component");
+        topLevelMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                onScopeChangeStart();
+                _topLevelJobBuilder.moveComponent(_componentBuilder);
+                _componentBuilder.setComponentRequirement(null);
+                onScopeChangeComplete();
+            }
+        });
+
+        if(_topLevelJobBuilder == _componentBuilder.getAnalysisJobBuilder()){
+            topLevelMenuItem.setIcon(selectedScopeIcon);
+        }
+
+        popup.add(topLevelMenuItem);
+
+        final List<AnalysisJobBuilder> allJobBuilders = _topLevelJobBuilder.getDescendants();
+
+        for (final AnalysisJobBuilder ajb : allJobBuilders) {
+            final JMenuItem scopeMenuItem = new JMenuItem(ajb.getDatastore().getName());
+
+            if(ajb == _componentBuilder.getAnalysisJobBuilder()){
+                scopeMenuItem.setIcon(selectedScopeIcon);
+            }
+
+            scopeMenuItem.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    onScopeChangeStart();
+                    ajb.moveComponent(_componentBuilder);
+                    _componentBuilder.setComponentRequirement(null);
+                    onScopeChangeComplete();
+                }
+            });
+            popup.add(scopeMenuItem);
+        }
+
+        return popup;
+    }
+
+    protected void onScopeChangeStart() {
+    }
+
+    protected void onScopeChangeComplete() {
+    }
+
+}

--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
@@ -115,13 +115,16 @@ public abstract class AbstractDialog extends JDialog implements DCWindow, Window
         setResizable(isWindowResizable());
 
         JComponent content = getWindowContent();
+        getContentPane().removeAll();
         getContentPane().add(content);
 
         getContentPane().setPreferredSize(content.getPreferredSize());
 
         pack();
 
-        WidgetUtils.centerOnScreen(this);
+        if(!initialized) {
+            WidgetUtils.centerOnScreen(this);
+        }
 
         if (_windowContext != null) {
             _windowContext.onShow(this);
@@ -130,12 +133,12 @@ public abstract class AbstractDialog extends JDialog implements DCWindow, Window
 
     @Override
     public final void setVisible(boolean b) {
-        if (b == false) {
+        if (!b) {
             throw new UnsupportedOperationException("Window does not support hiding, consider using dispose()");
         }
         if (!initialized) {
-            initialized = true;
             initialize();
+            initialized = true;
         }
         super.setVisible(true);
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphActions.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphActions.java
@@ -68,10 +68,8 @@ public class JobGraphActions {
                 .getRenderer(componentBuilder, ComponentBuilderPresenterRenderingFormat.class);
 
         if (renderer != null) {
-            final ComponentBuilderPresenter presenter = renderer.render(componentBuilder);
-
             final ComponentConfigurationDialog dialog = new ComponentConfigurationDialog(_windowContext,
-                    componentBuilder, presenter);
+                    componentBuilder, renderer);
             dialog.addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowClosed(WindowEvent e) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
@@ -32,6 +32,7 @@ import org.datacleaner.actions.ComponentReferenceDocumentationActionListener;
 import org.datacleaner.actions.RenameComponentActionListener;
 import org.datacleaner.api.Renderer;
 import org.datacleaner.bootstrap.WindowContext;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.job.builder.ComponentRemovalListener;
 import org.datacleaner.panels.ComponentBuilderPresenter;
@@ -73,15 +74,14 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
             @Override
             protected void onScopeChangeStart() {
                 _changingScope = true;
-                _componentScopeButton.updateText();
             }
 
             @Override
-            protected void onScopeChangeComplete() {
+            protected void onScopeChangeComplete(final AnalysisJobBuilder osJobBuilder, final ComponentBuilder osComponentBuilder) {
                 _changingScope = false;
+                _componentScopeButton.updateText(osJobBuilder, osComponentBuilder);
                 initialize();
             }
-
         };
 
         _componentScopeButton = new ComponentScopeButton(_componentBuilder, menuBuilder);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ComponentConfigurationDialog.java
@@ -30,6 +30,7 @@ import javax.swing.JComponent;
 
 import org.datacleaner.actions.ComponentReferenceDocumentationActionListener;
 import org.datacleaner.actions.RenameComponentActionListener;
+import org.datacleaner.api.Renderer;
 import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.job.builder.ComponentRemovalListener;
@@ -43,6 +44,8 @@ import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.Alignment;
 import org.datacleaner.widgets.ChangeRequirementButton;
 import org.datacleaner.widgets.ChangeRequirementMenu;
+import org.datacleaner.widgets.visualization.ComponentScopeButton;
+import org.datacleaner.widgets.visualization.ComponentScopeMenuBuilder;
 import org.datacleaner.widgets.visualization.JobGraph;
 
 /**
@@ -53,18 +56,35 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
 
     private static final long serialVersionUID = 1L;
 
-    private final ComponentBuilderPresenter _presenter;
     private final ComponentBuilder _componentBuilder;
+    private final ComponentScopeButton _componentScopeButton;
+    private boolean _changingScope;
+
+    private final Renderer<ComponentBuilder, ? extends ComponentBuilderPresenter> _renderer;
 
     public ComponentConfigurationDialog(WindowContext windowContext, ComponentBuilder componentBuilder,
-            ComponentBuilderPresenter presenter) {
-        // super(null,
-        // ImageManager.get().getImage("images/window/banner-logo.png"));
+            Renderer<ComponentBuilder, ? extends ComponentBuilderPresenter> renderer) {
         super(windowContext, getBannerImage(componentBuilder));
 
         _componentBuilder = componentBuilder;
         _componentBuilder.addRemovalListener(this);
-        _presenter = presenter;
+        _renderer = renderer;
+        final ComponentScopeMenuBuilder menuBuilder = new ComponentScopeMenuBuilder(_componentBuilder) {
+            @Override
+            protected void onScopeChangeStart() {
+                _changingScope = true;
+                _componentScopeButton.updateText();
+            }
+
+            @Override
+            protected void onScopeChangeComplete() {
+                _changingScope = false;
+                initialize();
+            }
+
+        };
+
+        _componentScopeButton = new ComponentScopeButton(_componentBuilder, menuBuilder);
     }
 
     private static Image getBannerImage(ComponentBuilder componentBuilder) {
@@ -115,6 +135,10 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
         documentationButton.addActionListener(new ComponentReferenceDocumentationActionListener(_componentBuilder
                 .getAnalysisJobBuilder().getConfiguration(), _componentBuilder.getDescriptor()));
 
+        if (_componentScopeButton.isRelevant()) {
+            banner.add(_componentScopeButton);
+        }
+
         banner.add(documentationButton);
         if (ChangeRequirementMenu.isRelevant(_componentBuilder)) {
             banner.add(new ChangeRequirementButton(_componentBuilder));
@@ -136,7 +160,7 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
 
     @Override
     protected JComponent getDialogContent() {
-        final JComponent configurationComponent = _presenter.createJComponent();
+        final JComponent configurationComponent = _renderer.render(_componentBuilder).createJComponent();
 
         final JButton closeButton = WidgetFactory.createPrimaryButton("Close", IconUtils.ACTION_CLOSE_BRIGHT);
         closeButton.addActionListener(new ActionListener() {
@@ -156,6 +180,8 @@ public class ComponentConfigurationDialog extends AbstractDialog implements Comp
 
     @Override
     public void onRemove(ComponentBuilder componentBuilder) {
-        close();
+        if(!_changingScope){
+            close();
+        }
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
@@ -734,7 +734,7 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
 
             final Table table = outputDataStream.getTable();
 
-            analysisJobBuilder = new AnalysisJobBuilder(_analysisJobBuilder.getConfiguration());
+            analysisJobBuilder = new AnalysisJobBuilder(_analysisJobBuilder.getConfiguration(), _analysisJobBuilder);
             analysisJobBuilder.setDatastore(new OutputDataStreamDatastore(outputDataStream));
             analysisJobBuilder.addSourceColumns(table.getColumns());
 

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1220,7 +1220,7 @@ public final class AnalysisJobBuilder implements Closeable {
         return result;
     }
 
-    public AnalysisJobBuilder getTopLevelJobBuilder(){
+    public AnalysisJobBuilder getRootJobBuilder(){
         AnalysisJobBuilder builder = this;
         AnalysisJobBuilder tempBuilder = builder._parentBuilder;
         while(tempBuilder != null){
@@ -1229,27 +1229,5 @@ public final class AnalysisJobBuilder implements Closeable {
         }
 
         return builder;
-    }
-
-    private List<AnalysisJobBuilder> getChildren() {
-        List<AnalysisJobBuilder> childJobBuilders = new ArrayList<>();
-
-        for (ComponentBuilder componentBuilder : getComponentBuilders()) {
-            for (OutputDataStream outputDataStream : componentBuilder.getOutputDataStreams()) {
-                childJobBuilders.add(componentBuilder.getOutputDataStreamJobBuilder(outputDataStream));
-            }
-        }
-
-        return childJobBuilders;
-    }
-
-    public List<AnalysisJobBuilder> getDescendants() {
-        List<AnalysisJobBuilder> descendants = new ArrayList<>();
-        for(AnalysisJobBuilder child : getChildren()){
-            descendants.add(child);
-            descendants.addAll(child.getDescendants());
-        }
-
-        return descendants;
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -39,6 +39,7 @@ import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.Filter;
 import org.datacleaner.api.HasAnalyzerResult;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.api.Transformer;
 import org.datacleaner.api.Validate;
 import org.datacleaner.configuration.DataCleanerConfiguration;
@@ -78,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * Main entry to the Job Builder API. Use this class to build jobs either
  * programmatically, while parsing a marshalled job-representation (such as an
  * XML job definition) or for making an end-user able to build a job in a UI.
- * 
+ *
  * The AnalysisJobBuilder supports a wide variety of listeners to make it
  * possible to be informed of changes to the state and dependencies between the
  * components/beans that defines the job.
@@ -88,6 +89,7 @@ public final class AnalysisJobBuilder implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(AnalysisJobBuilder.class);
 
     private final DataCleanerConfiguration _configuration;
+    private final AnalysisJobBuilder _parentBuilder;
     private final IdGenerator _transformedColumnIdGenerator;
 
     // the configurable components
@@ -109,7 +111,12 @@ public final class AnalysisJobBuilder implements Closeable {
     private ComponentRequirement _defaultRequirement;
 
     public AnalysisJobBuilder(DataCleanerConfiguration configuration) {
+        this(configuration, (AnalysisJobBuilder) null);
+    }
+
+    public AnalysisJobBuilder(DataCleanerConfiguration configuration, AnalysisJobBuilder parentBuilder) {
         _configuration = configuration;
+        _parentBuilder = parentBuilder;
         _transformedColumnIdGenerator = new PrefixedIdGenerator("");
         _sourceColumns = new ArrayList<>();
         _filterComponentBuilders = new ArrayList<>();
@@ -124,7 +131,8 @@ public final class AnalysisJobBuilder implements Closeable {
             DatastoreConnection datastoreConnection, MutableAnalysisJobMetadata metadata,
             List<MetaModelInputColumn> sourceColumns, ComponentRequirement defaultRequirement, IdGenerator idGenerator,
             List<TransformerComponentBuilder<?>> transformerJobBuilders,
-            List<FilterComponentBuilder<?, ?>> filterJobBuilders, List<AnalyzerComponentBuilder<?>> analyzerJobBuilders) {
+            List<FilterComponentBuilder<?, ?>> filterJobBuilders, List<AnalyzerComponentBuilder<?>> analyzerJobBuilders,
+            AnalysisJobBuilder parentBuilder) {
         _configuration = configuration;
         _datastore = datastore;
         _analysisJobMetadata = metadata;
@@ -135,10 +143,16 @@ public final class AnalysisJobBuilder implements Closeable {
         _filterComponentBuilders = filterJobBuilders;
         _transformerComponentBuilders = transformerJobBuilders;
         _analyzerComponentBuilders = analyzerJobBuilders;
+        _parentBuilder = parentBuilder;
     }
 
+
     public AnalysisJobBuilder(DataCleanerConfiguration configuration, AnalysisJob job) {
-        this(configuration);
+        this(configuration, job, null);
+    }
+
+    public AnalysisJobBuilder(DataCleanerConfiguration configuration, AnalysisJob job, AnalysisJobBuilder parentBuilder) {
+        this(configuration, parentBuilder);
         importJob(job);
     }
 
@@ -268,7 +282,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Removes the specified table (or rather - all columns of that table) from
      * this job's source.
-     * 
+     *
      * @param table
      */
     public AnalysisJobBuilder removeSourceTable(Table table) {
@@ -287,7 +301,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Imports the datastore, components and configuration of a
      * {@link AnalysisJob} into this builder.
-     * 
+     *
      * @param job
      */
     public void importJob(AnalysisJob job) {
@@ -428,7 +442,7 @@ public final class AnalysisJobBuilder implements Closeable {
 
     /**
      * Adds a {@link ComponentBuilder} and removes it from its previous scope.
-     * 
+     *
      * @param builder
      *            The builder to add
      * @return The same builder
@@ -450,9 +464,9 @@ public final class AnalysisJobBuilder implements Closeable {
      * input (columns and requirements) will not be mapped since these depend on
      * the context of the {@link FilterJob} and may not be matched in the
      * {@link AnalysisJobBuilder}.
-     * 
+     *
      * @param componentJob
-     * 
+     *
      * @return the builder object for the specific component
      */
     protected Object addComponent(ComponentJob componentJob) {
@@ -641,7 +655,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Finds the available input columns (source or transformed) that match the
      * given data type specification.
-     * 
+     *
      * @param dataType
      *            the data type to look for
      * @return a list of matching input columns
@@ -655,7 +669,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Used to verify whether or not the builder's configuration is valid and
      * all properties are satisfied.
-     * 
+     *
      * @param throwException
      *            whether or not an exception should be thrown in case of
      *            invalid configuration. Typically an exception message will
@@ -720,7 +734,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Used to verify whether or not the builder's configuration is valid and
      * all properties are satisfied.
-     * 
+     *
      * @return true if the analysis job builder is correctly configured
      */
     public boolean isConfigured() {
@@ -729,7 +743,7 @@ public final class AnalysisJobBuilder implements Closeable {
 
     /**
      * Creates an analysis job of this {@link AnalysisJobBuilder}.
-     * 
+     *
      * @param validate
      *            whether or not to validate job configuration while building
      * @return
@@ -826,7 +840,7 @@ public final class AnalysisJobBuilder implements Closeable {
 
     /**
      * Creates an analysis job of this {@link AnalysisJobBuilder}.
-     * 
+     *
      * @return
      * @throws IllegalStateException
      *             if the job is invalidly configured. See
@@ -929,7 +943,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Sets a default requirement for all newly added and existing row
      * processing component, unless they have another requirement.
-     * 
+     *
      * @param filterJobBuilder
      * @param category
      */
@@ -940,7 +954,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Sets a default requirement for all newly added and existing row
      * processing component, unless they have another requirement.
-     * 
+     *
      * @param defaultRequirement
      */
     public void setDefaultRequirement(final FilterOutcome defaultRequirement) {
@@ -1000,7 +1014,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets a default requirement, which will be applied to all newly added row
      * processing components.
-     * 
+     *
      * @return a default requirement, which will be applied to all newly added
      *         row processing components.
      */
@@ -1085,7 +1099,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets a mutable {@link Map} for setting properties that will eventually be
      * available via {@link AnalysisJobMetadata#getProperties()}.
-     * 
+     *
      * @return
      */
     public Map<String, String> getMetadataProperties() {
@@ -1101,16 +1115,16 @@ public final class AnalysisJobBuilder implements Closeable {
 
     public AnalysisJobBuilder withoutListeners() {
         final MutableAnalysisJobMetadata metadataClone = new MutableAnalysisJobMetadata(getAnalysisJobMetadata());
-        final AnalysisJobBuilder clone = new AnalysisJobBuilder(_configuration, _datastore, _datastoreConnection,
+        return new AnalysisJobBuilder(_configuration, _datastore, _datastoreConnection,
                 metadataClone, _sourceColumns, _defaultRequirement, _transformedColumnIdGenerator,
-                _transformerComponentBuilders, _filterComponentBuilders, _analyzerComponentBuilders);
-        return clone;
+                _transformerComponentBuilders, _filterComponentBuilders, _analyzerComponentBuilders,
+                _parentBuilder);
     }
 
     /**
      * Gets the total number of active components (transformation or analysis)
      * in this job.
-     * 
+     *
      * @return
      */
     public int getComponentCount() {
@@ -1121,7 +1135,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets all component builders contained within this
      * {@link AnalysisJobBuilder}
-     * 
+     *
      * @return
      */
     public Collection<ComponentBuilder> getComponentBuilders() {
@@ -1135,7 +1149,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets all component builders that are expected to generate an
      * {@link AnalyzerResult}.
-     * 
+     *
      * @return
      */
     public Collection<ComponentBuilder> getResultProducingComponentBuilders() {
@@ -1153,7 +1167,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets all available {@link InputColumn}s to map to a particular
      * {@link ComponentBuilder}
-     * 
+     *
      * @param componentBuilder
      * @return
      */
@@ -1164,7 +1178,7 @@ public final class AnalysisJobBuilder implements Closeable {
     /**
      * Gets all available {@link InputColumn}s of a particular type to map to a
      * particular {@link ComponentBuilder}
-     * 
+     *
      * @param componentBuilder
      * @param dataType
      * @return
@@ -1204,5 +1218,46 @@ public final class AnalysisJobBuilder implements Closeable {
         });
 
         return result;
+    }
+
+    public AnalysisJobBuilder getTopLevelJobBuilder(){
+        AnalysisJobBuilder builder = this;
+        AnalysisJobBuilder tempBuilder = builder._parentBuilder;
+        while(tempBuilder != null){
+            builder = tempBuilder;
+            tempBuilder = builder._parentBuilder;
+        }
+
+        return builder;
+    }
+
+    private List<AnalysisJobBuilder> getChildren() {
+        List<AnalysisJobBuilder> childJobBuilders = new ArrayList<>();
+
+        for (ComponentBuilder componentBuilder : getComponentBuilders()) {
+            for (OutputDataStream outputDataStream : componentBuilder.getOutputDataStreams()) {
+                childJobBuilders.add(componentBuilder.getOutputDataStreamJobBuilder(outputDataStream));
+            }
+        }
+
+        return childJobBuilders;
+    }
+
+    private List<AnalysisJobBuilder> getDescendants() {
+        List<AnalysisJobBuilder> descendants = new ArrayList<>();
+        for(AnalysisJobBuilder child : getChildren()){
+            descendants.add(child);
+            descendants.addAll(child.getDescendants());
+        }
+
+        return descendants;
+    }
+
+    public List<AnalysisJobBuilder> getAllAnalysisJobBuilders() {
+        List<AnalysisJobBuilder> jobBuilders = new ArrayList<>();
+        AnalysisJobBuilder topLevelBuilder = getTopLevelJobBuilder();
+        jobBuilders.add(topLevelBuilder);
+        jobBuilders.addAll(topLevelBuilder.getDescendants());
+        return jobBuilders;
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1243,7 +1243,7 @@ public final class AnalysisJobBuilder implements Closeable {
         return childJobBuilders;
     }
 
-    private List<AnalysisJobBuilder> getDescendants() {
+    public List<AnalysisJobBuilder> getDescendants() {
         List<AnalysisJobBuilder> descendants = new ArrayList<>();
         for(AnalysisJobBuilder child : getChildren()){
             descendants.add(child);
@@ -1251,13 +1251,5 @@ public final class AnalysisJobBuilder implements Closeable {
         }
 
         return descendants;
-    }
-
-    public List<AnalysisJobBuilder> getAllAnalysisJobBuilders() {
-        List<AnalysisJobBuilder> jobBuilders = new ArrayList<>();
-        AnalysisJobBuilder topLevelBuilder = getTopLevelJobBuilder();
-        jobBuilders.add(topLevelBuilder);
-        jobBuilders.addAll(topLevelBuilder.getDescendants());
-        return jobBuilders;
     }
 }

--- a/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
@@ -223,18 +223,10 @@ public class AnalysisJobBuilderTest extends TestCase {
 
 
             // Any random analyzer should work:
-            assertEquals(ajb, analyzer1Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
-            assertEquals(ajb, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
-            assertEquals(ajb, analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
-            assertEquals(ajb, analyzer0Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
-
-            assertEquals(16, ajb.getDescendants().size());
-
-            // First should be a0 stream 0
-            assertEquals(analyzer0DataStream0JobBuilder, ajb.getDescendants().get(0));
-
-            // Last should be a1a1 stream 1
-            assertEquals(analyzer1Analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer1.getOutputDataStreams().get(1)), ajb.getDescendants().get(15));
+            assertEquals(ajb, analyzer1Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+            assertEquals(ajb, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+            assertEquals(ajb, analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+            assertEquals(ajb, analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
         }
     }
 }

--- a/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
@@ -21,22 +21,23 @@ package org.datacleaner.job.builder;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 
 import junit.framework.TestCase;
 
 import org.apache.metamodel.schema.MutableColumn;
 import org.apache.metamodel.schema.MutableTable;
+import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
 import org.datacleaner.data.MetaModelInputColumn;
 import org.datacleaner.test.MockFilter;
 import org.datacleaner.test.MockFilter.Category;
+import org.datacleaner.test.MockOutputDataStreamAnalyzer;
 import org.datacleaner.test.MockTransformer;
 import org.datacleaner.test.mock.MockDatastore;
-import org.junit.Test;
 
 public class AnalysisJobBuilderTest extends TestCase {
 
-    @Test
     public void testGetAvailableInputColumnsForComponentPreventsCyclicDependencies() throws Exception {
         final MutableTable table = new MutableTable("table");
         final MutableColumn column = new MutableColumn("foo").setTable(table);
@@ -144,6 +145,93 @@ public class AnalysisJobBuilderTest extends TestCase {
                             + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[MetaModelInputColumn[table.foo]]], "
                             + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[TransformedInputColumn[id=trans-0001-0002,name=mock output]]]]",
                     componentBuilders.toString());
+        }
+    }
+
+    public void testGetAllJobBuilders() {
+        MutableTable table = new MutableTable("table");
+        MutableColumn column = new MutableColumn("foo").setTable(table);
+        table.addColumn(column);
+
+        // set up
+        try (final AnalysisJobBuilder ajb = new AnalysisJobBuilder(new DataCleanerConfigurationImpl())) {
+            final MockDatastore datastore = new MockDatastore();
+            ajb.setDatastore(datastore);
+            ajb.addSourceColumn(new MetaModelInputColumn(column));
+
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0 =
+                    ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer0.setName("analyzer0");
+            analyzer0.addInputColumn(ajb.getSourceColumns().get(0));
+
+            final List<OutputDataStream> analyzer0OutputDataStreams = analyzer0.getOutputDataStreams();
+
+            final AnalysisJobBuilder analyzer0DataStream0JobBuilder =
+                    analyzer0.getOutputDataStreamJobBuilder(analyzer0OutputDataStreams.get(0));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0 =
+                    analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer0Analyzer0.setName("analyzer0Analyzer0");
+            analyzer0Analyzer0.addInputColumn(analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
+
+            final List<OutputDataStream> analyzer0Analyzer0OutputDataStreams =
+                    analyzer0Analyzer0.getOutputDataStreams();
+
+            final AnalysisJobBuilder analyzer0Analyzer0DataStream0JobBuilder =
+                    analyzer0Analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(0));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0Analyzer0 =
+                    analyzer0Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer0Analyzer0Analyzer0.setName("analyzer0Analyzer0Analyzer0");
+            analyzer0Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
+
+            final AnalysisJobBuilder analyzer0DataStream1JobBuilder =
+                    analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(1));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer1 =
+                    analyzer0DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer0Analyzer1.setName("analyzer0Analyzer1");
+            analyzer0Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
+
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1 =
+                    ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer1.setName("analyzer1");
+            analyzer1.addInputColumn(ajb.getSourceColumns().get(0));
+
+            final List<OutputDataStream> analyzer1OutputDataStreams = analyzer1.getOutputDataStreams();
+
+            final AnalysisJobBuilder analyzer1DataStream0JobBuilder =
+                    analyzer1.getOutputDataStreamJobBuilder(analyzer1OutputDataStreams.get(0));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0 =
+                    analyzer1DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer1Analyzer0.setName("analyzer1Analyzer0");
+            analyzer1Analyzer0.addInputColumn(analyzer1DataStream0JobBuilder.getSourceColumns().get(0));
+
+            final List<OutputDataStream> analyzer1Analyzer0OutputDataStreams =
+                    analyzer1Analyzer0.getOutputDataStreams();
+
+            final AnalysisJobBuilder analyzer1Analyzer0DataStream0JobBuilder =
+                    analyzer1Analyzer0.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(0));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0Analyzer0 =
+                    analyzer1Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer1Analyzer0Analyzer0.setName("analyzer1Analyzer0Analyzer0");
+            analyzer1Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
+
+            final AnalysisJobBuilder analyzer1DataStream1JobBuilder =
+                    analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(1));
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer1 =
+                    analyzer1DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+            analyzer1Analyzer1.setName("analyzer1Analyzer1");
+            analyzer1Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
+
+            // Any random analyzer should work:
+            assertEquals(17, analyzer1Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
+            assertEquals(17, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
+            assertEquals(17, analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
+            assertEquals(17, analyzer0Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
+
+            // First should be top-level
+            assertEquals(ajb, analyzer0Analyzer0DataStream0JobBuilder.getAllAnalysisJobBuilders().get(0));
+
+            // Last should be a1a1 stream 1
+            assertEquals(analyzer1Analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer1.getOutputDataStreams().get(1)), analyzer0Analyzer0DataStream0JobBuilder.getAllAnalysisJobBuilders().get(16));
         }
     }
 }

--- a/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
@@ -221,17 +221,20 @@ public class AnalysisJobBuilderTest extends TestCase {
             analyzer1Analyzer1.setName("analyzer1Analyzer1");
             analyzer1Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
 
-            // Any random analyzer should work:
-            assertEquals(17, analyzer1Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
-            assertEquals(17, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
-            assertEquals(17, analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
-            assertEquals(17, analyzer0Analyzer0.getAnalysisJobBuilder().getAllAnalysisJobBuilders().size());
 
-            // First should be top-level
-            assertEquals(ajb, analyzer0Analyzer0DataStream0JobBuilder.getAllAnalysisJobBuilders().get(0));
+            // Any random analyzer should work:
+            assertEquals(ajb, analyzer1Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
+            assertEquals(ajb, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
+            assertEquals(ajb, analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
+            assertEquals(ajb, analyzer0Analyzer0.getAnalysisJobBuilder().getTopLevelJobBuilder());
+
+            assertEquals(16, ajb.getDescendants().size());
+
+            // First should be a0 stream 0
+            assertEquals(analyzer0DataStream0JobBuilder, ajb.getDescendants().get(0));
 
             // Last should be a1a1 stream 1
-            assertEquals(analyzer1Analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer1.getOutputDataStreams().get(1)), analyzer0Analyzer0DataStream0JobBuilder.getAllAnalysisJobBuilders().get(16));
+            assertEquals(analyzer1Analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer1.getOutputDataStreams().get(1)), ajb.getDescendants().get(15));
         }
     }
 }


### PR DESCRIPTION
This adds methods to get the top-level AnalysisJobBuilder as well as all AnalysisJobBuilders.

To make that possible each AnalysisJobBuilder now know its parent, creating a chain of AnalysisJobBuilders.

This is a prerequisite for #570

Change: No longer getting _all_, only getting descendants

Edit: 
Accidentally added the rest of the #570 fix, so if merged, fixes #570.

Please note that there is still a few limitations: Only the default scope will instantly reflect the changes, other scopes will update upon closing the dialog. The scope label does not show which component it comes from, making i.e. several CompletenessAnalyzers will end up with several "Complete rows" scopes and several "Incomplete rows" scopes.

Edit: This should be mergeable, though we have some serious space and overlapping issues now:
![image](https://cloud.githubusercontent.com/assets/1282832/9518008/e77f283e-4cb3-11e5-88b1-254e9b565d81.png)

(Just realized this may be confusing: "Completeness analyzer 1" and "Completeness analyzer 2" are the actual names of the AnalyzerBuilder instances, the menu is not counting them)