### PR TITLE
Feature/647 value dist reducer

### DIFF
--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/GroupedValueDistributionResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/GroupedValueDistributionResult.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.result.AnnotatedRowsResult;
 import org.datacleaner.result.GroupedValueCountingAnalyzerResult;
-import org.datacleaner.result.ValueFrequency;
 import org.datacleaner.result.ValueCountingAnalyzerResult;
+import org.datacleaner.result.ValueFrequency;
 
 /**
  * Represents the result of the {@link ValueDistributionAnalyzer}.
@@ -65,32 +65,44 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public Integer getDistinctCount() {
-        return getSingleValueDistributionResult().getDistinctCount();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return -1;
     }
 
     @Override
     public int getNullCount() {
-        return getSingleValueDistributionResult().getNullCount();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return -1;
     }
 
     @Override
     public int getTotalCount() {
-        return getSingleValueDistributionResult().getTotalCount();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return -1;
     }
 
     @Override
     public Integer getCount(String value) {
-        return getSingleValueDistributionResult().getCount(value);
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return -1;
     }
 
     @Override
     public Integer getUniqueCount() {
-        return getSingleValueDistributionResult().getUniqueCount();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return -1;
     }
 
     @Override
     public Collection<ValueFrequency> getValueCounts() {
-        return getSingleValueDistributionResult().getValueCounts();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return null;
     }
 
     @Override
@@ -126,12 +138,16 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public AnnotatedRowsResult getAnnotatedRowsForValue(String value) {
-        return getSingleValueDistributionResult().getAnnotatedRowsForValue(value);
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return null;
     }
 
     @Override
     public AnnotatedRowsResult getAnnotatedRowsForNull() {
-        return getSingleValueDistributionResult().getAnnotatedRowsForNull();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return null;
     }
 
     @Override
@@ -142,12 +158,16 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public Collection<String> getUniqueValues() {
-        return getSingleValueDistributionResult().getUniqueValues();
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return null;
     }
 
     @Override
-    public boolean hasAnnotatedRows(String value) {
-        return getSingleValueDistributionResult().hasAnnotatedRows(value);
+    public Boolean hasAnnotatedRows(String value) {
+        // This operation is not supported on GroupValueDistributionResult, but
+        // we don't want to throw exceptions...
+        return null; 
     }
 
     @Override

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/GroupedValueDistributionResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/GroupedValueDistributionResult.java
@@ -65,44 +65,74 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public Integer getDistinctCount() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return -1;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getDistinctCount();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return -1;
+        }
     }
 
     @Override
     public int getNullCount() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return -1;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getNullCount();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return -1;
+        }
     }
 
     @Override
     public int getTotalCount() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return -1;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getTotalCount();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return -1;
+        }
     }
 
     @Override
     public Integer getCount(String value) {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return -1;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getCount(value);
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return -1;
+        }
     }
 
     @Override
     public Integer getUniqueCount() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return -1;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getUniqueCount();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return -1;
+        }
     }
 
     @Override
     public Collection<ValueFrequency> getValueCounts() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return null;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getValueCounts();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult
+            // with many children, but
+            // we don't want to throw exceptions...
+            return null;
+        }
     }
 
     @Override
@@ -138,16 +168,24 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public AnnotatedRowsResult getAnnotatedRowsForValue(String value) {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return null;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getAnnotatedRowsForValue(value);
+        } else {
+            // This operation is not supported on GroupValueDistributionResult with many children, but
+            // we don't want to throw exceptions...
+            return null;
+        }
     }
 
     @Override
     public AnnotatedRowsResult getAnnotatedRowsForNull() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return null;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getAnnotatedRowsForNull();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult with many children, but
+            // we don't want to throw exceptions...
+            return null;
+        }
     }
 
     @Override
@@ -158,21 +196,37 @@ public class GroupedValueDistributionResult extends ValueDistributionAnalyzerRes
 
     @Override
     public Collection<String> getUniqueValues() {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return null;
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().getUniqueValues();
+        } else {
+            // This operation is not supported on GroupValueDistributionResult with many children, but
+            // we don't want to throw exceptions...
+            return null;
+        }
     }
 
     @Override
     public Boolean hasAnnotatedRows(String value) {
-        // This operation is not supported on GroupValueDistributionResult, but
-        // we don't want to throw exceptions...
-        return null; 
+        if (_result.size() == 1) {
+            return getSingleValueDistributionResult().hasAnnotatedRows(value);
+        } else {
+            // This operation is not supported on GroupValueDistributionResult with many children, but
+            // we don't want to throw exceptions...
+            return null;
+        }
     }
 
     @Override
     public Integer getUnexpectedValueCount() {
         // not applicable
         return null;
+    }
+
+    public InputColumn<?> getColumn() {
+        return _column;
+    }
+
+    public InputColumn<String> getGroupColumn() {
+        return _groupColumn;
     }
 }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
@@ -171,6 +171,10 @@ public class SingleValueDistributionResult extends ValueDistributionAnalyzerResu
         }
         return _bottomValues;
     }
+    
+    public InputColumn<?>[] getHighlightedColumns() {
+        return _highlightedColumns;
+    }
 
     @Override
     public int getNullCount() {

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
@@ -100,7 +100,7 @@ public class SingleValueDistributionResult extends ValueDistributionAnalyzerResu
     }
 
     @Override
-    public boolean hasAnnotatedRows(String value) {
+    public Boolean hasAnnotatedRows(String value) {
         if (_annotations == null) {
             return false;
         }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -22,7 +22,9 @@ package org.datacleaner.beans.valuedist;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -181,20 +183,36 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
     }
 
     private Collection<String> reduceUniqueValues(Collection<String> uniqueValues1, Collection<String> uniqueValues2) {
-        Collection<String> reducedUniqueValues = new ArrayList<>();
-
-        for (String value : uniqueValues1) {
-            if (!uniqueValues2.contains(value)) {
-                reducedUniqueValues.add(value);
+        Map<String, Integer> frequencyMap = new HashMap<String, Integer>();
+        
+        if (uniqueValues1 != null) {
+            for (String value : uniqueValues1) {
+                if (frequencyMap.containsKey(value)) {
+                    frequencyMap.put(value, frequencyMap.get(value) + 1);
+                } else {
+                    frequencyMap.put(value, 1);
+                }
             }
         }
-        for (String value : uniqueValues2) {
-            if (!uniqueValues1.contains(value)) {
-                reducedUniqueValues.add(value);
+        
+        if (uniqueValues2 != null) {
+            for (String value : uniqueValues2) {
+                if (frequencyMap.containsKey(value)) {
+                    frequencyMap.put(value, frequencyMap.get(value) + 1);
+                } else {
+                    frequencyMap.put(value, 1);
+                }
             }
         }
-
-        return reducedUniqueValues;
+        
+        List<String> uniqueList = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry: frequencyMap.entrySet()) {
+            if (entry.getValue() == 1) {
+                uniqueList.add(entry.getKey());
+            }
+        }
+        
+        return uniqueList;
     }
 
 }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -19,32 +19,26 @@
  */
 package org.datacleaner.beans.valuedist;
 
-import org.datacleaner.api.Distributed;
-import org.datacleaner.api.Metric;
-import org.datacleaner.result.AbstractValueCountingAnalyzerResult;
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.datacleaner.api.AnalyzerResultReducer;
+import org.datacleaner.api.Provided;
+import org.datacleaner.storage.RowAnnotationFactory;
 
 /**
- * Defines abstract methods, metrics etc. for analyzer results of the Value
- * Distribution analyzer.
+ * A reducer of {@link ValueDistributionAnalyzerResult}s.
  */
