### PR TITLE
Propagate builder listeners

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/MetadataPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/MetadataPanel.java
@@ -62,7 +62,7 @@ public class MetadataPanel extends DCPanel implements SourceColumnChangeListener
     public MetadataPanel(AnalysisJobBuilder analysisJobBuilder) {
         super(WidgetUtils.COLOR_DEFAULT_BACKGROUND);
         _analysisJobBuilder = analysisJobBuilder;
-        _analysisJobBuilder.getSourceColumnListeners().add(this);
+        _analysisJobBuilder.addSourceColumnChangeListener(this);
 
         _table = new DCTable(COLUMN_NAMES);
         _table.setColumnControlVisible(false);

--- a/desktop/ui/src/main/java/org/datacleaner/panels/SourceColumnsPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/SourceColumnsPanel.java
@@ -78,7 +78,7 @@ public final class SourceColumnsPanel extends DCPanel implements SourceColumnCha
         for (InputColumn<?> column : sourceColumns) {
             onAdd(column);
         }
-        analysisJobBuilder.getSourceColumnListeners().add(this);
+        analysisJobBuilder.addSourceColumnChangeListener(this);
     }
 
     private MaxRowsFilterShortcutPanel createMaxRowsFilterShortcutPanel() {
@@ -150,13 +150,13 @@ public final class SourceColumnsPanel extends DCPanel implements SourceColumnCha
 
     @Override
     public void removeNotify() {
-        _analysisJobBuilder.getSourceColumnListeners().remove(this);
+        _analysisJobBuilder.removeSourceColumnChangeListener(this);
         super.removeNotify();
     }
 
     @Override
     public void addNotify() {
-        _analysisJobBuilder.getSourceColumnListeners().add(this);
+        _analysisJobBuilder.addSourceColumnChangeListener(this);
         super.addNotify();
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/panels/coalesce/MultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/coalesce/MultipleCoalesceUnitPropertyWidget.java
@@ -77,8 +77,8 @@ public class MultipleCoalesceUnitPropertyWidget extends AbstractPropertyWidget<I
         _unitContainerPanel = new DCPanel();
         _unitContainerPanel.setLayout(new VerticalLayout(2));
 
-        getAnalysisJobBuilder().getSourceColumnListeners().add(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().addSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
 
         _unitPropertyWidget = createUnitPropertyWidget();
 
@@ -130,8 +130,8 @@ public class MultipleCoalesceUnitPropertyWidget extends AbstractPropertyWidget<I
     @Override
     public void onPanelRemove() {
         super.onPanelRemove();
-        getAnalysisJobBuilder().getSourceColumnListeners().remove(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
     }
 
     public void removeCoalesceUnit() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
@@ -125,8 +125,8 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
         _checkBoxDecorations = new IdentityHashMap<DCCheckBox<InputColumn<?>>, JComponent>();
         _firstUpdate = true;
         _dataType = propertyDescriptor.getTypeArgument(0);
-        getAnalysisJobBuilder().getSourceColumnListeners().add(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().addSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
         setLayout(new VerticalLayout(2));
 
         _searchDatastoreTextField = WidgetFactory.createTextField("Search/filter columns");
@@ -366,8 +366,8 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     @Override
     public void onPanelRemove() {
         super.onPanelRemove();
-        getAnalysisJobBuilder().getSourceColumnListeners().remove(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleInputColumnComboBoxPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleInputColumnComboBoxPropertyWidget.java
@@ -64,8 +64,8 @@ public class SingleInputColumnComboBoxPropertyWidget extends AbstractPropertyWid
                 fireValueChanged();
             }
         });
-        getAnalysisJobBuilder().getSourceColumnListeners().add(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().addSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
         _dataType = propertyDescriptor.getTypeArgument(0);
 
         updateComponents();
@@ -167,8 +167,8 @@ public class SingleInputColumnComboBoxPropertyWidget extends AbstractPropertyWid
     @Override
     public void onPanelRemove() {
         super.onPanelRemove();
-        getAnalysisJobBuilder().getSourceColumnListeners().remove(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().remove(this);
+        getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().removeTransformerChangeListener(this);
 
         for (InputColumn<?> column : _inputColumns) {
             if (column instanceof MutableInputColumn) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleInputColumnRadioButtonPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleInputColumnRadioButtonPropertyWidget.java
@@ -72,8 +72,8 @@ public class SingleInputColumnRadioButtonPropertyWidget extends AbstractProperty
         _radioGroup.setLayoutAxis(BoxLayout.Y_AXIS);
         _radioGroup.setOpaque(false);
 
-        getAnalysisJobBuilder().getSourceColumnListeners().add(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().add(this);
+        getAnalysisJobBuilder().addSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().addTransformerChangeListener(this);
         _propertyDescriptor = propertyDescriptor;
         _dataType = propertyDescriptor.getTypeArgument(0);
 
@@ -259,8 +259,8 @@ public class SingleInputColumnRadioButtonPropertyWidget extends AbstractProperty
     @Override
     public void onPanelRemove() {
         super.onPanelRemove();
-        getAnalysisJobBuilder().getSourceColumnListeners().remove(this);
-        getAnalysisJobBuilder().getTransformerChangeListeners().remove(this);
+        getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
+        getAnalysisJobBuilder().removeTransformerChangeListener(this);
 
         for (InputColumn<?> column : _inputColumns) {
             if (column instanceof MutableInputColumn) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -90,6 +90,7 @@ import org.datacleaner.job.FilterOutcome;
 import org.datacleaner.job.JaxbJobWriter;
 import org.datacleaner.job.SimpleComponentRequirement;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.AnalysisJobChangeListener;
 import org.datacleaner.job.builder.AnalyzerChangeListener;
 import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
@@ -139,6 +140,148 @@ import org.slf4j.LoggerFactory;
 public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implements AnalysisJobBuilderWindow,
         WindowListener {
 
+    private class WindowAnalysisJobChangeListener implements AnalysisJobChangeListener {
+        @Override
+        public void onActivation(final AnalysisJobBuilder builder) {
+            builder.getAnalyzerChangeListeners().add(_analyzerChangeListener);
+            builder.getTransformerChangeListeners().add(_transformerChangeListener);
+            builder.getFilterChangeListeners().add(_filterChangeListener);
+            builder.getSourceColumnListeners().add(_sourceColumnChangeListener);
+            builder.getAnalysisJobChangeListeners().add(this);
+            for(AnalysisJobBuilder analysisJobBuilder : builder.getConsumedOutputDataStreamsJobBuilders()){
+                onActivation(analysisJobBuilder);
+            }
+        }
+
+        @Override
+        public void onDeactivation(final AnalysisJobBuilder builder) {
+            builder.getAnalyzerChangeListeners().remove(_analyzerChangeListener);
+            builder.getTransformerChangeListeners().remove(_transformerChangeListener);
+            builder.getFilterChangeListeners().remove(_filterChangeListener);
+            builder.getSourceColumnListeners().remove(_sourceColumnChangeListener);
+            builder.getAnalysisJobChangeListeners().remove(this);
+        }
+    }
+
+    private class WindowAnalyzerChangeListener implements AnalyzerChangeListener {
+        @Override
+        public void onAdd(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
+            if (_classicView != null) {
+                _classicView.addAnalyzer(analyzerJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRemove(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
+            if (_classicView != null) {
+                _classicView.removeAnalyzer(analyzerJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onConfigurationChanged(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRequirementChanged(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
+            _graph.refresh();
+        }
+    }
+
+    private class WindowTransformerChangeListener implements TransformerChangeListener {
+
+        @Override
+        public void onAdd(final TransformerComponentBuilder<?> transformerJobBuilder) {
+            if (_classicView != null) {
+                _classicView.addTransformer(transformerJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRemove(final TransformerComponentBuilder<?> transformerJobBuilder) {
+            if (_classicView != null) {
+                _classicView.removeTransformer(transformerJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onOutputChanged(final TransformerComponentBuilder<?> transformerJobBuilder,
+                List<MutableInputColumn<?>> outputColumns) {
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRequirementChanged(final TransformerComponentBuilder<?> transformerJobBuilder) {
+            _graph.refresh();
+        }
+
+        @Override
+        public void onConfigurationChanged(final TransformerComponentBuilder<?> transformerJobBuilder) {
+            updateStatusLabel();
+            _graph.refresh();
+        }
+    }
+
+    private class WindowFilterChangeListener implements FilterChangeListener {
+
+        @Override
+        public void onAdd(final FilterComponentBuilder<?, ?> filterJobBuilder) {
+            if (_classicView != null) {
+                _classicView.addFilter(filterJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRemove(final FilterComponentBuilder<?, ?> filterJobBuilder) {
+            if (_classicView != null) {
+                _classicView.removeFilter(filterJobBuilder);
+            }
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onConfigurationChanged(final FilterComponentBuilder<?, ?> filterJobBuilder) {
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRequirementChanged(final FilterComponentBuilder<?, ?> filterJobBuilder) {
+            _graph.refresh();
+        }
+    }
+
+    private class WindowSourceColumnChangeListener implements SourceColumnChangeListener {
+
+        @Override
+        public void onAdd(final InputColumn<?> sourceColumn) {
+            onSourceColumnsChanged();
+            updateStatusLabel();
+            _graph.refresh();
+        }
+
+        @Override
+        public void onRemove(final InputColumn<?> sourceColumn) {
+            onSourceColumnsChanged();
+            updateStatusLabel();
+            _graph.refresh();
+        }
+    }
+
+
     private static final String USER_PREFERENCES_PROPERTY_EDITING_MODE_PREFERENCE = "editing_mode_preference";
 
     private static final long serialVersionUID = 1L;
@@ -178,6 +321,11 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     private final DCPanel _contentContainerPanel;
     private final JComponent _editingContentView;
     private final UsageLogger _usageLogger;
+    private final AnalyzerChangeListener _analyzerChangeListener = new WindowAnalyzerChangeListener();
+    private final TransformerChangeListener _transformerChangeListener = new WindowTransformerChangeListener();
+    private final FilterChangeListener _filterChangeListener = new WindowFilterChangeListener();
+    private final SourceColumnChangeListener _sourceColumnChangeListener = new WindowSourceColumnChangeListener();
+    private final AnalysisJobChangeListener _analysisJobChangeListener = new WindowAnalysisJobChangeListener();
     private JobClassicView _classicView;
     private FileObject _jobFilename;
     private Datastore _datastore;
@@ -230,10 +378,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         _graph = new JobGraph(windowContext, userPreferences, analysisJobBuilder, _presenterRendererFactory,
                 usageLogger);
 
-        _analysisJobBuilder.getAnalyzerChangeListeners().add(createAnalyzerChangeListener());
-        _analysisJobBuilder.getTransformerChangeListeners().add(createTransformerChangeListener());
-        _analysisJobBuilder.getFilterChangeListeners().add(createFilterChangeListener());
-        _analysisJobBuilder.getSourceColumnListeners().add(createSourceColumnChangeListener());
+        _analysisJobChangeListener.onActivation(_analysisJobBuilder);
 
         _saveButton = createToolbarButton("Save", IconUtils.ACTION_SAVE_BRIGHT);
         _saveAsButton = createToolbarButton("Save As...", IconUtils.ACTION_SAVE_BRIGHT);
@@ -619,10 +764,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     }
 
     private void cleanupForWindowClose() {
-        _analysisJobBuilder.getAnalyzerChangeListeners().remove(this);
-        _analysisJobBuilder.getTransformerChangeListeners().remove(this);
-        _analysisJobBuilder.getFilterChangeListeners().remove(this);
-        _analysisJobBuilder.getSourceColumnListeners().remove(this);
+        _analysisJobChangeListener.onDeactivation(_analysisJobBuilder);
         _analysisJobBuilder.close();
         if (_datastoreConnection != null) {
             _datastoreConnection.close();
@@ -1072,133 +1214,6 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     @Override
     protected boolean isCentered() {
         return true;
-    }
-
-    private AnalyzerChangeListener createAnalyzerChangeListener() {
-        return new AnalyzerChangeListener() {
-
-            @Override
-            public void onAdd(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.addAnalyzer(analyzerJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRemove(AnalyzerComponentBuilder<?> analyzerJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.removeAnalyzer(analyzerJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onConfigurationChanged(AnalyzerComponentBuilder<?> analyzerJobBuilder) {
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRequirementChanged(AnalyzerComponentBuilder<?> analyzerJobBuilder) {
-                _graph.refresh();
-            }
-        };
-    }
-
-    private TransformerChangeListener createTransformerChangeListener() {
-        return new TransformerChangeListener() {
-
-            @Override
-            public void onAdd(final TransformerComponentBuilder<?> transformerJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.addTransformer(transformerJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRemove(TransformerComponentBuilder<?> transformerJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.removeTransformer(transformerJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onOutputChanged(TransformerComponentBuilder<?> transformerJobBuilder,
-                    List<MutableInputColumn<?>> outputColumns) {
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRequirementChanged(TransformerComponentBuilder<?> transformerJobBuilder) {
-                _graph.refresh();
-            }
-
-            @Override
-            public void onConfigurationChanged(TransformerComponentBuilder<?> transformerJobBuilder) {
-                updateStatusLabel();
-                _graph.refresh();
-            }
-        };
-    }
-
-    private FilterChangeListener createFilterChangeListener() {
-        return new FilterChangeListener() {
-
-            @Override
-            public void onAdd(final FilterComponentBuilder<?, ?> filterJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.addFilter(filterJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRemove(FilterComponentBuilder<?, ?> filterJobBuilder) {
-                if (_classicView != null) {
-                    _classicView.removeFilter(filterJobBuilder);
-                }
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onConfigurationChanged(FilterComponentBuilder<?, ?> filterJobBuilder) {
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRequirementChanged(FilterComponentBuilder<?, ?> filterJobBuilder) {
-                _graph.refresh();
-            }
-        };
-    }
-
-    private SourceColumnChangeListener createSourceColumnChangeListener() {
-        return new SourceColumnChangeListener() {
-
-            @Override
-            public void onAdd(InputColumn<?> sourceColumn) {
-                onSourceColumnsChanged();
-                updateStatusLabel();
-                _graph.refresh();
-            }
-
-            @Override
-            public void onRemove(InputColumn<?> sourceColumn) {
-                onSourceColumnsChanged();
-                updateStatusLabel();
-                _graph.refresh();
-            }
-        };
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -143,11 +143,13 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     private class WindowAnalysisJobChangeListener implements AnalysisJobChangeListener {
         @Override
         public void onActivation(final AnalysisJobBuilder builder) {
-            builder.getAnalyzerChangeListeners().add(_analyzerChangeListener);
-            builder.getTransformerChangeListeners().add(_transformerChangeListener);
-            builder.getFilterChangeListeners().add(_filterChangeListener);
-            builder.getSourceColumnListeners().add(_sourceColumnChangeListener);
-            builder.getAnalysisJobChangeListeners().add(this);
+            builder.addAnalyzerChangeListener(_analyzerChangeListener);
+            builder.addTransformerChangeListener(_transformerChangeListener);
+            builder.addFilterChangeListener(_filterChangeListener);
+            builder.addSourceColumnChangeListener(_sourceColumnChangeListener);
+            builder.addAnalysisJobChangeListener(this);
+
+            // We'll need to listen to already added output data stream job builders
             for(AnalysisJobBuilder analysisJobBuilder : builder.getConsumedOutputDataStreamsJobBuilders()){
                 onActivation(analysisJobBuilder);
             }
@@ -155,11 +157,11 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
 
         @Override
         public void onDeactivation(final AnalysisJobBuilder builder) {
-            builder.getAnalyzerChangeListeners().remove(_analyzerChangeListener);
-            builder.getTransformerChangeListeners().remove(_transformerChangeListener);
-            builder.getFilterChangeListeners().remove(_filterChangeListener);
-            builder.getSourceColumnListeners().remove(_sourceColumnChangeListener);
-            builder.getAnalysisJobChangeListeners().remove(this);
+            builder.removeAnalyzerChangeListener(_analyzerChangeListener);
+            builder.removeTransformerChangeListener(_transformerChangeListener);
+            builder.removeFilterChangeListener(_filterChangeListener);
+            builder.removeSourceColumnChangeListener(_sourceColumnChangeListener);
+            builder.removeAnalysisJobChangeListener(this);
         }
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SourceTableConfigurationDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SourceTableConfigurationDialog.java
@@ -65,13 +65,13 @@ public class SourceTableConfigurationDialog extends AbstractDialog implements So
     @Override
     public void addNotify() {
         super.addNotify();
-        _analysisJobBuilder.getSourceColumnListeners().add(this);
+        _analysisJobBuilder.addSourceColumnChangeListener(this);
     }
 
     @Override
     public void removeNotify() {
         super.removeNotify();
-        _analysisJobBuilder.getSourceColumnListeners().remove(this);
+        _analysisJobBuilder.removeSourceColumnChangeListener(this);
     }
 
     @Override

--- a/desktop/ui/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
@@ -279,7 +279,7 @@ public class AnalysisJobBuilderTest extends TestCase {
             ajb.setDatastore(datastore);
 
             SourceColumnChangeListener listener1 = EasyMock.createMock(SourceColumnChangeListener.class);
-            ajb.getSourceColumnListeners().add(listener1);
+            ajb.addSourceColumnChangeListener(listener1);
 
             Column column = ajb.getDatastoreConnection().getSchemaNavigator().convertToColumn("EMPLOYEES.EMAIL");
             MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);
@@ -300,7 +300,7 @@ public class AnalysisJobBuilderTest extends TestCase {
 
             // scene 2: add transformer
             TransformerChangeListener listener2 = EasyMock.createMock(TransformerChangeListener.class);
-            ajb.getTransformerChangeListeners().add(listener2);
+            ajb.addTransformerChangeListener(listener2);
 
             final TransformerDescriptor<EmailStandardizerTransformer> descriptor = Descriptors
                     .ofTransformer(EmailStandardizerTransformer.class);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -39,6 +39,7 @@ import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.Filter;
 import org.datacleaner.api.HasAnalyzerResult;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.api.Transformer;
 import org.datacleaner.api.Validate;
 import org.datacleaner.configuration.DataCleanerConfiguration;
@@ -107,6 +108,7 @@ public final class AnalysisJobBuilder implements Closeable {
     private final List<AnalyzerChangeListener> _analyzerChangeListeners = new ArrayList<>();
     private final List<TransformerChangeListener> _transformerChangeListeners = new ArrayList<>();
     private final List<FilterChangeListener> _filterChangeListeners = new ArrayList<>();
+    private final List<AnalysisJobChangeListener> _analysisJobChangeListeners = new ArrayList<>();
     private ComponentRequirement _defaultRequirement;
 
     public AnalysisJobBuilder(DataCleanerConfiguration configuration) {
@@ -229,7 +231,7 @@ public final class AnalysisJobBuilder implements Closeable {
         if (!_sourceColumns.contains(inputColumn)) {
             _sourceColumns.add(inputColumn);
 
-            List<SourceColumnChangeListener> listeners = new ArrayList<SourceColumnChangeListener>(
+            List<SourceColumnChangeListener> listeners = new ArrayList<>(
                     _sourceColumnListeners);
             for (SourceColumnChangeListener listener : listeners) {
                 listener.onAdd(inputColumn);
@@ -310,7 +312,7 @@ public final class AnalysisJobBuilder implements Closeable {
     public AnalysisJobBuilder removeSourceColumn(MetaModelInputColumn inputColumn) {
         boolean removed = _sourceColumns.remove(inputColumn);
         if (removed) {
-            List<SourceColumnChangeListener> listeners = new ArrayList<SourceColumnChangeListener>(
+            List<SourceColumnChangeListener> listeners = new ArrayList<>(
                     _sourceColumnListeners);
             for (SourceColumnChangeListener listener : listeners) {
                 listener.onRemove(inputColumn);
@@ -366,7 +368,7 @@ public final class AnalysisJobBuilder implements Closeable {
     public <T extends Transformer> TransformerComponentBuilder<T> addTransformer(TransformerDescriptor<T> descriptor,
             Map<ConfiguredPropertyDescriptor, Object> configuredProperties, ComponentRequirement requirement,
             Map<String, String> metadataProperties) {
-        final TransformerComponentBuilder<T> transformer = new TransformerComponentBuilder<T>(this, descriptor,
+        final TransformerComponentBuilder<T> transformer = new TransformerComponentBuilder<>(this, descriptor,
                 _transformedColumnIdGenerator);
         initializeComponentBuilder(transformer, configuredProperties, requirement, metadataProperties);
         return addTransformer(transformer);
@@ -378,9 +380,12 @@ public final class AnalysisJobBuilder implements Closeable {
         }
         _transformerComponentBuilders.add(tjb);
 
+        // Before triggering component's listeners, so listeners are ready.
+        onComponentAdded();
+
         // make a copy since some of the listeners may add additional listeners
         // which will otherwise cause ConcurrentModificationExceptions
-        List<TransformerChangeListener> listeners = new ArrayList<TransformerChangeListener>(
+        List<TransformerChangeListener> listeners = new ArrayList<>(
                 _transformerChangeListeners);
         for (TransformerChangeListener listener : listeners) {
             listener.onAdd(tjb);
@@ -392,6 +397,9 @@ public final class AnalysisJobBuilder implements Closeable {
         boolean removed = _transformerComponentBuilders.remove(tjb);
         if (removed) {
             tjb.onRemoved();
+
+            // Ajb removal last, so listeners gets triggered
+            onComponentRemoved();
         }
         return this;
     }
@@ -399,17 +407,21 @@ public final class AnalysisJobBuilder implements Closeable {
     public ComponentBuilder addComponent(ComponentDescriptor<?> descriptor,
             Map<ConfiguredPropertyDescriptor, Object> configuredProperties, ComponentRequirement requirement,
             Map<String, String> metadataProperties) {
+        final ComponentBuilder builder;
         if (descriptor instanceof FilterDescriptor) {
-            return addFilter((FilterDescriptor<?, ?>) descriptor, configuredProperties, requirement, metadataProperties);
+            builder =
+                    addFilter((FilterDescriptor<?, ?>) descriptor, configuredProperties, requirement, metadataProperties);
         } else if (descriptor instanceof TransformerDescriptor) {
-            return addTransformer((TransformerDescriptor<?>) descriptor, configuredProperties, requirement,
+            builder = addTransformer((TransformerDescriptor<?>) descriptor, configuredProperties, requirement,
                     metadataProperties);
         } else if (descriptor instanceof AnalyzerDescriptor) {
-            return addAnalyzer((AnalyzerDescriptor<?>) descriptor, configuredProperties, requirement,
+            builder = addAnalyzer((AnalyzerDescriptor<?>) descriptor, configuredProperties, requirement,
                     metadataProperties);
         } else {
             throw new UnsupportedOperationException("Unknown component type: " + descriptor);
         }
+
+        return builder;
     }
 
     public ComponentBuilder addComponent(ComponentDescriptor<?> descriptor) {
@@ -428,13 +440,44 @@ public final class AnalysisJobBuilder implements Closeable {
 
     public ComponentBuilder addComponent(ComponentBuilder builder) {
         if (builder instanceof FilterComponentBuilder) {
-            return addFilter((FilterComponentBuilder<?, ?>) builder);
+            addFilter((FilterComponentBuilder<?, ?>) builder);
         } else if (builder instanceof TransformerComponentBuilder) {
-            return addTransformer((TransformerComponentBuilder<?>) builder);
+            addTransformer((TransformerComponentBuilder<?>) builder);
         } else if (builder instanceof AnalyzerComponentBuilder) {
-            return addAnalyzer((AnalyzerComponentBuilder<?>) builder);
+            addAnalyzer((AnalyzerComponentBuilder<?>) builder);
         } else {
             throw new UnsupportedOperationException("Unknown component type: " + builder);
+        }
+        return builder;
+    }
+
+    private void onComponentAdded() {
+        if(_parentBuilder != null && getComponentCount() == 1){
+            // make a copy since some of the listeners may add additional listeners
+            // which will otherwise cause ConcurrentModificationExceptions
+            List<AnalysisJobChangeListener> listeners = new ArrayList<>(_parentBuilder.getAnalysisJobChangeListeners());
+            for(AnalysisJobChangeListener analysisJobChangeListener : listeners){
+                try {
+                    analysisJobChangeListener.onActivation(this);
+                } catch (Exception e){
+                    logger.warn("A listener failed when trying to inform it of activation", e);
+                }
+            }
+        }
+    }
+
+    private void onComponentRemoved() {
+        if(_parentBuilder != null && getComponentCount() == 0){
+            // make a copy since some of the listeners may add additional listeners
+            // which will otherwise cause ConcurrentModificationExceptions
+            List<AnalysisJobChangeListener> listeners = new ArrayList<>(_parentBuilder.getAnalysisJobChangeListeners());
+            for(AnalysisJobChangeListener analysisJobChangeListener : listeners){
+                try {
+                    analysisJobChangeListener.onDeactivation(this);
+                } catch (Exception e){
+                    logger.warn("A listener failed when trying to inform it of deactivation", e);
+                }
+            }
         }
     }
 
@@ -494,15 +537,16 @@ public final class AnalysisJobBuilder implements Closeable {
 
     public AnalysisJobBuilder removeComponent(ComponentBuilder builder) {
         if (builder instanceof FilterComponentBuilder) {
-            return removeFilter((FilterComponentBuilder<?, ?>) builder);
+            removeFilter((FilterComponentBuilder<?, ?>) builder);
         } else if (builder instanceof TransformerComponentBuilder) {
-            return removeTransformer((TransformerComponentBuilder<?>) builder);
+            removeTransformer((TransformerComponentBuilder<?>) builder);
         } else if (builder instanceof AnalyzerComponentBuilder) {
-            return removeAnalyzer((AnalyzerComponentBuilder<?>) builder);
+            removeAnalyzer((AnalyzerComponentBuilder<?>) builder);
         } else {
             throw new UnsupportedOperationException("Unknown component type: " + builder);
         }
 
+        return this;
     }
 
     public <F extends Filter<C>, C extends Enum<C>> FilterComponentBuilder<F, C> addFilter(Class<F> filterClass) {
@@ -522,7 +566,7 @@ public final class AnalysisJobBuilder implements Closeable {
     public <F extends Filter<C>, C extends Enum<C>> FilterComponentBuilder<F, C> addFilter(
             FilterDescriptor<F, C> descriptor, Map<ConfiguredPropertyDescriptor, Object> configuredProperties,
             ComponentRequirement requirement, Map<String, String> metadataProperties) {
-        final FilterComponentBuilder<F, C> filter = new FilterComponentBuilder<F, C>(this, descriptor);
+        final FilterComponentBuilder<F, C> filter = new FilterComponentBuilder<>(this, descriptor);
         initializeComponentBuilder(filter, configuredProperties, requirement, metadataProperties);
         return addFilter(filter);
     }
@@ -549,7 +593,10 @@ public final class AnalysisJobBuilder implements Closeable {
             fjb.setComponentRequirement(_defaultRequirement);
         }
 
-        List<FilterChangeListener> listeners = new ArrayList<FilterChangeListener>(_filterChangeListeners);
+        // Before triggering component's listeners, so listeners are ready.
+        onComponentAdded();
+
+        List<FilterChangeListener> listeners = new ArrayList<>(_filterChangeListeners);
         for (FilterChangeListener listener : listeners) {
             listener.onAdd(fjb);
         }
@@ -592,6 +639,9 @@ public final class AnalysisJobBuilder implements Closeable {
             }
 
             filterJobBuilder.onRemoved();
+
+            // Ajb removal last, so listeners gets triggered
+            onComponentRemoved();
         }
         return this;
     }
@@ -611,7 +661,7 @@ public final class AnalysisJobBuilder implements Closeable {
     public <A extends Analyzer<?>> AnalyzerComponentBuilder<A> addAnalyzer(AnalyzerDescriptor<A> descriptor,
             Map<ConfiguredPropertyDescriptor, Object> configuredProperties, ComponentRequirement requirement,
             Map<String, String> metadataProperties) {
-        final AnalyzerComponentBuilder<A> analyzerJobBuilder = new AnalyzerComponentBuilder<A>(this, descriptor);
+        final AnalyzerComponentBuilder<A> analyzerJobBuilder = new AnalyzerComponentBuilder<>(this, descriptor);
         initializeComponentBuilder(analyzerJobBuilder, configuredProperties, requirement, metadataProperties);
         return addAnalyzer(analyzerJobBuilder);
     }
@@ -624,9 +674,12 @@ public final class AnalysisJobBuilder implements Closeable {
             analyzerJobBuilder.setComponentRequirement(_defaultRequirement);
         }
 
+        // Before triggering component's listeners, so listeners are ready.
+        onComponentAdded();
+
         // make a copy since some of the listeners may add additional listeners
         // which will otherwise cause ConcurrentModificationExceptions
-        List<AnalyzerChangeListener> listeners = new ArrayList<AnalyzerChangeListener>(_analyzerChangeListeners);
+        List<AnalyzerChangeListener> listeners = new ArrayList<>(_analyzerChangeListeners);
         for (AnalyzerChangeListener listener : listeners) {
             listener.onAdd(analyzerJobBuilder);
         }
@@ -642,10 +695,13 @@ public final class AnalysisJobBuilder implements Closeable {
         return addAnalyzer(descriptor);
     }
 
-    public AnalysisJobBuilder removeAnalyzer(AnalyzerComponentBuilder<?> ajb) {
-        boolean removed = _analyzerComponentBuilders.remove(ajb);
+    public AnalysisJobBuilder removeAnalyzer(AnalyzerComponentBuilder<?> acb) {
+        boolean removed = _analyzerComponentBuilders.remove(acb);
         if (removed) {
-            ajb.onRemoved();
+            acb.onRemoved();
+
+            // Ajb removal last, so listeners gets triggered
+            onComponentRemoved();
         }
         return this;
     }
@@ -755,7 +811,7 @@ public final class AnalysisJobBuilder implements Closeable {
 
         final AnalysisJobImmutabilizer immutabilizer = new AnalysisJobImmutabilizer();
 
-        final Collection<FilterJob> filterJobs = new LinkedList<FilterJob>();
+        final Collection<FilterJob> filterJobs = new LinkedList<>();
         for (final FilterComponentBuilder<?, ?> fjb : _filterComponentBuilders) {
             try {
                 final FilterJob filterJob = fjb.toFilterJob(validate, immutabilizer);
@@ -766,7 +822,7 @@ public final class AnalysisJobBuilder implements Closeable {
             }
         }
 
-        final Collection<TransformerJob> transformerJobs = new LinkedList<TransformerJob>();
+        final Collection<TransformerJob> transformerJobs = new LinkedList<>();
         for (final TransformerComponentBuilder<?> tjb : _transformerComponentBuilders) {
             try {
                 final TransformerJob transformerJob = tjb.toTransformerJob(validate, immutabilizer);
@@ -777,13 +833,11 @@ public final class AnalysisJobBuilder implements Closeable {
             }
         }
 
-        final Collection<AnalyzerJob> analyzerJobs = new LinkedList<AnalyzerJob>();
+        final Collection<AnalyzerJob> analyzerJobs = new LinkedList<>();
         for (final AnalyzerComponentBuilder<?> ajb : _analyzerComponentBuilders) {
             try {
                 final AnalyzerJob[] analyzerJob = ajb.toAnalyzerJobs(validate, immutabilizer);
-                for (AnalyzerJob job : analyzerJob) {
-                    analyzerJobs.add(job);
-                }
+                Collections.addAll(analyzerJobs, analyzerJob);
             } catch (IllegalArgumentException e) {
                 throw new IllegalStateException("Could not create analyzer job from builder: " + ajb + ", ("
                         + e.getMessage() + ")", e);
@@ -924,12 +978,11 @@ public final class AnalysisJobBuilder implements Closeable {
             }
 
             for (AnalyzerComponentBuilder<?> ajb : _analyzerComponentBuilders) {
-                if (ajb instanceof AnalyzerComponentBuilder<?>) {
-                    AnalyzerComponentBuilder<?> rpajb = (AnalyzerComponentBuilder<?>) ajb;
-                    if (rpajb.getComponentRequirement() == null) {
-                        Table foundTable = getOriginatingTable(rpajb);
+                if (ajb != null) {
+                    if (ajb.getComponentRequirement() == null) {
+                        Table foundTable = getOriginatingTable(ajb);
                         if (requiredTable == null || requiredTable.equals(foundTable)) {
-                            result.add(rpajb);
+                            result.add(ajb);
                         }
                     }
                 }
@@ -983,11 +1036,10 @@ public final class AnalysisJobBuilder implements Closeable {
             final Set<Object> excludedSet = sourceColumnFinder.findAllSourceJobs(defaultRequirement);
 
             for (AnalyzerComponentBuilder<?> ajb : _analyzerComponentBuilders) {
-                if (ajb instanceof AnalyzerComponentBuilder) {
-                    final AnalyzerComponentBuilder<?> analyzerJobBuilder = (AnalyzerComponentBuilder<?>) ajb;
-                    final ComponentRequirement requirement = analyzerJobBuilder.getComponentRequirement();
+                if (ajb != null) {
+                    final ComponentRequirement requirement = ajb.getComponentRequirement();
                     if (requirement == null) {
-                        analyzerJobBuilder.setComponentRequirement(defaultRequirement);
+                        ajb.setComponentRequirement(defaultRequirement);
                     }
                 }
             }
@@ -1036,8 +1088,10 @@ public final class AnalysisJobBuilder implements Closeable {
         return _filterChangeListeners;
     }
 
+    public List<AnalysisJobChangeListener> getAnalysisJobChangeListeners() { return _analysisJobChangeListeners; }
+
     public List<Table> getSourceTables() {
-        final List<Table> tables = new ArrayList<Table>();
+        final List<Table> tables = new ArrayList<>();
         final List<MetaModelInputColumn> columns = getSourceColumns();
         for (MetaModelInputColumn column : columns) {
             Table table = column.getPhysicalColumn().getTable();
@@ -1060,7 +1114,7 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void removeAllSourceColumns() {
-        final List<MetaModelInputColumn> sourceColumns = new ArrayList<MetaModelInputColumn>(_sourceColumns);
+        final List<MetaModelInputColumn> sourceColumns = new ArrayList<>(_sourceColumns);
         for (MetaModelInputColumn inputColumn : sourceColumns) {
             removeSourceColumn(inputColumn);
         }
@@ -1068,7 +1122,7 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void removeAllAnalyzers() {
-        final List<AnalyzerComponentBuilder<?>> analyzers = new ArrayList<AnalyzerComponentBuilder<?>>(
+        final List<AnalyzerComponentBuilder<?>> analyzers = new ArrayList<>(
                 _analyzerComponentBuilders);
         for (AnalyzerComponentBuilder<?> ajb : analyzers) {
             removeAnalyzer(ajb);
@@ -1077,7 +1131,7 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void removeAllTransformers() {
-        final List<TransformerComponentBuilder<?>> transformers = new ArrayList<TransformerComponentBuilder<?>>(
+        final List<TransformerComponentBuilder<?>> transformers = new ArrayList<>(
                 _transformerComponentBuilders);
         for (TransformerComponentBuilder<?> transformerJobBuilder : transformers) {
             removeTransformer(transformerJobBuilder);
@@ -1086,7 +1140,7 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void removeAllFilters() {
-        final List<FilterComponentBuilder<?, ?>> filters = new ArrayList<FilterComponentBuilder<?, ?>>(
+        final List<FilterComponentBuilder<?, ?>> filters = new ArrayList<>(
                 _filterComponentBuilders);
         for (FilterComponentBuilder<?, ?> filterJobBuilder : filters) {
             removeFilter(filterJobBuilder);
@@ -1205,12 +1259,8 @@ public final class AnalysisJobBuilder implements Closeable {
                 }
 
                 final Set<Object> sourceComponents = finder.findAllSourceJobs(origin);
-                if (sourceComponents.contains(componentBuilder)) {
-                    // exclude columns that depend
-                    return false;
-                }
+                return !sourceComponents.contains(componentBuilder);
 
-                return true;
             }
         });
 
@@ -1235,5 +1285,17 @@ public final class AnalysisJobBuilder implements Closeable {
         }
 
         return builder;
+    }
+
+    public List<AnalysisJobBuilder> getConsumedOutputDataStreamsJobBuilders(){
+        List<AnalysisJobBuilder> consumedOutputDataStreamJobBuilders = new ArrayList<>();
+        for(ComponentBuilder builder : getComponentBuilders()){
+            for(OutputDataStream outputDataStream : builder.getOutputDataStreams()){
+                if(builder.isOutputDataStreamConsumed(outputDataStream)){
+                    consumedOutputDataStreamJobBuilders.add(builder.getOutputDataStreamJobBuilder(outputDataStream));
+                }
+            }
+        }
+        return consumedOutputDataStreamJobBuilders;
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1072,23 +1072,85 @@ public final class AnalysisJobBuilder implements Closeable {
         return _defaultRequirement;
     }
 
+    public void addSourceColumnChangeListener(SourceColumnChangeListener sourceColumnChangeListener){
+        _sourceColumnListeners.add(sourceColumnChangeListener);
+    }
+
+    public void removeSourceColumnChangeListener(SourceColumnChangeListener sourceColumnChangeListener){
+        _sourceColumnListeners.remove(sourceColumnChangeListener);
+    }
+
+    public void addTransformerChangeListener(TransformerChangeListener transformerChangeListener){
+        _transformerChangeListeners.add(transformerChangeListener);
+    }
+
+    public void removeTransformerChangeListener(TransformerChangeListener transformerChangeListener){
+        _transformerChangeListeners.remove(transformerChangeListener);
+    }
+
+    public void addAnalyzerChangeListener(AnalyzerChangeListener analyzerChangeListener){
+        _analyzerChangeListeners.add(analyzerChangeListener);
+    }
+
+    public void removeAnalyzerChangeListener(AnalyzerChangeListener analyzerChangeListener){
+        _analyzerChangeListeners.remove(analyzerChangeListener);
+    }
+
+    public void addFilterChangeListener(FilterChangeListener filterChangeListener){
+        _filterChangeListeners.add(filterChangeListener);
+    }
+
+    public void removeFilterChangeListener(FilterChangeListener filterChangeListener){
+        _filterChangeListeners.remove(filterChangeListener);
+    }
+
+    public void addAnalysisJobChangeListener(AnalysisJobChangeListener analysisJobChangeListener){
+        _analysisJobChangeListeners.add(analysisJobChangeListener);
+    }
+
+    public void removeAnalysisJobChangeListener(AnalysisJobChangeListener analysisJobChangeListener){
+        _analysisJobChangeListeners.remove(analysisJobChangeListener);
+    }
+
+    /**
+     * @deprecated Use {@link #addSourceColumnChangeListener(SourceColumnChangeListener)}
+     * and {@link #removeSourceColumnChangeListener(SourceColumnChangeListener)}
+     */
+    @Deprecated
     public List<SourceColumnChangeListener> getSourceColumnListeners() {
         return _sourceColumnListeners;
     }
 
+    /**
+     * @deprecated Use {@link #addAnalyzerChangeListener(AnalyzerChangeListener)}
+     * and {@link #removeAnalyzerChangeListener(AnalyzerChangeListener)}
+     */
+    @Deprecated
     public List<AnalyzerChangeListener> getAnalyzerChangeListeners() {
         return _analyzerChangeListeners;
     }
 
+    /**
+     * @deprecated Use {@link #addTransformerChangeListener(TransformerChangeListener)}
+     * and {@link #removeTransformerChangeListener(TransformerChangeListener)}
+     */
+    @Deprecated
     public List<TransformerChangeListener> getTransformerChangeListeners() {
         return _transformerChangeListeners;
     }
 
+    /**
+     * @deprecated Use {@link #addFilterChangeListener(FilterChangeListener)}
+     * and {@link #removeFilterChangeListener(FilterChangeListener)}
+     */
+    @Deprecated
     public List<FilterChangeListener> getFilterChangeListeners() {
         return _filterChangeListeners;
     }
 
-    public List<AnalysisJobChangeListener> getAnalysisJobChangeListeners() { return _analysisJobChangeListeners; }
+    private List<AnalysisJobChangeListener> getAnalysisJobChangeListeners() {
+        return _analysisJobChangeListeners;
+    }
 
     public List<Table> getSourceTables() {
         final List<Table> tables = new ArrayList<>();
@@ -1287,6 +1349,9 @@ public final class AnalysisJobBuilder implements Closeable {
         return builder;
     }
 
+    /**
+     * This gets all job builders from consumed {@link OutputDataStream}s. This only pertains to immediate children.
+     */
     public List<AnalysisJobBuilder> getConsumedOutputDataStreamsJobBuilders(){
         List<AnalysisJobBuilder> consumedOutputDataStreamJobBuilders = new ArrayList<>();
         for(ComponentBuilder builder : getComponentBuilders()){

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobChangeListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobChangeListener.java
@@ -1,0 +1,36 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.job.builder;
+
+public interface AnalysisJobChangeListener {
+    /**
+     * Invoked when a {@link AnalysisJobBuilder} gets the first component, and is therefore considered active.
+     *
+     * @param builder
+     */
+    void onActivation(AnalysisJobBuilder builder);
+
+    /**
+     * Invoked when a {@link AnalysisJobBuilder} has the last component removed, and is therefore considered deactivated.
+     *
+     * @param builder
+     */
+    void onDeactivation(AnalysisJobBuilder builder);
+}

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
@@ -94,8 +94,9 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
      * @return
      */
     private List<AnalyzerChangeListener> getAllListeners() {
+        @SuppressWarnings("deprecation")
         List<AnalyzerChangeListener> globalChangeListeners = getAnalysisJobBuilder().getAnalyzerChangeListeners();
-        List<AnalyzerChangeListener> list = new ArrayList<AnalyzerChangeListener>(globalChangeListeners.size()
+        List<AnalyzerChangeListener> list = new ArrayList<>(globalChangeListeners.size()
                 + _localChangeListeners.size());
         list.addAll(globalChangeListeners);
         list.addAll(_localChangeListeners);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/FilterComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/FilterComponentBuilder.java
@@ -105,6 +105,7 @@ public final class FilterComponentBuilder<F extends Filter<C>, C extends Enum<C>
      * @return
      */
     private List<FilterChangeListener> getAllListeners() {
+        @SuppressWarnings("deprecation")
         List<FilterChangeListener> globalChangeListeners = getAnalysisJobBuilder().getFilterChangeListeners();
         List<FilterChangeListener> list = new ArrayList<FilterChangeListener>(globalChangeListeners.size()
                 + _localChangeListeners.size());

--- a/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
@@ -206,6 +206,7 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
      * @return
      */
     private List<TransformerChangeListener> getAllListeners() {
+        @SuppressWarnings("deprecation")
         List<TransformerChangeListener> globalChangeListeners = getAnalysisJobBuilder().getTransformerChangeListeners();
 
         List<TransformerChangeListener> list = new ArrayList<TransformerChangeListener>(globalChangeListeners.size()

--- a/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/builder/AnalysisJobBuilderTest.java
@@ -27,75 +27,90 @@ import junit.framework.TestCase;
 
 import org.apache.metamodel.schema.MutableColumn;
 import org.apache.metamodel.schema.MutableTable;
+import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
 import org.datacleaner.data.MetaModelInputColumn;
+import org.datacleaner.data.MutableInputColumn;
+import org.datacleaner.test.MockAnalyzer;
 import org.datacleaner.test.MockFilter;
 import org.datacleaner.test.MockFilter.Category;
 import org.datacleaner.test.MockOutputDataStreamAnalyzer;
 import org.datacleaner.test.MockTransformer;
 import org.datacleaner.test.mock.MockDatastore;
+import org.easymock.EasyMock;
+
+import static org.easymock.EasyMock.*;
 
 public class AnalysisJobBuilderTest extends TestCase {
+    private MutableTable _table;
+    private MutableColumn _column;
+    private AnalysisJobBuilder _ajb;
+    private MockDatastore _datastore;
+
+    @Override
+    protected void setUp() throws Exception {
+        _table = new MutableTable("table");
+        _column = new MutableColumn("foo").setTable(_table);
+        _table.addColumn(_column);
+        _ajb = new AnalysisJobBuilder(new DataCleanerConfigurationImpl());
+        _datastore = new MockDatastore();
+        _ajb.addSourceColumn(new MetaModelInputColumn(_column));
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        _ajb.close();
+    }
 
     public void testGetAvailableInputColumnsForComponentPreventsCyclicDependencies() throws Exception {
-        final MutableTable table = new MutableTable("table");
-        final MutableColumn column = new MutableColumn("foo").setTable(table);
-        table.addColumn(column);
+        final TransformerComponentBuilder<MockTransformer> transformer1 = _ajb.addTransformer(MockTransformer.class);
+        transformer1.addInputColumn(_ajb.getSourceColumnByName("foo"));
+        transformer1.getOutputColumns().get(0).setName("out1");
 
-        try (AnalysisJobBuilder ajb = new AnalysisJobBuilder(new DataCleanerConfigurationImpl())) {
-            final MockDatastore datastore = new MockDatastore();
-            ajb.setDatastore(datastore);
-            ajb.addSourceColumn(new MetaModelInputColumn(column));
+        assertEquals("[TransformedInputColumn[id=trans-0001-0002,name=out1]]", transformer1.getOutputColumns()
+                .toString());
+        assertEquals("[MetaModelInputColumn[table.foo]]", _ajb.getAvailableInputColumns(transformer1).toString());
 
-            final TransformerComponentBuilder<MockTransformer> transformer1 = ajb.addTransformer(MockTransformer.class);
-            transformer1.addInputColumn(ajb.getSourceColumnByName("foo"));
-            transformer1.getOutputColumns().get(0).setName("out1");
+        final TransformerComponentBuilder<MockTransformer> transformer2 = _ajb.addTransformer(MockTransformer.class);
+        transformer2.addInputColumn(transformer1.getOutputColumns().get(0));
+        transformer2.getOutputColumns().get(0).setName("out2");
 
-            assertEquals("[TransformedInputColumn[id=trans-0001-0002,name=out1]]", transformer1.getOutputColumns()
-                    .toString());
-            assertEquals("[MetaModelInputColumn[table.foo]]", ajb.getAvailableInputColumns(transformer1).toString());
+        assertEquals("[MetaModelInputColumn[table.foo]]", _ajb.getAvailableInputColumns(transformer1).toString());
+        assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", _ajb
+                .getAvailableInputColumns(transformer2).toString());
 
-            final TransformerComponentBuilder<MockTransformer> transformer2 = ajb.addTransformer(MockTransformer.class);
-            transformer2.addInputColumn(transformer1.getOutputColumns().get(0));
-            transformer2.getOutputColumns().get(0).setName("out2");
+        final TransformerComponentBuilder<MockTransformer> transformer3 = _ajb.addTransformer(MockTransformer.class);
+        assertEquals("[MetaModelInputColumn[table.foo]]", _ajb.getAvailableInputColumns(transformer1).toString());
+        assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", _ajb
+                .getAvailableInputColumns(transformer2).toString());
+        assertEquals(
+                "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0003-0004,name=out2]]",
+                _ajb.getAvailableInputColumns(transformer3).toString());
 
-            assertEquals("[MetaModelInputColumn[table.foo]]", ajb.getAvailableInputColumns(transformer1).toString());
-            assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", ajb
-                    .getAvailableInputColumns(transformer2).toString());
+        transformer3.addInputColumn(_ajb.getSourceColumns().get(0));
+        transformer3.getOutputColumns().get(0).setName("out3");
 
-            final TransformerComponentBuilder<MockTransformer> transformer3 = ajb.addTransformer(MockTransformer.class);
-            assertEquals("[MetaModelInputColumn[table.foo]]", ajb.getAvailableInputColumns(transformer1).toString());
-            assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", ajb
-                    .getAvailableInputColumns(transformer2).toString());
-            assertEquals(
-                    "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0003-0004,name=out2]]",
-                    ajb.getAvailableInputColumns(transformer3).toString());
+        assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0005-0006,name=out3]]", _ajb
+                .getAvailableInputColumns(transformer1).toString());
+        assertEquals(
+                "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
+                _ajb.getAvailableInputColumns(transformer2).toString());
+        assertEquals(
+                "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0003-0004,name=out2]]",
+                _ajb.getAvailableInputColumns(transformer3).toString());
 
-            transformer3.addInputColumn(ajb.getSourceColumns().get(0));
-            transformer3.getOutputColumns().get(0).setName("out3");
+        transformer2.clearInputColumns();
+        transformer2.addInputColumn(transformer3.getOutputColumns().get(0));
 
-            assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0005-0006,name=out3]]", ajb
-                    .getAvailableInputColumns(transformer1).toString());
-            assertEquals(
-                    "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
-                    ajb.getAvailableInputColumns(transformer2).toString());
-            assertEquals(
-                    "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0003-0004,name=out2]]",
-                    ajb.getAvailableInputColumns(transformer3).toString());
-
-            transformer2.clearInputColumns();
-            transformer2.addInputColumn(transformer3.getOutputColumns().get(0));
-
-            assertEquals(
-                    "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0003-0004,name=out2], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
-                    ajb.getAvailableInputColumns(transformer1).toString());
-            assertEquals(
-                    "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
-                    ajb.getAvailableInputColumns(transformer2).toString());
-            assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", ajb
-                    .getAvailableInputColumns(transformer3).toString());
-        }
+        assertEquals(
+                "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0003-0004,name=out2], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
+                _ajb.getAvailableInputColumns(transformer1).toString());
+        assertEquals(
+                "[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1], TransformedInputColumn[id=trans-0005-0006,name=out3]]",
+                _ajb.getAvailableInputColumns(transformer2).toString());
+        assertEquals("[MetaModelInputColumn[table.foo], TransformedInputColumn[id=trans-0001-0002,name=out1]]", _ajb
+                .getAvailableInputColumns(transformer3).toString());
     }
 
     /**
@@ -104,129 +119,194 @@ public class AnalysisJobBuilderTest extends TestCase {
      * only be set on the succeeding (not preceeding) transformer.
      */
     public void testSetDefaultRequirementNonCyclic() throws Exception {
-        MutableTable table = new MutableTable("table");
-        MutableColumn column = new MutableColumn("foo").setTable(table);
-        table.addColumn(column);
+        MockDatastore datastore = new MockDatastore();
+        _ajb.setDatastore(datastore);
+        _ajb.addSourceColumn(new MetaModelInputColumn(_column));
 
-        // set up
-        try (AnalysisJobBuilder ajb = new AnalysisJobBuilder(new DataCleanerConfigurationImpl())) {
-            MockDatastore datastore = new MockDatastore();
-            ajb.setDatastore(datastore);
-            ajb.addSourceColumn(new MetaModelInputColumn(column));
+        // add a transformer
+        TransformerComponentBuilder<MockTransformer> tjb1 = _ajb.addTransformer(MockTransformer.class);
+        tjb1.addInputColumn(_ajb.getSourceColumns().get(0));
+        assertTrue(tjb1.isConfigured(true));
 
-            // add a transformer
-            TransformerComponentBuilder<MockTransformer> tjb1 = ajb.addTransformer(MockTransformer.class);
-            tjb1.addInputColumn(ajb.getSourceColumns().get(0));
-            assertTrue(tjb1.isConfigured(true));
+        // add filter
+        FilterComponentBuilder<MockFilter, Category> filter = _ajb.addFilter(MockFilter.class);
+        filter.addInputColumn(tjb1.getOutputColumns().get(0));
+        filter.getComponentInstance().setSomeEnum(Category.VALID);
+        filter.getComponentInstance().setSomeFile(new File("."));
+        assertTrue(filter.isConfigured(true));
 
-            // add filter
-            FilterComponentBuilder<MockFilter, Category> filter = ajb.addFilter(MockFilter.class);
-            filter.addInputColumn(tjb1.getOutputColumns().get(0));
-            filter.getComponentInstance().setSomeEnum(Category.VALID);
-            filter.getComponentInstance().setSomeFile(new File("."));
-            assertTrue(filter.isConfigured(true));
+        // set default requirement
+        _ajb.setDefaultRequirement(filter, Category.VALID);
 
-            // set default requirement
-            ajb.setDefaultRequirement(filter, Category.VALID);
+        // add another transformer
+        TransformerComponentBuilder<MockTransformer> tjb2 = _ajb.addTransformer(MockTransformer.class);
+        tjb2.addInputColumn(tjb1.getOutputColumns().get(0));
+        assertTrue(tjb2.isConfigured(true));
 
-            // add another transformer
-            TransformerComponentBuilder<MockTransformer> tjb2 = ajb.addTransformer(MockTransformer.class);
-            tjb2.addInputColumn(tjb1.getOutputColumns().get(0));
-            assertTrue(tjb2.isConfigured(true));
+        // assertions
+        assertEquals("Mock filter=VALID", tjb2.getComponentRequirement().toString());
+        assertEquals(null, filter.getComponentRequirement());
+        assertEquals(null, tjb1.getComponentRequirement());
 
-            // assertions
-            assertEquals("Mock filter=VALID", tjb2.getComponentRequirement().toString());
-            assertEquals(null, filter.getComponentRequirement());
-            assertEquals(null, tjb1.getComponentRequirement());
-
-            final Collection<ComponentBuilder> componentBuilders = ajb.getComponentBuilders();
-            assertEquals(
-                    "[FilterComponentBuilder[filter=Mock filter,inputColumns=[TransformedInputColumn[id=trans-0001-0002,name=mock output]]], "
-                            + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[MetaModelInputColumn[table.foo]]], "
-                            + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[TransformedInputColumn[id=trans-0001-0002,name=mock output]]]]",
-                    componentBuilders.toString());
-        }
+        final Collection<ComponentBuilder> componentBuilders = _ajb.getComponentBuilders();
+        assertEquals(
+                "[FilterComponentBuilder[filter=Mock filter,inputColumns=[TransformedInputColumn[id=trans-0001-0002,name=mock output]]], "
+                        + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[MetaModelInputColumn[table.foo]]], "
+                        + "TransformerComponentBuilder[transformer=Mock transformer,inputColumns=[TransformedInputColumn[id=trans-0001-0002,name=mock output]]]]",
+                componentBuilders.toString());
     }
 
     public void testGetAllJobBuilders() {
-        MutableTable table = new MutableTable("table");
-        MutableColumn column = new MutableColumn("foo").setTable(table);
-        table.addColumn(column);
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0 =
+                _ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer0.setName("analyzer0");
+        analyzer0.addInputColumn(_ajb.getSourceColumns().get(0));
 
-        // set up
-        try (final AnalysisJobBuilder ajb = new AnalysisJobBuilder(new DataCleanerConfigurationImpl())) {
-            final MockDatastore datastore = new MockDatastore();
-            ajb.setDatastore(datastore);
-            ajb.addSourceColumn(new MetaModelInputColumn(column));
+        final List<OutputDataStream> analyzer0OutputDataStreams = analyzer0.getOutputDataStreams();
 
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0 =
-                    ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer0.setName("analyzer0");
-            analyzer0.addInputColumn(ajb.getSourceColumns().get(0));
+        final AnalysisJobBuilder analyzer0DataStream0JobBuilder =
+                analyzer0.getOutputDataStreamJobBuilder(analyzer0OutputDataStreams.get(0));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0 =
+                analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer0Analyzer0.setName("analyzer0Analyzer0");
+        analyzer0Analyzer0.addInputColumn(analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
 
-            final List<OutputDataStream> analyzer0OutputDataStreams = analyzer0.getOutputDataStreams();
+        final List<OutputDataStream> analyzer0Analyzer0OutputDataStreams =
+                analyzer0Analyzer0.getOutputDataStreams();
 
-            final AnalysisJobBuilder analyzer0DataStream0JobBuilder =
-                    analyzer0.getOutputDataStreamJobBuilder(analyzer0OutputDataStreams.get(0));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0 =
-                    analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer0Analyzer0.setName("analyzer0Analyzer0");
-            analyzer0Analyzer0.addInputColumn(analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
+        final AnalysisJobBuilder analyzer0Analyzer0DataStream0JobBuilder =
+                analyzer0Analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(0));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0Analyzer0 =
+                analyzer0Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer0Analyzer0Analyzer0.setName("analyzer0Analyzer0Analyzer0");
+        analyzer0Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
 
-            final List<OutputDataStream> analyzer0Analyzer0OutputDataStreams =
-                    analyzer0Analyzer0.getOutputDataStreams();
+        final AnalysisJobBuilder analyzer0DataStream1JobBuilder =
+                analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(1));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer1 =
+                analyzer0DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer0Analyzer1.setName("analyzer0Analyzer1");
+        analyzer0Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
 
-            final AnalysisJobBuilder analyzer0Analyzer0DataStream0JobBuilder =
-                    analyzer0Analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(0));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer0Analyzer0 =
-                    analyzer0Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer0Analyzer0Analyzer0.setName("analyzer0Analyzer0Analyzer0");
-            analyzer0Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1 =
+                _ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer1.setName("analyzer1");
+        analyzer1.addInputColumn(_ajb.getSourceColumns().get(0));
 
-            final AnalysisJobBuilder analyzer0DataStream1JobBuilder =
-                    analyzer0.getOutputDataStreamJobBuilder(analyzer0Analyzer0OutputDataStreams.get(1));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0Analyzer1 =
-                    analyzer0DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer0Analyzer1.setName("analyzer0Analyzer1");
-            analyzer0Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
+        final List<OutputDataStream> analyzer1OutputDataStreams = analyzer1.getOutputDataStreams();
 
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1 =
-                    ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer1.setName("analyzer1");
-            analyzer1.addInputColumn(ajb.getSourceColumns().get(0));
+        final AnalysisJobBuilder analyzer1DataStream0JobBuilder =
+                analyzer1.getOutputDataStreamJobBuilder(analyzer1OutputDataStreams.get(0));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0 =
+                analyzer1DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer1Analyzer0.setName("analyzer1Analyzer0");
+        analyzer1Analyzer0.addInputColumn(analyzer1DataStream0JobBuilder.getSourceColumns().get(0));
 
-            final List<OutputDataStream> analyzer1OutputDataStreams = analyzer1.getOutputDataStreams();
+        final List<OutputDataStream> analyzer1Analyzer0OutputDataStreams =
+                analyzer1Analyzer0.getOutputDataStreams();
 
-            final AnalysisJobBuilder analyzer1DataStream0JobBuilder =
-                    analyzer1.getOutputDataStreamJobBuilder(analyzer1OutputDataStreams.get(0));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0 =
-                    analyzer1DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer1Analyzer0.setName("analyzer1Analyzer0");
-            analyzer1Analyzer0.addInputColumn(analyzer1DataStream0JobBuilder.getSourceColumns().get(0));
+        final AnalysisJobBuilder analyzer1Analyzer0DataStream0JobBuilder =
+                analyzer1Analyzer0.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(0));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0Analyzer0 =
+                analyzer1Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer1Analyzer0Analyzer0.setName("analyzer1Analyzer0Analyzer0");
+        analyzer1Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
 
-            final List<OutputDataStream> analyzer1Analyzer0OutputDataStreams =
-                    analyzer1Analyzer0.getOutputDataStreams();
+        final AnalysisJobBuilder analyzer1DataStream1JobBuilder =
+                analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(1));
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer1 =
+                analyzer1DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer1Analyzer1.setName("analyzer1Analyzer1");
+        analyzer1Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
 
-            final AnalysisJobBuilder analyzer1Analyzer0DataStream0JobBuilder =
-                    analyzer1Analyzer0.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(0));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer0Analyzer0 =
-                    analyzer1Analyzer0DataStream0JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer1Analyzer0Analyzer0.setName("analyzer1Analyzer0Analyzer0");
-            analyzer1Analyzer0Analyzer0.addInputColumn(analyzer0Analyzer0DataStream0JobBuilder.getSourceColumns().get(0));
-
-            final AnalysisJobBuilder analyzer1DataStream1JobBuilder =
-                    analyzer1.getOutputDataStreamJobBuilder(analyzer1Analyzer0OutputDataStreams.get(1));
-            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1Analyzer1 =
-                    analyzer1DataStream1JobBuilder.addAnalyzer(MockOutputDataStreamAnalyzer.class);
-            analyzer1Analyzer1.setName("analyzer1Analyzer1");
-            analyzer1Analyzer1.addInputColumn(analyzer0DataStream1JobBuilder.getSourceColumns().get(0));
-
-
-            // Any random analyzer should work:
-            assertEquals(ajb, analyzer1Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
-            assertEquals(ajb, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
-            assertEquals(ajb, analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
-            assertEquals(ajb, analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
-        }
+        // Any random analyzer should work:
+        assertEquals(_ajb, analyzer1Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+        assertEquals(_ajb, analyzer0Analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+        assertEquals(_ajb, analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
+        assertEquals(_ajb, analyzer0Analyzer0.getAnalysisJobBuilder().getRootJobBuilder());
     }
+
+    public void testChildOutputDataStreamListeners() {
+        // Set up expectations for the listeners
+        final AnalysisJobChangeListener mockedAnalysisJobChangeListener =  mock(AnalysisJobChangeListener.class);
+        mockedAnalysisJobChangeListener.onActivation(anyObject(AnalysisJobBuilder.class));
+        expectLastCall().times(3);
+        mockedAnalysisJobChangeListener.onDeactivation(anyObject(AnalysisJobBuilder.class));
+        expectLastCall().times(3);
+
+        final AnalyzerChangeListener analyzerChangeListener = mock(AnalyzerChangeListener.class);
+        analyzerChangeListener.onAdd(anyObject(AnalyzerComponentBuilder.class));
+        expectLastCall().times(2);
+        analyzerChangeListener.onRemove(anyObject(AnalyzerComponentBuilder.class));
+        expectLastCall().times(2);
+        analyzerChangeListener.onConfigurationChanged(anyObject(AnalyzerComponentBuilder.class));
+        expectLastCall().atLeastOnce();
+
+        final TransformerChangeListener transformerChangeListener = mock(TransformerChangeListener.class);
+        transformerChangeListener.onAdd(anyObject(TransformerComponentBuilder.class));
+        transformerChangeListener.onRemove(anyObject(TransformerComponentBuilder.class));
+        transformerChangeListener.onOutputChanged(anyObject(TransformerComponentBuilder.class), EasyMock.<List<MutableInputColumn<?>>> anyObject());
+        expectLastCall().times(2); // Both configuration and removal will trigger this
+        transformerChangeListener.onConfigurationChanged(anyObject(TransformerComponentBuilder.class));
+        expectLastCall().times(1);
+
+        final FilterChangeListener filterChangeListener = mock(FilterChangeListener.class);
+        filterChangeListener.onAdd(anyObject(FilterComponentBuilder.class));
+        filterChangeListener.onRemove(anyObject(FilterComponentBuilder.class));
+        filterChangeListener.onConfigurationChanged(anyObject(FilterComponentBuilder.class));
+
+
+        replay(mockedAnalysisJobChangeListener, analyzerChangeListener, transformerChangeListener, filterChangeListener);
+        final AnalysisJobChangeListener realAnalysisJobChangeListener = new AnalysisJobChangeListener() {
+            @Override
+            public void onActivation(final AnalysisJobBuilder builder) {
+                builder.addAnalysisJobChangeListener(this);
+                builder.addAnalysisJobChangeListener(mockedAnalysisJobChangeListener);
+                builder.addAnalyzerChangeListener(analyzerChangeListener);
+                builder.addTransformerChangeListener(transformerChangeListener);
+                builder.addFilterChangeListener(filterChangeListener);
+            }
+
+            @Override
+            public void onDeactivation(final AnalysisJobBuilder builder) {
+                builder.removeAnalysisJobChangeListener(this);
+                builder.removeAnalysisJobChangeListener(mockedAnalysisJobChangeListener);
+                builder.removeAnalyzerChangeListener(analyzerChangeListener);
+                builder.removeTransformerChangeListener(transformerChangeListener);
+                builder.removeFilterChangeListener(filterChangeListener);
+            }
+        };
+
+        realAnalysisJobChangeListener.onActivation(_ajb);
+
+        final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer0 =
+                _ajb.addAnalyzer(MockOutputDataStreamAnalyzer.class);
+        analyzer0.setName("analyzer0");
+        analyzer0.addInputColumn(_ajb.getSourceColumns().get(0));
+        final List<OutputDataStream> analyzer0OutputDataStreams = analyzer0.getOutputDataStreams();
+        final AnalysisJobBuilder childAnalysisJobBuilder =
+                analyzer0.getOutputDataStreamJobBuilder(analyzer0OutputDataStreams.get(0));
+
+        final AnalyzerComponentBuilder<MockAnalyzer> childAnalyzer =
+                childAnalysisJobBuilder.addAnalyzer(MockAnalyzer.class);
+        childAnalyzer.setName("childAnalyzer");
+        childAnalyzer.addInputColumn(childAnalysisJobBuilder.getSourceColumns().get(0));
+        childAnalysisJobBuilder.removeAllAnalyzers();
+
+        final TransformerComponentBuilder<MockTransformer> childTransformer =
+                childAnalysisJobBuilder.addTransformer(MockTransformer.class);
+        childTransformer.setName("childTransformer");
+        childTransformer.addInputColumn(childAnalysisJobBuilder.getSourceColumns().get(0));
+        childAnalysisJobBuilder.removeAllTransformers();
+
+        final FilterComponentBuilder<MockFilter, Category> childFilter =
+                childAnalysisJobBuilder.addFilter(MockFilter.class);
+        childFilter.setName("childFilter");
+        childFilter.addInputColumn(childAnalysisJobBuilder.getSourceColumns().get(0));
+        childAnalysisJobBuilder.removeAllFilters();
+
+        _ajb.removeAllAnalyzers();
+        verify(mockedAnalysisJobChangeListener, analyzerChangeListener, transformerChangeListener, filterChangeListener);
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<junit.version>4.12</junit.version>
 		<hadoop.version>2.7.1</hadoop.version>
 		<spark.version>1.4.1</spark.version>
-		<easymock.version>3.3.1</easymock.version>
+		<easymock.version>3.4</easymock.version>
 		<httpcomponents.version>4.4.1</httpcomponents.version>
 		<guava.version>16.0.1</guava.version>
 		<curator.version>2.6.0</curator.version>


### PR DESCRIPTION
This creates a new listener for AnalysisJobBuilder changes, which is used for propagating listeners to newly consumed AnalysisJobBuilders.

Fixes #594 
Fixes #580