### PR TITLE
Added logging about all CountDownLatch.await() calls in engine and api

### DIFF
--- a/api/src/main/java/org/datacleaner/api/AnalyzerResultFutureImpl.java
+++ b/api/src/main/java/org/datacleaner/api/AnalyzerResultFutureImpl.java
@@ -169,11 +169,12 @@ public class AnalyzerResultFutureImpl<R extends AnalyzerResult> implements Analy
             try {
                 boolean finished = false;
                 int iteration = 0;
+                final int minutesToWaitPerIteration = 2;
                 while (!finished) {
                     iteration++;
-                    finished = _countDownLatch.await(2, TimeUnit.MINUTES);
+                    finished = _countDownLatch.await(minutesToWaitPerIteration, TimeUnit.MINUTES);
                     if (!finished) {
-                        logger.info("Awaited completion for " + (iteration * 2) + " minutes...");
+                        logger.info("Awaited completion for " + (iteration * minutesToWaitPerIteration) + " minutes...");
                     }
                 }
             } catch (InterruptedException e) {

--- a/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/concurrent/JobCompletionTaskListener.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.datacleaner.job.runner.AnalysisJobMetrics;
 import org.datacleaner.job.runner.AnalysisListener;
 import org.datacleaner.job.tasks.Task;
+import org.datacleaner.util.ConcurrencyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +57,7 @@ public final class JobCompletionTaskListener implements StatusAwareTaskListener 
 
     @Override
     public void await() throws InterruptedException {
-        _countDownLatch.await();
+        ConcurrencyUtils.awaitCountDown(_countDownLatch, "job completion");
     }
 
     @Override

--- a/engine/core/src/main/java/org/datacleaner/job/runner/ActiveOutputDataStream.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/ActiveOutputDataStream.java
@@ -29,6 +29,7 @@ import org.apache.metamodel.schema.Table;
 import org.datacleaner.api.HasOutputDataStreams;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.job.OutputDataStreamJob;
+import org.datacleaner.util.ConcurrencyUtils;
 
 public class ActiveOutputDataStream implements Closeable {
 
@@ -38,8 +39,8 @@ public class ActiveOutputDataStream implements Closeable {
     private final CountDownLatch _countDownLatch;
     private OutputDataStreamRowCollector _outputRowCollector;
 
-    public ActiveOutputDataStream(OutputDataStreamJob outputDataStreamJob,
-            RowProcessingPublisher publisher, HasOutputDataStreams component) {
+    public ActiveOutputDataStream(OutputDataStreamJob outputDataStreamJob, RowProcessingPublisher publisher,
+            HasOutputDataStreams component) {
         _outputDataStreamJob = outputDataStreamJob;
         _publisher = publisher;
         _component = component;
@@ -71,7 +72,7 @@ public class ActiveOutputDataStream implements Closeable {
     }
 
     public void await() throws InterruptedException {
-        _countDownLatch.await();
+        ConcurrencyUtils.awaitCountDown(_countDownLatch, "stream: " + _outputDataStreamJob.getOutputDataStream());
     }
 
     @Override

--- a/engine/core/src/main/java/org/datacleaner/util/ConcurrencyUtils.java
+++ b/engine/core/src/main/java/org/datacleaner/util/ConcurrencyUtils.java
@@ -1,0 +1,73 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+/**
+ *  This file is part of DataCleaner.
+ *
+ *  DataCleaner is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  DataCleaner is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with DataCleaner.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.datacleaner.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utilities for handling concurrency - mostly the oriented around the
+ * java.util.concurrent classes.
+ */
+public class ConcurrencyUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConcurrencyUtils.class);
+    private static final int AWAIT_TIMEOUT_MINUTES = 2;
+
+    private ConcurrencyUtils() {
+        // prevent instantiation
+    }
+
+    public static void awaitCountDown(CountDownLatch countDownLatch, String countDownLatchId) {
+        int iteration = 0;
+        try {
+            boolean finished = false;
+            while (!finished) {
+                iteration++;
+                finished = countDownLatch.await(AWAIT_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+                if (!finished) {
+                    logger.info("Awaited completion of '" + countDownLatchId + "' for "
+                            + (iteration * AWAIT_TIMEOUT_MINUTES) + " minutes...");
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Awaiting completion of '" + countDownLatchId + "' was interrupted!", e);
+        }
+    }
+}


### PR DESCRIPTION
This is a small fix to add some logging whenever we are waiting for a long time on CountDownLatches. 

Background: Recently we've seen that the build sometimes stalls in Travis CI ("no output received in 10 minutes"). While I still don't know why that would happen, my guess is that somewhere we maybe have a race condition. And since we call the "normal" CountDownLatch.await() method which blocks infinitely here and there, I thought it would be good to add some logging instead for every 2 minutes that pass by while waiting. That way we gain two things:

 * A bit of logging in general on what is happening, why something is not responding.
 * Maybe good hints from Travis on where we may have some issues.