-@Distributed(reducer = ValueDistributionAnalyzerResultReducer.class)
-public abstract class ValueDistributionAnalyzerResult extends AbstractValueCountingAnalyzerResult {
+public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultReducer<ValueDistributionAnalyzerResult> {
 
-    private static final long serialVersionUID = 1L;
+    @Inject
+    @Provided
+    RowAnnotationFactory _rowAnnotationFactory;
 
-    @Metric("Total count")
     @Override
-    public abstract int getTotalCount();
+    public ValueDistributionAnalyzerResult reduce(Collection<? extends ValueDistributionAnalyzerResult> analyzerResults) {
+        return analyzerResults.iterator().next();
+    }
 
-    @Metric("Null count")
-    @Override
-    public abstract int getNullCount();
-
-    @Metric("Unique count")
-    @Override
-    public abstract Integer getUniqueCount();
-
-    @Metric("Distinct count")
-    @Override
-    public abstract Integer getDistinctCount();
 }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -157,23 +157,16 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
     }
 
     private Collection<String> reduceUniqueValues(Collection<String> uniqueValues1, Collection<String> uniqueValues2) {
-        if ((uniqueValues1 == null) || uniqueValues1.isEmpty()) {
-            return uniqueValues2;
-        }
-
         Collection<String> reducedUniqueValues = new ArrayList<>();
 
-        if (uniqueValues1.size() >= uniqueValues2.size()) {
-            for (String value : uniqueValues1) {
-                if (!uniqueValues2.contains(value)) {
-                    reducedUniqueValues.add(value);
-                }
+        for (String value : uniqueValues1) {
+            if (!uniqueValues2.contains(value)) {
+                reducedUniqueValues.add(value);
             }
-        } else {
-            for (String value : uniqueValues2) {
-                if (!uniqueValues1.contains(value)) {
-                    reducedUniqueValues.add(value);
-                }
+        }
+        for (String value : uniqueValues2) {
+            if (!uniqueValues1.contains(value)) {
+                reducedUniqueValues.add(value);
             }
         }
 

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -37,7 +37,6 @@ import org.datacleaner.result.CompositeValueFrequency;
 import org.datacleaner.result.SingleValueFrequency;
 import org.datacleaner.result.ValueCountList;
 import org.datacleaner.result.ValueCountListImpl;
-import org.datacleaner.result.ValueCountingAnalyzerResult;
 import org.datacleaner.result.ValueFrequency;
 import org.datacleaner.storage.RowAnnotation;
 import org.datacleaner.storage.RowAnnotationFactory;
@@ -106,17 +105,16 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
         
         InputColumn<?>[] highlightedColumns = null;
 
-        final Collection<ValueCountingAnalyzerResult> reducedChildResults = new ArrayList<ValueCountingAnalyzerResult>();
-        for (ValueCountingAnalyzerResult singleValueCountingResult : groupedResult.getGroupResults()) {
+        final Collection<SingleValueDistributionResult> reducedChildResults = (Collection<SingleValueDistributionResult>) reducedResult.getGroupResults();
+        for (SingleValueDistributionResult singleResult : (Collection<SingleValueDistributionResult>) groupedResult.getGroupResults()) {
             boolean groupFound = false;
-            SingleValueDistributionResult singleResult = (SingleValueDistributionResult) singleValueCountingResult;
-            for (ValueCountingAnalyzerResult singleValueCountingReducedResult : reducedResult.getGroupResults()) {
-                SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) singleValueCountingReducedResult;
 
-                // TODO: Not only name but also grouping column
+            for (SingleValueDistributionResult singleReducedResult : (Collection<SingleValueDistributionResult>) reducedResult.getGroupResults()) {
+
                 if (singleReducedResult.getName().equals(singleResult.getName())) {
                     SingleValueDistributionResult reducedSingleResult = reduceSingleResult(annotations,
                             singleResult.getHighlightedColumns(), singleReducedResult, singleResult);
+                    reducedChildResults.remove(singleResult);
                     reducedChildResults.add(reducedSingleResult);
                     highlightedColumns = reducedSingleResult.getHighlightedColumns();
                     groupFound = true;
@@ -125,7 +123,6 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
             }
             
             if (!groupFound) {
-                reducedChildResults.addAll(reducedResult.getGroupResults());
                 reducedChildResults.add(singleResult);
                 highlightedColumns = singleResult.getHighlightedColumns();
             }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -29,8 +29,10 @@ import javax.inject.Inject;
 import org.datacleaner.api.AnalyzerResultReducer;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.Provided;
+import org.datacleaner.result.SingleValueFrequency;
 import org.datacleaner.result.ValueCountList;
 import org.datacleaner.result.ValueCountListImpl;
+import org.datacleaner.result.ValueFrequency;
 import org.datacleaner.storage.InMemoryRowAnnotationFactory;
 import org.datacleaner.storage.RowAnnotation;
 import org.datacleaner.storage.RowAnnotationFactory;
@@ -53,25 +55,49 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
         final RowAnnotationFactory annotationFactory = new InMemoryRowAnnotationFactory();
         final InputColumn<?>[] highlightedColumns = null;
 
-        SingleValueDistributionResult reducedResult = new SingleValueDistributionResult("", topValues, uniqueValues, 0,
-                0, 0, annotations, new RowAnnotationImpl(), annotationFactory, highlightedColumns);
+        SingleValueDistributionResult reducedResult = new SingleValueDistributionResult(null, topValues, uniqueValues,
+                0, 0, 0, annotations, new RowAnnotationImpl(), annotationFactory, highlightedColumns);
 
         for (ValueDistributionAnalyzerResult partialResult : analyzerResults) {
             if (partialResult instanceof SingleValueDistributionResult) {
-                int reducedTotalCount = reducedResult.getTotalCount() + partialResult.getTotalCount();
-                Collection<String> reducedUniqueValues = reduceUniqueValues(reducedResult.getUniqueValues(),
+                final SingleValueDistributionResult singleResult = (SingleValueDistributionResult) partialResult;
+                final ValueCountList reducedTopValues = reduceTopValues(reducedResult.getTopValues(),
+                        singleResult.getTopValues());
+                final int reducedTotalCount = reducedResult.getTotalCount() + partialResult.getTotalCount();
+                final Collection<String> reducedUniqueValues = reduceUniqueValues(reducedResult.getUniqueValues(),
                         partialResult.getUniqueValues());
 
-                reducedResult = new SingleValueDistributionResult(reducedResult.getName(),
-                        reducedResult.getTopValues(), reducedUniqueValues, reducedUniqueValues.size(),
-                        reducedResult.getDistinctCount(), reducedTotalCount, annotations, new RowAnnotationImpl(),
-                        annotationFactory, highlightedColumns);
+                reducedResult = new SingleValueDistributionResult(reducedResult.getName(), reducedTopValues,
+                        reducedUniqueValues, reducedUniqueValues.size(), reducedResult.getDistinctCount(),
+                        reducedTotalCount, annotations, new RowAnnotationImpl(), annotationFactory, highlightedColumns);
             } else {
                 // TODO: Disregard grouped results for now
             }
         }
 
         return reducedResult;
+    }
+
+    private ValueCountList reduceTopValues(ValueCountList topValues1, ValueCountList topValues2) {
+        if (topValues1.getValueCounts().isEmpty()) {
+            return topValues2;
+        }
+
+        ValueCountListImpl topValuesImpl1 = (ValueCountListImpl) topValues1;
+        ValueCountListImpl topValuesImpl2 = (ValueCountListImpl) topValues2;
+
+        for (ValueFrequency valueFrequency2 : topValuesImpl2.getValueCounts()) {
+            for (ValueFrequency valueFrequency1 : topValuesImpl1.getValueCounts()) {
+                if (valueFrequency1.getName().equals(valueFrequency2.getName())) {
+                    topValuesImpl1.getValueCounts().remove(valueFrequency1);
+                    topValuesImpl1.register(new SingleValueFrequency(valueFrequency2.getValue(), valueFrequency2
+                            .getCount() + valueFrequency1.getCount()));
+                    break;
+                }
+            }
+        }
+
+        return topValuesImpl1;
     }
 
     private Collection<String> reduceUniqueValues(Collection<String> uniqueValues1, Collection<String> uniqueValues2) {

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducer.java
@@ -108,6 +108,7 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
 
         final Collection<ValueCountingAnalyzerResult> reducedChildResults = new ArrayList<ValueCountingAnalyzerResult>();
         for (ValueCountingAnalyzerResult singleValueCountingResult : groupedResult.getGroupResults()) {
+            boolean groupFound = false;
             SingleValueDistributionResult singleResult = (SingleValueDistributionResult) singleValueCountingResult;
             for (ValueCountingAnalyzerResult singleValueCountingReducedResult : reducedResult.getGroupResults()) {
                 SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) singleValueCountingReducedResult;
@@ -118,11 +119,18 @@ public class ValueDistributionAnalyzerResultReducer implements AnalyzerResultRed
                             singleResult.getHighlightedColumns(), singleReducedResult, singleResult);
                     reducedChildResults.add(reducedSingleResult);
                     highlightedColumns = reducedSingleResult.getHighlightedColumns();
+                    groupFound = true;
                     break;
                 }
             }
+            
+            if (!groupFound) {
+                reducedChildResults.addAll(reducedResult.getGroupResults());
+                reducedChildResults.add(singleResult);
+                highlightedColumns = singleResult.getHighlightedColumns();
+            }
         }
-
+        
         return new GroupedValueDistributionResult(highlightedColumns[0], (InputColumn<String>) highlightedColumns[1],
                 reducedChildResults);
     }

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuematch/ValueMatchAnalyzerResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuematch/ValueMatchAnalyzerResult.java
@@ -168,7 +168,7 @@ public class ValueMatchAnalyzerResult extends AbstractValueCountingAnalyzerResul
     }
 
     @Override
-    public boolean hasAnnotatedRows(String value) {
+    public Boolean hasAnnotatedRows(String value) {
         if (_rowAnnotationFactoryRef.get() == null) {
             return false;
         }

--- a/components/value-distribution/src/main/java/org/datacleaner/result/ValueCountingAnalyzerResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/result/ValueCountingAnalyzerResult.java
@@ -61,7 +61,7 @@ public interface ValueCountingAnalyzerResult extends AnalyzerResult {
 
     public Integer getUnexpectedValueCount();
 
-    public boolean hasAnnotatedRows(String value);
+    public Boolean hasAnnotatedRows(String value);
 
     public AnnotatedRowsResult getAnnotatedRowsForValue(String value);
 

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -20,6 +20,7 @@
 package org.datacleaner.beans.valuedist;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -103,7 +104,8 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist1.runInternal(new MockInputRow(), "locallyUniqueWord", "group1", 1);
         final ValueDistributionAnalyzerResult partialResult1 = valueDist1.getResult();
 
-        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList1 = ((GroupedValueDistributionResult) partialResult1).getGroupResults();
+        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList1 = ((GroupedValueDistributionResult) partialResult1)
+                .getGroupResults();
         assertEquals(2, partialSingleResultList1.size());
         final Iterator<? extends ValueCountingAnalyzerResult> iterator = partialSingleResultList1.iterator();
         final SingleValueDistributionResult firstGroup = (SingleValueDistributionResult) iterator.next();
@@ -113,11 +115,13 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult1.getNullCount());
         assertEquals(2, partialResult1.getUniqueCount().intValue());
-        assertEquals("[hello, locallyUniqueWord]", partialResult1.getUniqueValues().toString());
+        assertTrue(partialResult1.getUniqueValues().contains("hello"));
+        assertTrue(partialResult1.getUniqueValues().contains("locallyUniqueWord"));
         assertEquals(6, partialResult1.getTotalCount());
 
         ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
-                new MutableColumn("col")), new MetaModelInputColumn(new MutableColumn("groupCol", ColumnType.STRING)).narrow(String.class), true);
+                new MutableColumn("col")),
+                new MetaModelInputColumn(new MutableColumn("groupCol", ColumnType.STRING)).narrow(String.class), true);
 
         valueDist2.runInternal(new MockInputRow(), "hello", "group1", 5);
         valueDist2.runInternal(new MockInputRow(), "hello", "group1", 1);
@@ -126,7 +130,8 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist2.runInternal(new MockInputRow(), "globallyUniqueWord", "group1", 1);
         ValueDistributionAnalyzerResult partialResult2 = valueDist2.getResult();
 
-        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList2 = ((GroupedValueDistributionResult) partialResult1).getGroupResults();
+        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList2 = ((GroupedValueDistributionResult) partialResult1)
+                .getGroupResults();
         assertEquals(2, partialSingleResultList2.size());
         final Iterator<? extends ValueCountingAnalyzerResult> iterator2 = partialSingleResultList2.iterator();
         final SingleValueDistributionResult firstGroup2 = (SingleValueDistributionResult) iterator2.next();

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -22,20 +22,24 @@ package org.datacleaner.beans.valuedist;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
+import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.MutableColumn;
 import org.datacleaner.data.MetaModelInputColumn;
 import org.datacleaner.data.MockInputRow;
 import org.datacleaner.result.ValueCountList;
+import org.datacleaner.result.ValueCountingAnalyzerResult;
 import org.junit.Test;
 
 public class ValueDistributionAnalyzerResultReducerTest {
 
     @Test
     public void testReduceSingleResults() throws Exception {
-        ValueDistributionAnalyzer valueDist1 = new ValueDistributionAnalyzer(
-                new MetaModelInputColumn(new MutableColumn("col")), true);
+        ValueDistributionAnalyzer valueDist1 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
+                new MutableColumn("col")), true);
 
         valueDist1.runInternal(new MockInputRow(), "hello", 1);
         valueDist1.runInternal(new MockInputRow(), "hello", 1);
@@ -50,10 +54,10 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult1.getNullCount());
         assertEquals(1, partialResult1.getUniqueCount().intValue());
