### PR TITLE
Fixed UI's response to non-analyzers adding "executability" to a job

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
@@ -290,7 +290,8 @@ public final class JobGraph {
                     subTitle = "Right-click the source table and select 'Link to ...'.\n"
                             + "This directs the flow of data to the component.";
                     imagePath = "images/window/canvas-bg-connect.png";
-                } else if (_analysisJobBuilder.getAnalyzerComponentBuilders().size() == 0
+                } else if (_analysisJobBuilder.getResultProducingComponentBuilders().size() == 0
+                        && _analysisJobBuilder.getConsumedOutputDataStreamsJobBuilders().size() == 0
                         && _analysisJobBuilder.getComponentCount() <= 3) {
                     title = "Your job is almost ready.";
                     subTitle = "Jobs need to either 'Analyze' or 'Write' something.\n"

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -982,13 +982,15 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
             public void actionPerformed(ActionEvent e) {
                 applyPropertyValues();
 
-                if (analysisJobBuilder.getAnalyzerComponentBuilders().isEmpty()) {
-                    // Present choices to user to write file somewhere,
-                    // and then run a copy of the job based on that.
-                    ExecuteJobWithoutAnalyzersDialog executeJobWithoutAnalyzersPanel = new ExecuteJobWithoutAnalyzersDialog(
-                            _dcModule, getWindowContext(), analysisJobBuilder, _userPreferences);
-                    executeJobWithoutAnalyzersPanel.open();
-                    return;
+                if (analysisJobBuilder.getResultProducingComponentBuilders().isEmpty()) {
+                    if (analysisJobBuilder.getConsumedOutputDataStreamsJobBuilders().isEmpty()) {
+                        // Present choices to user to write file somewhere,
+                        // and then run a copy of the job based on that.
+                        ExecuteJobWithoutAnalyzersDialog executeJobWithoutAnalyzersPanel = new ExecuteJobWithoutAnalyzersDialog(
+                                _dcModule, getWindowContext(), analysisJobBuilder, _userPreferences);
+                        executeJobWithoutAnalyzersPanel.open();
+                        return;
+                    }
                 }
 
                 final RunAnalysisActionListener runAnalysis = new RunAnalysisActionListener(_dcModule,


### PR DESCRIPTION
Fixes #671 

In short: Analyzers are no longer the only type of component that could make a job worth executing, so this PR relaxes some of the feedback you get in the UI about wanting to execute a job under certain circumstances.