### PR TITLE
Updated the enforcer plugin configurations to catch monitor dependencies

### DIFF
--- a/monitor/pom.xml
+++ b/monitor/pom.xml
@@ -33,10 +33,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.1.1</version>
 				<executions>
 					<execution>
-						<id>enforce-versions</id>
+						<id>enforce-versions-monitor</id>
 						<goals>
 							<goal>enforce</goal>
 						</goals>
@@ -44,7 +43,6 @@
 							<rules>
 								<bannedDependencies>
 									<excludes>
-										<exclude>commons-logging:commons-logging</exclude>
 										<exclude>log4j:log4j</exclude>
 										<exclude>org.slf4j:slf4j-log4j12</exclude>
 									</excludes>

--- a/monitor/services/pom.xml
+++ b/monitor/services/pom.xml
@@ -199,12 +199,34 @@
             <groupId>org.jvnet.ws.wadl</groupId>
             <artifactId>wadl-core</artifactId>
             <version>1.1.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.jvnet.ws.wadl</groupId>
             <artifactId>wadl-client-plugin</artifactId>
             <version>1.1.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>com.mangofactory</groupId>
             <artifactId>swagger-springmvc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>enforce-versions</id>
+						<id>enforce-versions-parent</id>
 						<goals>
 							<goal>enforce</goal>
 						</goals>
@@ -384,8 +384,8 @@
 										<exclude>org.mortbay.jetty:servlet-api:*:*:compile</exclude>
 										<exclude>org.eclipse.jetty.aggregate:jetty-all:*:jar:compile</exclude>
 										<exclude>org.mortbay.jetty:jetty:*:jar:compile</exclude>
-										<exclude>org.codehaus.jackson</exclude>
-										<exclude>org.eobjects.metamodel</exclude>
+										<exclude>org.codehaus.jackson:*</exclude>
+										<exclude>org.eobjects.metamodel:*</exclude>
 									</excludes>
 								</bannedDependencies>
 							</rules>


### PR DESCRIPTION
It seems that our configuration of the enforcer plugin used the same id in parent and monitor pom. And unfortunately that means that a few banned dependencies have slipped into our build!

We need to do something about this asap since downstream builds are affected.