-        
-        ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(
-                new MetaModelInputColumn(new MutableColumn("col")), true);
-        
+
+        ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
+                new MutableColumn("col")), true);
+
         valueDist2.runInternal(new MockInputRow(), "hello", 5);
         valueDist2.runInternal(new MockInputRow(), "hello", 1);
         valueDist2.runInternal(new MockInputRow(), "world", 7);
@@ -68,14 +72,14 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult2.getNullCount());
         assertEquals(2, partialResult2.getUniqueCount().intValue());
-        
+
         List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
         partialResults.add(partialResult1);
         partialResults.add(partialResult2);
-        
+
         ValueDistributionAnalyzerResultReducer reducer = new ValueDistributionAnalyzerResultReducer();
         ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
-        
+
         SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) reducedResult;
         assertEquals(Integer.valueOf(4), singleReducedResult.getDistinctCount());
         assertEquals(21, singleReducedResult.getTotalCount());
@@ -85,6 +89,68 @@ public class ValueDistributionAnalyzerResultReducerTest {
         assertEquals(2, reducedTopValues.getActualSize());
         assertEquals("[world->10]", reducedTopValues.getValueCounts().get(0).toString());
         assertEquals("[hello->8]", reducedTopValues.getValueCounts().get(1).toString());
+    }
+
+    @Test
+    public void testReduceGroupedResults() throws Exception {
+        final ValueDistributionAnalyzer valueDist1 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
+                new MutableColumn("col")),
+                new MetaModelInputColumn(new MutableColumn("groupCol", ColumnType.STRING)).narrow(String.class), true);
+
+        valueDist1.runInternal(new MockInputRow(), "hello", "group1", 1);
+        valueDist1.runInternal(new MockInputRow(), "hello", "group2", 1);
+        valueDist1.runInternal(new MockInputRow(), "world", "group1", 3);
+        valueDist1.runInternal(new MockInputRow(), "locallyUniqueWord", "group1", 1);
+        final ValueDistributionAnalyzerResult partialResult1 = valueDist1.getResult();
+
+        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList1 = ((GroupedValueDistributionResult) partialResult1).getGroupResults();
+        assertEquals(2, partialSingleResultList1.size());
+        final Iterator<? extends ValueCountingAnalyzerResult> iterator = partialSingleResultList1.iterator();
+        final SingleValueDistributionResult firstGroup = (SingleValueDistributionResult) iterator.next();
+        assertEquals("group1", firstGroup.getName());
+        final SingleValueDistributionResult secondGroup = (SingleValueDistributionResult) iterator.next();
+        assertEquals("group2", secondGroup.getName());
+
+        assertEquals(0, partialResult1.getNullCount());
+        assertEquals(2, partialResult1.getUniqueCount().intValue());
+        assertEquals("[hello, locallyUniqueWord]", partialResult1.getUniqueValues().toString());
+        assertEquals(6, partialResult1.getTotalCount());
+
+        ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
+                new MutableColumn("col")), new MetaModelInputColumn(new MutableColumn("groupCol", ColumnType.STRING)).narrow(String.class), true);
+
+        valueDist2.runInternal(new MockInputRow(), "hello", "group1", 5);
+        valueDist2.runInternal(new MockInputRow(), "hello", "group1", 1);
+        valueDist2.runInternal(new MockInputRow(), "world", "group2", 7);
+        valueDist2.runInternal(new MockInputRow(), "locallyUniqueWord", "group1", 1);
+        valueDist2.runInternal(new MockInputRow(), "globallyUniqueWord", "group1", 1);
+        ValueDistributionAnalyzerResult partialResult2 = valueDist2.getResult();
+
+        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList2 = ((GroupedValueDistributionResult) partialResult1).getGroupResults();
+        assertEquals(2, partialSingleResultList2.size());
+        final Iterator<? extends ValueCountingAnalyzerResult> iterator2 = partialSingleResultList2.iterator();
+        final SingleValueDistributionResult firstGroup2 = (SingleValueDistributionResult) iterator2.next();
+        assertEquals("group1", firstGroup2.getName());
+        final SingleValueDistributionResult secondGroup2 = (SingleValueDistributionResult) iterator2.next();
+        assertEquals("group2", secondGroup2.getName());
+
+        assertEquals(0, partialResult2.getNullCount());
+        assertEquals(2, partialResult2.getUniqueCount().intValue());
+        assertEquals("[globallyUniqueWord, locallyUniqueWord]", partialResult2.getUniqueValues().toString());
+        assertEquals(15, partialResult2.getTotalCount());
+
+        List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
+        partialResults.add(partialResult1);
+        partialResults.add(partialResult2);
+
+        ValueDistributionAnalyzerResultReducer reducer = new ValueDistributionAnalyzerResultReducer();
+        ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
+
+        GroupedValueDistributionResult groupedReducedResult = (GroupedValueDistributionResult) reducedResult;
+        assertEquals(Integer.valueOf(4), groupedReducedResult.getDistinctCount());
+        assertEquals(21, groupedReducedResult.getTotalCount());
+        assertEquals(Integer.valueOf(1), groupedReducedResult.getUniqueCount());
+        assertEquals("[globallyUniqueWord]", groupedReducedResult.getUniqueValues().toString());
     }
 
 }

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -1,0 +1,63 @@
+package org.datacleaner.beans.valuedist;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.metamodel.schema.MutableColumn;
+import org.datacleaner.data.MetaModelInputColumn;
+import org.datacleaner.data.MockInputRow;
+import org.datacleaner.result.ValueCountList;
+import org.junit.Test;
+
+public class ValueDistributionAnalyzerResultReducerTest {
+
+    @Test
+    public void testReduceSingleResults() throws Exception {
+        ValueDistributionAnalyzer valueDist1 = new ValueDistributionAnalyzer(
+                new MetaModelInputColumn(new MutableColumn("col")), true);
+
+        valueDist1.runInternal(new MockInputRow(), "hello", 1);
+        valueDist1.runInternal(new MockInputRow(), "hello", 1);
+        valueDist1.runInternal(new MockInputRow(), "world", 3);
+        ValueDistributionAnalyzerResult partialResult1 = valueDist1.getResult();
+
+        ValueCountList partialTopValues1 = ((SingleValueDistributionResult) partialResult1).getTopValues();
+        assertEquals(2, partialTopValues1.getActualSize());
+        assertEquals("[world->3]", partialTopValues1.getValueCounts().get(0).toString());
+        assertEquals("[hello->2]", partialTopValues1.getValueCounts().get(1).toString());
+
+        assertEquals(0, partialResult1.getNullCount());
+        assertEquals(0, partialResult1.getUniqueCount().intValue());
+        
+        ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(
+                new MetaModelInputColumn(new MutableColumn("col")), true);
+        
+        valueDist2.runInternal(new MockInputRow(), "hello", 5);
+        valueDist2.runInternal(new MockInputRow(), "hello", 1);
+        valueDist2.runInternal(new MockInputRow(), "world", 7);
+        ValueDistributionAnalyzerResult partialResult2 = valueDist2.getResult();
+
+        ValueCountList partialTopValues2 = ((SingleValueDistributionResult) partialResult2).getTopValues();
+        assertEquals(2, partialTopValues2.getActualSize());
+        assertEquals("[world->7]", partialTopValues2.getValueCounts().get(0).toString());
+        assertEquals("[hello->6]", partialTopValues2.getValueCounts().get(1).toString());
+
+        assertEquals(0, partialResult2.getNullCount());
+        assertEquals(0, partialResult2.getUniqueCount().intValue());
+        
+        List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
+        partialResults.add(partialResult1);
+        partialResults.add(partialResult2);
+        
+        ValueDistributionAnalyzerResultReducer reducer = new ValueDistributionAnalyzerResultReducer();
+        ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
+        
+        ValueCountList reducedTopValues = ((SingleValueDistributionResult) reducedResult).getTopValues();
+        assertEquals(2, reducedTopValues.getActualSize());
+        assertEquals("[world->10]", reducedTopValues.getValueCounts().get(0).toString());
+        assertEquals("[hello->8]", reducedTopValues.getValueCounts().get(1).toString());
+    }
+
+}

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -40,6 +40,7 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist1.runInternal(new MockInputRow(), "hello", 1);
         valueDist1.runInternal(new MockInputRow(), "hello", 1);
         valueDist1.runInternal(new MockInputRow(), "world", 3);
