### PR TITLE
Issue #622: Fixed by having special null-logic in setConfiguredProperty

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
@@ -143,7 +143,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
 
         final ComponentRequirement componentRequirement = immutabilizer.load(getComponentRequirement());
 
-        if (!_multipleJobsSupported) {
+        if (!isMultipleJobsSupported()) {
             final OutputDataStreamJob[] outputDataStreamJobs = immutabilizer.load(getOutputDataStreamJobs(), validate);
             final ImmutableAnalyzerJob job = new ImmutableAnalyzerJob(getName(), getDescriptor(),
                     new ImmutableComponentConfiguration(configuredProperties), componentRequirement,
@@ -235,7 +235,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
 
     @Override
     public boolean isConfigured(ConfiguredPropertyDescriptor configuredProperty, boolean throwException) {
-        if (_multipleJobsSupported && configuredProperty == _inputProperty) {
+        if (isMultipleJobsSupported() && configuredProperty == _inputProperty) {
             if (_inputColumns.isEmpty()) {
                 Object propertyValue = super.getConfiguredProperty(configuredProperty);
                 if (propertyValue != null) {
@@ -290,10 +290,12 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
             final InputColumn<?> dummyValue;
 
             _inputColumns.clear();
-            if (ReflectionUtils.isArray(value)) {
+            if (value == null) {
+                dummyValue = null;
+            } else if (ReflectionUtils.isArray(value)) {
                 int length = Array.getLength(value);
                 for (int i = 0; i < length; i++) {
-                    InputColumn<?> inputColumn = (InputColumn<?>) Array.get(value, i);
+                    final InputColumn<?> inputColumn = (InputColumn<?>) Array.get(value, i);
                     _inputColumns.add(inputColumn);
                 }
                 if (_inputColumns.isEmpty()) {
@@ -302,7 +304,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
                     dummyValue = _inputColumns.iterator().next();
                 }
             } else {
-                InputColumn<?> col = (InputColumn<?>) value;
+                final InputColumn<?> col = (InputColumn<?>) value;
                 _inputColumns.add(col);
                 dummyValue = col;
             }
@@ -354,7 +356,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
     public boolean isMultipleJobsSupported() {
         return _multipleJobsSupported;
     }
-    
+
     @Override
     public List<OutputDataStream> getOutputDataStreams() {
         if (isMultipleJobsSupported()) {


### PR DESCRIPTION
Fixes #622 

Turned out that this was only an issue when dealing with components that has ```@ColumnProperty(escalateToMultipleJobs=true)``` (typically Value Distribution or Pattern Finder) ... Yet another rare case, but good to have it caught.

![image](https://cloud.githubusercontent.com/assets/291450/9715815/4e42269e-5564-11e5-8640-5c21a8092578.png)