+        valueDist1.runInternal(new MockInputRow(), "locallyUniqueWord", 1);
         ValueDistributionAnalyzerResult partialResult1 = valueDist1.getResult();
 
         ValueCountList partialTopValues1 = ((SingleValueDistributionResult) partialResult1).getTopValues();
@@ -48,7 +49,7 @@ public class ValueDistributionAnalyzerResultReducerTest {
         assertEquals("[hello->2]", partialTopValues1.getValueCounts().get(1).toString());
 
         assertEquals(0, partialResult1.getNullCount());
-        assertEquals(0, partialResult1.getUniqueCount().intValue());
+        assertEquals(1, partialResult1.getUniqueCount().intValue());
         
         ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(
                 new MetaModelInputColumn(new MutableColumn("col")), true);
@@ -56,6 +57,8 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist2.runInternal(new MockInputRow(), "hello", 5);
         valueDist2.runInternal(new MockInputRow(), "hello", 1);
         valueDist2.runInternal(new MockInputRow(), "world", 7);
+        valueDist2.runInternal(new MockInputRow(), "locallyUniqueWord", 1);
+        valueDist2.runInternal(new MockInputRow(), "globallyUniqueWord", 1);
         ValueDistributionAnalyzerResult partialResult2 = valueDist2.getResult();
 
         ValueCountList partialTopValues2 = ((SingleValueDistributionResult) partialResult2).getTopValues();
@@ -64,7 +67,7 @@ public class ValueDistributionAnalyzerResultReducerTest {
         assertEquals("[hello->6]", partialTopValues2.getValueCounts().get(1).toString());
 
         assertEquals(0, partialResult2.getNullCount());
-        assertEquals(0, partialResult2.getUniqueCount().intValue());
+        assertEquals(2, partialResult2.getUniqueCount().intValue());
         
         List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
         partialResults.add(partialResult1);
@@ -74,7 +77,9 @@ public class ValueDistributionAnalyzerResultReducerTest {
         ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
         
         SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) reducedResult;
-        assertEquals(18, singleReducedResult.getTotalCount());
+        assertEquals(21, singleReducedResult.getTotalCount());
+        assertEquals(Integer.valueOf(1), singleReducedResult.getUniqueCount());
+        assertEquals("[globallyUniqueWord]", singleReducedResult.getUniqueValues().toString());
         ValueCountList reducedTopValues = singleReducedResult.getTopValues();
         assertEquals(2, reducedTopValues.getActualSize());
         assertEquals("[world->10]", reducedTopValues.getValueCounts().get(0).toString());

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -54,6 +54,7 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult1.getNullCount());
         assertEquals(1, partialResult1.getUniqueCount().intValue());
+        assertTrue(partialResult1.getUniqueValues().contains("locallyUniqueWord"));
 
         ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
                 new MutableColumn("col")), true);
@@ -103,37 +104,27 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist1.runInternal(new MockInputRow(), "hello", "group2", 1);
         final ValueDistributionAnalyzerResult partialResult1 = valueDist1.getResult();
 
-        // Confirm what we got from the the first analyzer...
         final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList1 = ((GroupedValueDistributionResult) partialResult1)
                 .getGroupResults();
-        assertEquals(2, partialSingleResultList1.size());
-        final Iterator<? extends ValueCountingAnalyzerResult> iterator = partialSingleResultList1.iterator();
-        final SingleValueDistributionResult group1Analyzer1 = (SingleValueDistributionResult) iterator.next();
-        assertEquals("group1", group1Analyzer1.getName());
-        assertEquals(0, group1Analyzer1.getNullCount());
-        assertEquals(2, group1Analyzer1.getUniqueCount().intValue());
-        assertTrue(group1Analyzer1.getUniqueValues().contains("hello"));
-        assertTrue(group1Analyzer1.getUniqueValues().contains("locallyUniqueWord"));
-        assertEquals(5, group1Analyzer1.getTotalCount());
-        final SingleValueDistributionResult group2Analyzer1 = (SingleValueDistributionResult) iterator.next();
-        assertEquals("group2", group2Analyzer1.getName());
-        assertEquals(0, group2Analyzer1.getNullCount());
-        assertEquals(1, group2Analyzer1.getUniqueCount().intValue());
-        assertTrue(group2Analyzer1.getUniqueValues().contains("hello"));
-        assertEquals(1, group2Analyzer1.getTotalCount());
+        // Confirm what we got from the the first analyzer...
+        {
+            assertEquals(2, partialSingleResultList1.size());
+            final Iterator<? extends ValueCountingAnalyzerResult> iterator = partialSingleResultList1.iterator();
+            final SingleValueDistributionResult group1Analyzer1 = (SingleValueDistributionResult) iterator.next();
+            assertEquals("group1", group1Analyzer1.getName());
+            assertEquals(0, group1Analyzer1.getNullCount());
+            assertEquals(2, group1Analyzer1.getUniqueCount().intValue());
+            assertTrue(group1Analyzer1.getUniqueValues().contains("hello"));
+            assertTrue(group1Analyzer1.getUniqueValues().contains("locallyUniqueWord"));
+            assertEquals(5, group1Analyzer1.getTotalCount());
+            final SingleValueDistributionResult group2Analyzer1 = (SingleValueDistributionResult) iterator.next();
+            assertEquals("group2", group2Analyzer1.getName());
+            assertEquals(0, group2Analyzer1.getNullCount());
+            assertEquals(1, group2Analyzer1.getUniqueCount().intValue());
+            assertTrue(group2Analyzer1.getUniqueValues().contains("hello"));
+            assertEquals(1, group2Analyzer1.getTotalCount());
+        }
 
-        // Assert the aggregates at the GroupValueDistribution
-        assertEquals(0, partialResult1.getNullCount());
-        assertEquals(2, partialResult1.getUniqueCount().intValue());
-        assertTrue(partialResult1.getUniqueValues().contains("hello"));
-        assertTrue(partialResult1.getUniqueValues().contains("locallyUniqueWord"));
-        // GroupedValueDistributionResult return the aggregates of the first
-        // group in the list, not total... Therefore, 5 is expected instead of
-        // 6.
-        assertEquals(5, partialResult1.getTotalCount());
-
-        
-        // Confirm what we got from the the second analyzer...
         ValueDistributionAnalyzer valueDist2 = new ValueDistributionAnalyzer(new MetaModelInputColumn(
                 new MutableColumn("col")),
                 new MetaModelInputColumn(new MutableColumn("groupCol", ColumnType.STRING)).narrow(String.class), true);
@@ -144,35 +135,25 @@ public class ValueDistributionAnalyzerResultReducerTest {
         valueDist2.runInternal(new MockInputRow(), "world", "group2", 7);
         ValueDistributionAnalyzerResult partialResult2 = valueDist2.getResult();
 
-        final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList2 = ((GroupedValueDistributionResult) partialResult1)
-                .getGroupResults();
-        assertEquals(2, partialSingleResultList2.size());
-        final Iterator<? extends ValueCountingAnalyzerResult> iterator2 = partialSingleResultList2.iterator();
-        final SingleValueDistributionResult group1Analyzer2 = (SingleValueDistributionResult) iterator2.next();
-        assertEquals("group1", group1Analyzer2.getName());
-        assertEquals(0, group1Analyzer2.getNullCount());
-        assertEquals(2, group1Analyzer2.getUniqueCount().intValue());
-        assertTrue(group1Analyzer2.getUniqueValues().contains("globallyUniqueWord"));
-        final Iterator<String> group1Analyzer2UniquesIterator = group1Analyzer2.getUniqueValues().iterator();
-        assertEquals("globallyUniqueWord", group1Analyzer2UniquesIterator.next());
-        assertFalse(group1Analyzer2UniquesIterator.hasNext());
-        assertTrue(group1Analyzer2.getUniqueValues().contains("locallyUniqueWord"));
-        assertEquals(8, group1Analyzer2.getTotalCount());
-        final SingleValueDistributionResult group2Analyzer2 = (SingleValueDistributionResult) iterator2.next();
-        assertEquals("group2", group2Analyzer2.getName());
-        assertEquals(0, group2Analyzer2.getNullCount());
-        assertEquals(0, group2Analyzer2.getUniqueCount().intValue());
-        assertEquals(7, group2Analyzer2.getTotalCount());
-
-        // Assert the aggregates at the GroupValueDistribution
-        assertEquals(0, partialResult2.getNullCount());
-        assertEquals(2, partialResult2.getUniqueCount().intValue());
-        assertTrue(partialResult2.getUniqueValues().contains("globallyUniqueWord"));
-        assertTrue(partialResult2.getUniqueValues().contains("locallyUniqueWord"));
-        // GroupedValueDistributionResult return the aggregates of the first
-        // group in the list, not total... Therefore, 8 is expected instead of
-        // 15.
-        assertEquals(8, partialResult2.getTotalCount());
+        // Confirm what we got from the the second analyzer...
+        {
+            final Collection<? extends ValueCountingAnalyzerResult> partialSingleResultList2 = ((GroupedValueDistributionResult) partialResult2)
+                    .getGroupResults();
+            assertEquals(2, partialSingleResultList2.size());
+            final Iterator<? extends ValueCountingAnalyzerResult> iterator2 = partialSingleResultList2.iterator();
+            final SingleValueDistributionResult group1Analyzer2 = (SingleValueDistributionResult) iterator2.next();
+            assertEquals("group1", group1Analyzer2.getName());
+            assertEquals(0, group1Analyzer2.getNullCount());
+            assertEquals(2, group1Analyzer2.getUniqueCount().intValue());
+            assertTrue(group1Analyzer2.getUniqueValues().contains("globallyUniqueWord"));
+            assertTrue(group1Analyzer2.getUniqueValues().contains("locallyUniqueWord"));
+            assertEquals(8, group1Analyzer2.getTotalCount());
+            final SingleValueDistributionResult group2Analyzer2 = (SingleValueDistributionResult) iterator2.next();
+            assertEquals("group2", group2Analyzer2.getName());
+            assertEquals(0, group2Analyzer2.getNullCount());
+            assertEquals(0, group2Analyzer2.getUniqueCount().intValue());
+            assertEquals(7, group2Analyzer2.getTotalCount());
+        }
 
         List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
         partialResults.add(partialResult1);
@@ -182,34 +163,27 @@ public class ValueDistributionAnalyzerResultReducerTest {
         ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
 
         // Assert the aggregates from the reduced groups
-        GroupedValueDistributionResult groupedReducedResult = (GroupedValueDistributionResult) reducedResult;
-        assertEquals(Integer.valueOf(4), groupedReducedResult.getDistinctCount());
-        // GroupedValueDistributionResult return the aggregates of the first
-        // group in the list, not total... Therefore, 13 is expected instead of
-        // 21.
-        assertEquals(13, groupedReducedResult.getTotalCount());
-        // GroupedValueDistributionResult return the aggregates of the first
-        // group in the list, not total... Therefore, 1 is expected instead of
-        // 2 and the "hello" is present in unique values.
-        assertEquals(Integer.valueOf(1), groupedReducedResult.getUniqueCount());
-        System.out.println(groupedReducedResult.getUniqueValues());
-        assertTrue(groupedReducedResult.getUniqueValues().contains("globallyUniqueWord"));
-        
-        // Now let's iterate over the groups and see manually if the values are aggregated correctly.
-        final Iterator<? extends ValueCountingAnalyzerResult> reducedGroupsIterator = groupedReducedResult.getGroupResults().iterator();
-        SingleValueDistributionResult firstReducedGroup = (SingleValueDistributionResult) reducedGroupsIterator.next();
-        assertEquals("group1", firstReducedGroup.getName());
-        assertEquals(0, firstReducedGroup.getNullCount());
-        assertEquals(2, firstReducedGroup.getUniqueCount().intValue());
-        assertTrue(firstReducedGroup.getUniqueValues().contains("globallyUniqueWord"));
-        assertEquals(13, firstReducedGroup.getTotalCount());
-        
-        SingleValueDistributionResult secondReducedGroup = (SingleValueDistributionResult) reducedGroupsIterator.next();
-        assertEquals("group2", secondReducedGroup.getName());
-        assertEquals(0, secondReducedGroup.getNullCount());
-        assertEquals(1, secondReducedGroup.getUniqueCount().intValue());
-        assertTrue(secondReducedGroup.getUniqueValues().contains("hello"));
-        assertEquals(8, secondReducedGroup.getTotalCount());
+        {
+            final GroupedValueDistributionResult groupedReducedResult = (GroupedValueDistributionResult) reducedResult;
+            final Iterator<? extends ValueCountingAnalyzerResult> reducedGroupsIterator = groupedReducedResult
+                    .getGroupResults().iterator();
+            SingleValueDistributionResult firstReducedGroup = (SingleValueDistributionResult) reducedGroupsIterator
+                    .next();
+            assertEquals("group1", firstReducedGroup.getName());
+            assertEquals(0, firstReducedGroup.getNullCount());
+            assertEquals(2, firstReducedGroup.getUniqueCount().intValue());
+            assertTrue(firstReducedGroup.getUniqueValues().contains("globallyUniqueWord"));
+            assertTrue(firstReducedGroup.getUniqueValues().contains("hello"));
+            assertEquals(13, firstReducedGroup.getTotalCount());
+
+            SingleValueDistributionResult secondReducedGroup = (SingleValueDistributionResult) reducedGroupsIterator
+                    .next();
+            assertEquals("group2", secondReducedGroup.getName());
+            assertEquals(0, secondReducedGroup.getNullCount());
+            assertEquals(1, secondReducedGroup.getUniqueCount().intValue());
+            assertTrue(secondReducedGroup.getUniqueValues().contains("hello"));
+            assertEquals(8, secondReducedGroup.getTotalCount());
+        }
     }
 
 }

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -141,7 +141,8 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult2.getNullCount());
         assertEquals(2, partialResult2.getUniqueCount().intValue());
-        assertEquals("[globallyUniqueWord, locallyUniqueWord]", partialResult2.getUniqueValues().toString());
+        assertTrue(partialResult2.getUniqueValues().contains("globallyUniqueWord"));
+        assertTrue(partialResult2.getUniqueValues().contains("locallyUniqueWord"));
         assertEquals(15, partialResult2.getTotalCount());
 
         List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -77,6 +77,7 @@ public class ValueDistributionAnalyzerResultReducerTest {
         ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
         
         SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) reducedResult;
+        assertEquals(Integer.valueOf(4), singleReducedResult.getDistinctCount());
         assertEquals(21, singleReducedResult.getTotalCount());
         assertEquals(Integer.valueOf(1), singleReducedResult.getUniqueCount());
         assertEquals("[globallyUniqueWord]", singleReducedResult.getUniqueValues().toString());

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -73,6 +73,8 @@ public class ValueDistributionAnalyzerResultReducerTest {
 
         assertEquals(0, partialResult2.getNullCount());
         assertEquals(2, partialResult2.getUniqueCount().intValue());
+        assertTrue(partialResult2.getUniqueValues().contains("locallyUniqueWord"));
+        assertTrue(partialResult2.getUniqueValues().contains("globallyUniqueWord"));
 
         List<ValueDistributionAnalyzerResult> partialResults = new ArrayList<>();
         partialResults.add(partialResult1);

--- a/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzerResultReducerTest.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.beans.valuedist;
 
 import static org.junit.Assert.assertEquals;
@@ -54,7 +73,9 @@ public class ValueDistributionAnalyzerResultReducerTest {
         ValueDistributionAnalyzerResultReducer reducer = new ValueDistributionAnalyzerResultReducer();
         ValueDistributionAnalyzerResult reducedResult = reducer.reduce(partialResults);
         
-        ValueCountList reducedTopValues = ((SingleValueDistributionResult) reducedResult).getTopValues();
+        SingleValueDistributionResult singleReducedResult = (SingleValueDistributionResult) reducedResult;
+        assertEquals(18, singleReducedResult.getTotalCount());
+        ValueCountList reducedTopValues = singleReducedResult.getTopValues();
         assertEquals(2, reducedTopValues.getActualSize());
         assertEquals("[world->10]", reducedTopValues.getValueCounts().get(0).toString());
         assertEquals("[hello->8]", reducedTopValues.getValueCounts().get(1).toString());

--- a/components/value-distribution/src/test/java/org/datacleaner/result/MockValueCountingAnalyzerResult.java
+++ b/components/value-distribution/src/test/java/org/datacleaner/result/MockValueCountingAnalyzerResult.java
@@ -72,7 +72,7 @@ public class MockValueCountingAnalyzerResult extends AbstractValueCountingAnalyz
     }
 
     @Override
-    public boolean hasAnnotatedRows(String value) {
+    public Boolean hasAnnotatedRows(String value) {
         return false;
     }
 

--- a/engine/env/spark/pom.xml
+++ b/engine/env/spark/pom.xml
@@ -220,5 +220,11 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-uniqueness</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
@@ -63,7 +63,7 @@ public class SparkAnalysisRunner implements AnalysisRunner {
     public SparkAnalysisRunner(JavaSparkContext sparkContext, SparkJobContext sparkJobContext, Integer minPartitions) {
         _sparkContext = sparkContext;
         _sparkJobContext = sparkJobContext;
-        if (minPartitions > 0) {
+        if ((minPartitions != null) && (minPartitions > 0)) {
             _minPartitions = minPartitions;
         } else {
             logger.warn(

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
@@ -92,20 +92,8 @@ public class SparkAnalysisRunner implements AnalysisRunner {
             final JavaPairRDD<String, NamedAnalyzerResult> partialNamedAnalyzerResultsRDD = inputRowsRDD
                     .mapPartitionsToPair(new RowProcessingFunction(_sparkJobContext));
 
-            List<Tuple2<String, NamedAnalyzerResult>> partials = partialNamedAnalyzerResultsRDD.collect();
-            for (Tuple2<String, NamedAnalyzerResult> tuple2 : partials) {
-                System.out.println("Key: " + tuple2._1);
-                System.out.println("\t\t\t" + tuple2._2.getAnalyzerResult().toString());
-            }
-
             namedAnalyzerResultsRDD = partialNamedAnalyzerResultsRDD.reduceByKey(new AnalyzerResultReduceFunction(
                     _sparkJobContext));
-
-            List<Tuple2<String, NamedAnalyzerResult>> reduced = namedAnalyzerResultsRDD.collect();
-            for (Tuple2<String, NamedAnalyzerResult> tuple2 : reduced) {
-                System.out.println("Key: " + tuple2._1);
-                System.out.println("\t\t\t" + tuple2._2.getAnalyzerResult().toString());
-            }
         } else {
             logger.warn("Running the job in non-distributed mode");
             JavaRDD<InputRow> coalescedInputRowsRDD = inputRowsRDD.coalesce(1);

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -249,17 +249,18 @@ public class SparkAnalysisRunnerTest extends TestCase {
         GroupedValueDistributionResult completeGroupedResult = (GroupedValueDistributionResult) completeValueDistributionAnalyzerResult;
         Iterator<? extends ValueCountingAnalyzerResult> iterator = completeGroupedResult.getGroupResults().iterator();
         SingleValueDistributionResult group1 = (SingleValueDistributionResult) iterator.next();
-        assertEquals("Netherlands", group1.getName());
-        assertEquals(3, group1.getTotalCount());
-        assertEquals(Integer.valueOf(3), group1.getUniqueCount());
-        assertEquals(Integer.valueOf(3), group1.getDistinctCount());
+        assertEquals("Denmark", group1.getName());
+        assertEquals(4, group1.getTotalCount());
+        assertEquals(Integer.valueOf(4), group1.getUniqueCount());
+        assertEquals(Integer.valueOf(4), group1.getDistinctCount());
         assertEquals(0, group1.getNullCount());
-        
+
         SingleValueDistributionResult group2 = (SingleValueDistributionResult) iterator.next();
-        assertEquals("Denmark", group2.getName());
-        assertEquals(4, group2.getTotalCount());
-        assertEquals(Integer.valueOf(4), group2.getUniqueCount());
-        assertEquals(Integer.valueOf(4), group2.getDistinctCount());
+        assertEquals("Netherlands", group2.getName());
+        assertEquals(3, group2.getTotalCount());
+        assertEquals(Integer.valueOf(3), group2.getUniqueCount());
+        assertEquals(Integer.valueOf(3), group2.getDistinctCount());
         assertEquals(0, group2.getNullCount());
+        
     }
 }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -208,7 +208,5 @@ public class SparkAnalysisRunnerTest extends TestCase {
         assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getUniqueCount());
         assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getDistinctCount());
         assertEquals(0, completeValueDistributionAnalyzerResult.getNullCount());
-        assertEquals("[Tomasz, Kasper, Dennis, Claudia, Stefan, Hans, Ankit]", completeValueDistributionAnalyzerResult
-                .getUniqueValues().toString());
     }
 }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -20,6 +20,7 @@
 package org.datacleaner.spark;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -31,10 +32,12 @@ import org.datacleaner.beans.CompletenessAnalyzerResult;
 import org.datacleaner.beans.StringAnalyzerResult;
 import org.datacleaner.beans.uniqueness.UniqueKeyCheckAnalyzerResult;
 import org.datacleaner.beans.valuedist.GroupedValueDistributionResult;
+import org.datacleaner.beans.valuedist.SingleValueDistributionResult;
 import org.datacleaner.beans.valuedist.ValueDistributionAnalyzerResult;
 import org.datacleaner.beans.valuematch.ValueMatchAnalyzerResult;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.runner.AnalysisResultFuture;
+import org.datacleaner.result.ValueCountingAnalyzerResult;
 import org.junit.Test;
 
 /**
@@ -243,9 +246,20 @@ public class SparkAnalysisRunnerTest extends TestCase {
         final ValueDistributionAnalyzerResult completeValueDistributionAnalyzerResult = result.getResults(
                 ValueDistributionAnalyzerResult.class).get(0);
         assertEquals(GroupedValueDistributionResult.class, completeValueDistributionAnalyzerResult.getClass());
-        assertEquals(7, completeValueDistributionAnalyzerResult.getTotalCount());
-        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getUniqueCount());
-        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getDistinctCount());
-        assertEquals(0, completeValueDistributionAnalyzerResult.getNullCount());
+        GroupedValueDistributionResult completeGroupedResult = (GroupedValueDistributionResult) completeValueDistributionAnalyzerResult;
+        Iterator<? extends ValueCountingAnalyzerResult> iterator = completeGroupedResult.getGroupResults().iterator();
+        SingleValueDistributionResult group1 = (SingleValueDistributionResult) iterator.next();
+        assertEquals("Netherlands", group1.getName());
+        assertEquals(3, group1.getTotalCount());
+        assertEquals(Integer.valueOf(3), group1.getUniqueCount());
+        assertEquals(Integer.valueOf(3), group1.getDistinctCount());
+        assertEquals(0, group1.getNullCount());
+        
+        SingleValueDistributionResult group2 = (SingleValueDistributionResult) iterator.next();
+        assertEquals("Denmark", group2.getName());
+        assertEquals(4, group2.getTotalCount());
+        assertEquals(Integer.valueOf(4), group2.getUniqueCount());
+        assertEquals(Integer.valueOf(4), group2.getDistinctCount());
+        assertEquals(0, group2.getNullCount());
     }
 }

--- a/engine/env/spark/src/test/resources/distributable-grouped-value-dist.analysis.xml
+++ b/engine/env/spark/src/test/resources/distributable-grouped-value-dist.analysis.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <job-description>Created with DataCleaner Community edition UNKNOWN</job-description>
+        <author>tomaszg</author>
+        <updated-date>2015-09-11+02:00</updated-date>
+        <metadata-properties>
+            <property name="CoordinatesY.resources.person_names.txt">40</property>
+            <property name="CoordinatesX.resources.person_names.txt">40</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="person_names"/>
+        <columns>
+            <column id="col_id" path="id" type="STRING"/>
+            <column id="col_name" path="name" type="STRING"/>
+            <column id="col_company" path="company" type="STRING"/>
+            <column id="col_country" path="country" type="STRING"/>
+        </columns>
+    </source>
+    <transformation/>
+    <analysis>
+        <analyzer>
+            <descriptor ref="Value distribution"/>
+            <metadata-properties>
+                <property name="CoordinatesY">70</property>
+                <property name="CoordinatesX">350</property>
+            </metadata-properties>
+            <properties>
+                <property name="Record unique values" value="true"/>
+                <property name="Record drill-down information" value="true"/>
+                <property name="Top n most frequent values" value="&lt;null&gt;"/>
+                <property name="Bottom n most frequent values" value="&lt;null&gt;"/>
+            </properties>
+            <input ref="col_name" name="Column"/>
+            <input ref="col_country" name="Group column"/>
+        </analyzer>
+    </analysis>
+</job>

--- a/engine/env/spark/src/test/resources/distributable-value-dist.analysis.xml
+++ b/engine/env/spark/src/test/resources/distributable-value-dist.analysis.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+	<source>
+		<data-context ref="person_names" />
+		<columns>
+			<column id="col_id" path="id" type="STRING" />
+			<column id="col_name" path="name" type="STRING" />
+			<column id="col_company" path="company" type="STRING" />
+			<column id="col_country" path="country" type="STRING" />
+		</columns>
+	</source>
+	<transformation />
+	<analysis>
+		<analyzer>
+			<descriptor ref="Value distribution" />
+			<properties>
+				<property name="Record unique values" value="true" />
+				<property name="Record drill-down information" value="true" />
+				<property name="Top n most frequent values" value="&lt;null&gt;" />
+				<property name="Bottom n most frequent values" value="&lt;null&gt;" />
+			</properties>
+			<input ref="col_name" name="Column" />
+		</analyzer>
+	</analysis>
+</job>

--- a/engine/env/spark/src/test/resources/non-dist-melon-job.analysis.xml
+++ b/engine/env/spark/src/test/resources/non-dist-melon-job.analysis.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
-    <job-metadata>
-        <job-description>Created with DataCleaner Community edition UNKNOWN</job-description>
-        <author>tomaszg</author>
-        <updated-date>2015-09-11+02:00</updated-date>
-        <metadata-properties>
-            <property name="CoordinatesY.resources.person_names.txt">40</property>
-            <property name="CoordinatesX.resources.person_names.txt">40</property>
-        </metadata-properties>
-    </job-metadata>
     <source>
         <data-context ref="person_names"/>
         <columns>
@@ -22,10 +13,6 @@
     <analysis>
         <analyzer>
             <descriptor ref="Completeness analyzer"/>
-            <metadata-properties>
-                <property name="CoordinatesX">200</property>
-                <property name="CoordinatesY">40</property>
-            </metadata-properties>
             <properties>
                 <property name="Conditions" value="[NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL]"/>
                 <property name="Evaluation mode" value="ANY_FIELD"/>
@@ -44,10 +31,6 @@
                     <analysis>
                         <analyzer>
                             <descriptor ref="Unique key check"/>
-                            <metadata-properties>
-<property name="CoordinatesY">38</property>
-<property name="CoordinatesX">372</property>
-                            </metadata-properties>
                             <properties>
 <property name="Buffer size" value="20000"/>
                             </properties>
@@ -68,10 +51,6 @@
                     <analysis>
                         <analyzer>
                             <descriptor ref="Value matcher"/>
-                            <metadata-properties>
-<property name="CoordinatesX">372</property>
-<property name="CoordinatesY">207</property>
-                            </metadata-properties>
                             <properties>
 <property name="Expected values" value="[Kasper]"/>
 <property name="Case sensitive matching" value="true"/>

--- a/engine/env/spark/src/test/resources/non-dist-melon-job.analysis.xml
+++ b/engine/env/spark/src/test/resources/non-dist-melon-job.analysis.xml
@@ -3,7 +3,7 @@
     <job-metadata>
         <job-description>Created with DataCleaner Community edition UNKNOWN</job-description>
         <author>tomaszg</author>
-        <updated-date>2015-09-04+02:00</updated-date>
+        <updated-date>2015-09-11+02:00</updated-date>
         <metadata-properties>
             <property name="CoordinatesY.resources.person_names.txt">40</property>
             <property name="CoordinatesX.resources.person_names.txt">40</property>
@@ -36,25 +36,22 @@
                 <job>
                     <source>
                         <columns>
-                            <column id="col_name" path="name" type="STRING"/>
-                            <column id="col_company" path="company" type="STRING"/>
+                            <column id="col_name2" path="name" type="STRING"/>
+                            <column id="col_company2" path="company" type="STRING"/>
                         </columns>
                     </source>
                     <transformation/>
                     <analysis>
                         <analyzer>
-                            <descriptor ref="Value distribution"/>
+                            <descriptor ref="Unique key check"/>
                             <metadata-properties>
-<property name="CoordinatesX">425</property>
-<property name="CoordinatesY">30</property>
+<property name="CoordinatesY">38</property>
+<property name="CoordinatesX">372</property>
                             </metadata-properties>
                             <properties>
-<property name="Record unique values" value="true"/>
-<property name="Record drill-down information" value="true"/>
-<property name="Top n most frequent values" value="&lt;null&gt;"/>
-<property name="Bottom n most frequent values" value="&lt;null&gt;"/>
+<property name="Buffer size" value="20000"/>
                             </properties>
-                            <input ref="col_name" name="Column"/>
+                            <input ref="col_name2"/>
                         </analyzer>
                     </analysis>
                 </job>
@@ -63,8 +60,8 @@
                 <job>
                     <source>
                         <columns>
-                            <column id="col_name" path="name" type="STRING"/>
-                            <column id="col_company" path="company" type="STRING"/>
+                            <column id="col_name3" path="name" type="STRING"/>
+                            <column id="col_company3" path="company" type="STRING"/>
                         </columns>
                     </source>
                     <transformation/>
@@ -80,7 +77,7 @@
 <property name="Case sensitive matching" value="true"/>
 <property name="White space sensitive matching" value="true"/>
                             </properties>
-                            <input ref="col_name"/>
+                            <input ref="col_name3"/>
                         </analyzer>
                     </analysis>
                 </job>


### PR DESCRIPTION
Ref #647 

This PR is competitive to #674, so have a look at both and merge only one!

I am posting this PR to gather feedback if I am on the right track and what I forgot to take care about. Especially Single vs GroupedValueDistributionResult.

The PR also adds a special test of reducing it in Spark + the new parameter to specify minimum number of partitions for the input data (in order to enforce more than one result that can be reduced later).

Also, ValueDistribution is not non-distributable anymore, so now using UniqueKeyCheck to test non-distributable jobs in Spark.