### PR TITLE
Feature/664 show melon columns

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -85,7 +85,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _descriptor = componentBuilder.getDescriptor();
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
-        _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder.getAnalysisJobBuilder(), _componentBuilder, null);
+        _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder);
         onOutputDataStreamsChanged();
 
         setLayout(new BorderLayout());

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -86,6 +86,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
         _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder.getAnalysisJobBuilder(), _componentBuilder, null);
+        onOutputDataStreamsChanged();
 
         setLayout(new BorderLayout());
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -85,6 +85,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
         _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder.getAnalysisJobBuilder(), _componentBuilder, null);
+        _outputDataStreamsViewer.refresh();
         addTaskPane(IconUtils.MODEL_TABLE, "Output data streams", _outputDataStreamsViewer);
 
         setLayout(new BorderLayout());

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -298,7 +298,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _taskPaneContainer.remove(_outputDataStreamsTaskPane);
         _outputDataStreamsViewer.refresh();
         if (_outputDataStreamsViewer.isEnabled()) {
-            _outputDataStreamsTaskPane = addTaskPane(IconUtils.MODEL_TABLE, "Output data streams", _outputDataStreamsViewer);
+            _outputDataStreamsTaskPane = addTaskPane(IconUtils.OUTPUT_DATA_STREAM_PATH, "Output data streams", _outputDataStreamsViewer);
         }
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -68,6 +68,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
     private final ComponentDescriptor<?> _descriptor;
     private final JComponent _buttonPanel;
     private final OutputDataStreamsViewer _outputDataStreamsViewer;
+    private JXTaskPane _outputDataStreamsTaskPane;
 
     protected AbstractComponentBuilderPanel(String watermarkImagePath, ComponentBuilder componentBuilder,
             PropertyWidgetFactory propertyWidgetFactory) {
@@ -85,8 +86,6 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
         _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder.getAnalysisJobBuilder(), _componentBuilder, null);
-        _outputDataStreamsViewer.refresh();
-        addTaskPane(IconUtils.MODEL_TABLE, "Output data streams", _outputDataStreamsViewer);
 
         setLayout(new BorderLayout());
 
@@ -287,7 +286,12 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
      */
     protected void onConfigurationChanged() {
         getPropertyWidgetCollection().onConfigurationChanged();
+        
+        _taskPaneContainer.remove(_outputDataStreamsTaskPane);
         _outputDataStreamsViewer.refresh();
+        if (_outputDataStreamsViewer.isEnabled()) {
+            _outputDataStreamsTaskPane = addTaskPane(IconUtils.MODEL_TABLE, "Output data streams", _outputDataStreamsViewer);
+        }
     }
 
     /**

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -287,6 +287,10 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
     protected void onConfigurationChanged() {
         getPropertyWidgetCollection().onConfigurationChanged();
         
+        onOutputDataStreamsChanged();
+    }
+
+    private void onOutputDataStreamsChanged() {
         _taskPaneContainer.remove(_outputDataStreamsTaskPane);
         _outputDataStreamsViewer.refresh();
         if (_outputDataStreamsViewer.isEnabled()) {

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -287,6 +287,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
      */
     protected void onConfigurationChanged() {
         getPropertyWidgetCollection().onConfigurationChanged();
+        _outputDataStreamsViewer.refresh();
     }
 
     /**

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -67,6 +67,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
     private final ComponentBuilder _componentBuilder;
     private final ComponentDescriptor<?> _descriptor;
     private final JComponent _buttonPanel;
+    private final OutputDataStreamsViewer _outputDataStreamsViewer;
 
     protected AbstractComponentBuilderPanel(String watermarkImagePath, ComponentBuilder componentBuilder,
             PropertyWidgetFactory propertyWidgetFactory) {
@@ -83,12 +84,14 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _descriptor = componentBuilder.getDescriptor();
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
+        _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder.getAnalysisJobBuilder(), _componentBuilder, null);
+        addTaskPane(IconUtils.MODEL_TABLE, "Output data streams", _outputDataStreamsViewer);
 
         setLayout(new BorderLayout());
 
         final JScrollPane scrolleable = WidgetUtils.scrolleable(_taskPaneContainer);
         add(scrolleable, BorderLayout.CENTER);
-
+        
         _buttonPanel = createTopButtonPanel();
         add(_buttonPanel, BorderLayout.NORTH);
     }

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -86,7 +86,6 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         _propertyWidgetFactory = propertyWidgetFactory;
         _propertyWidgetCollection = propertyWidgetFactory.getPropertyWidgetCollection();
         _outputDataStreamsViewer = new OutputDataStreamsViewer(_componentBuilder);
-        onOutputDataStreamsChanged();
 
         setLayout(new BorderLayout());
 
@@ -138,6 +137,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         final ComponentBuilder componentBuilder = getComponentBuilder();
 
         final List<ConfiguredPropertyTaskPane> propertyTaskPanes = createPropertyTaskPanes();
+        
 
         final Set<ConfiguredPropertyDescriptor> unconfiguredPropertyDescriptors = new HashSet<>();
         unconfiguredPropertyDescriptors.addAll(componentBuilder.getDescriptor().getConfiguredProperties());
@@ -150,6 +150,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
             unconfiguredPropertyDescriptors.removeAll(propertyTaskPane.getProperties());
         }
 
+
         if (!unconfiguredPropertyDescriptors.isEmpty()) {
             for (ConfiguredPropertyDescriptor property : unconfiguredPropertyDescriptors) {
                 logger.warn("No property widget was found in task panes for property: {}", property);
@@ -159,6 +160,8 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
                 getPropertyWidgetCollection().registerWidget(property, propertyWidget);
             }
         }
+        
+        onOutputDataStreamsChanged();
     }
 
     protected List<ConfiguredPropertyTaskPane> createPropertyTaskPanes() {

--- a/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
@@ -212,7 +212,7 @@ public final class ColumnListTable extends DCPanel {
         }
         _columnTable.setModel(model);
 
-        if ((hasPhysicalColumns) && (_editable)) {
+        if (hasPhysicalColumns && _editable) {
             final TableColumnExt columnExt = _columnTable.getColumnExt(2);
             columnExt.setMinWidth(26);
             columnExt.setMaxWidth(80);

--- a/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
@@ -77,7 +77,7 @@ public final class ColumnListTable extends DCPanel {
     private final WindowContext _windowContext;
     private final boolean _addShadowBorder;
 
-    private boolean _editable;
+    private final boolean _editable;
 
     public ColumnListTable(Collection<? extends InputColumn<?>> columns, AnalysisJobBuilder analysisJobBuilder,
             boolean addShadowBorder, WindowContext windowContext) {
@@ -176,7 +176,7 @@ public final class ColumnListTable extends DCPanel {
         }
 
         final String[] headers;
-        if ((hasPhysicalColumns) && (_editable)) {
+        if (hasPhysicalColumns && _editable) {
             headers = HEADERS_WITH_ACTION_COLUMN;
         } else {
             headers = HEADERS_WITHOUT_ACTIONS;

--- a/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
@@ -77,22 +77,35 @@ public final class ColumnListTable extends DCPanel {
     private final WindowContext _windowContext;
     private final boolean _addShadowBorder;
 
+    private boolean _editable;
+
     public ColumnListTable(Collection<? extends InputColumn<?>> columns, AnalysisJobBuilder analysisJobBuilder,
             boolean addShadowBorder, WindowContext windowContext) {
-        this(null, columns, analysisJobBuilder, addShadowBorder, windowContext);
+        this(null, columns, analysisJobBuilder, addShadowBorder, true, windowContext);
+    }
+    
+    public ColumnListTable(Collection<? extends InputColumn<?>> columns, AnalysisJobBuilder analysisJobBuilder,
+            boolean addShadowBorder, boolean editable, WindowContext windowContext) {
+        this(null, columns, analysisJobBuilder, addShadowBorder, editable, windowContext);
     }
 
     public ColumnListTable(Table table, AnalysisJobBuilder analysisJobBuilder, boolean addShadowBorder,
             WindowContext windowContext) {
-        this(table, null, analysisJobBuilder, addShadowBorder, windowContext);
+        this(table, null, analysisJobBuilder, addShadowBorder, true, windowContext);
+    }
+    
+    public ColumnListTable(Table table, AnalysisJobBuilder analysisJobBuilder, boolean addShadowBorder, boolean editable,
+            WindowContext windowContext) {
+        this(table, null, analysisJobBuilder, addShadowBorder, editable, windowContext);
     }
 
     private ColumnListTable(Table table, Collection<? extends InputColumn<?>> columns,
-            AnalysisJobBuilder analysisJobBuilder, boolean addShadowBorder, WindowContext windowContext) {
+            AnalysisJobBuilder analysisJobBuilder, boolean addShadowBorder, boolean editable, WindowContext windowContext) {
         super();
         _table = table;
         _analysisJobBuilder = analysisJobBuilder;
         _addShadowBorder = addShadowBorder;
+        _editable = editable;
         _windowContext = windowContext;
 
         setLayout(new BorderLayout());
@@ -124,16 +137,18 @@ public final class ColumnListTable extends DCPanel {
                 headerPanel.add(queryButton);
             }
 
-            final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE);
-            removeButton.setToolTipText("Remove table from source");
-            removeButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    _analysisJobBuilder.removeSourceTable(_table);
-                }
-            });
-            headerPanel.add(Box.createHorizontalStrut(4));
-            headerPanel.add(removeButton);
+            if (_editable) {
+                final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE);
+                removeButton.setToolTipText("Remove table from source");
+                removeButton.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        _analysisJobBuilder.removeSourceTable(_table);
+                    }
+                });
+                headerPanel.add(Box.createHorizontalStrut(4));
+                headerPanel.add(removeButton);
+            }
 
             add(headerPanel, BorderLayout.NORTH);
         }
@@ -161,7 +176,7 @@ public final class ColumnListTable extends DCPanel {
         }
 
         final String[] headers;
-        if (hasPhysicalColumns) {
+        if ((hasPhysicalColumns) && (_editable)) {
             headers = HEADERS_WITH_ACTION_COLUMN;
         } else {
             headers = HEADERS_WITHOUT_ACTIONS;
@@ -178,7 +193,7 @@ public final class ColumnListTable extends DCPanel {
             final String dataTypeString = LabelUtils.getDataTypeLabel(dataType);
             model.setValueAt(dataTypeString, i, 1);
 
-            if (column.isPhysicalColumn()) {
+            if (column.isPhysicalColumn() && (_editable)) {
                 final DCPanel buttonPanel = new DCPanel();
                 buttonPanel.setLayout(new GridBagLayout());
                 final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE);
@@ -197,7 +212,7 @@ public final class ColumnListTable extends DCPanel {
         }
         _columnTable.setModel(model);
 
-        if (hasPhysicalColumns) {
+        if ((hasPhysicalColumns) && (_editable)) {
             final TableColumnExt columnExt = _columnTable.getColumnExt(2);
             columnExt.setMinWidth(26);
             columnExt.setMaxWidth(80);
@@ -281,4 +296,9 @@ public final class ColumnListTable extends DCPanel {
     public int getColumnCount() {
         return _columns.size();
     }
+    
+    public boolean isEditable() {
+        return _editable;
+    }
+    
 }

--- a/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/ColumnListTable.java
@@ -193,7 +193,7 @@ public final class ColumnListTable extends DCPanel {
             final String dataTypeString = LabelUtils.getDataTypeLabel(dataType);
             model.setValueAt(dataTypeString, i, 1);
 
-            if (column.isPhysicalColumn() && (_editable)) {
+            if (column.isPhysicalColumn() && _editable) {
                 final DCPanel buttonPanel = new DCPanel();
                 buttonPanel.setLayout(new GridBagLayout());
                 final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE);

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -64,7 +64,7 @@ public final class OutputDataStreamsViewer extends DCPanel {
                 inputColumns.add(inputColumn);
             }
             final JLabel tableNameLabel = new JLabel(outputDataStream.getName(), ImageManager.get().getImageIcon(
-                    IconUtils.MODEL_COLUMN, IconUtils.ICON_SIZE_SMALL), JLabel.LEFT);
+                    IconUtils.OUTPUT_DATA_STREAM_PATH, IconUtils.ICON_SIZE_SMALL), JLabel.LEFT);
             tableNameLabel.setOpaque(false);
             tableNameLabel.setFont(WidgetUtils.FONT_HEADER1);
             tableNameLabel.setBorder(new EmptyBorder(5, 5, 0, 5));

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -19,9 +19,11 @@
  */
 package org.datacleaner.panels;
 
-import java.awt.BorderLayout;
+import java.awt.FlowLayout;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.swing.JLabel;
 
 import org.apache.metamodel.schema.Column;
 import org.datacleaner.api.InputColumn;
@@ -30,6 +32,10 @@ import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.data.MetaModelInputColumn;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.ImageManager;
+import org.datacleaner.util.WidgetUtils;
+import org.jdesktop.swingx.VerticalLayout;
 
 /**
  * Panel that displays {@link OutputDataStream}s published by the component.
@@ -47,24 +53,33 @@ public final class OutputDataStreamsViewer extends DCPanel {
         _analysisJobBuilder = analysisJobBuilder;
         _componentBuilder = componentBuilder;
         _windowContext = windowsContext;
+        
+        setLayout(new VerticalLayout(4));
+        
         refresh();
     }
 
     public void refresh() {
         removeAll();
-
+        
         for (OutputDataStream outputDataStream : _componentBuilder.getOutputDataStreams()) {
             List<InputColumn<?>> inputColumns = new ArrayList<>();
             for (Column column : outputDataStream.getTable().getColumns()) {
                 MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);
                 inputColumns.add(inputColumn);
             }
+            final DCPanel headerPanel = new DCPanel();
+            headerPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            final JLabel tableNameLabel = new JLabel(outputDataStream.getName(), ImageManager.get().getImageIcon(
+                    IconUtils.MODEL_COLUMN, IconUtils.ICON_SIZE_SMALL), JLabel.LEFT);
+            tableNameLabel.setOpaque(false);
+            tableNameLabel.setFont(WidgetUtils.FONT_HEADER1);
+            headerPanel.add(tableNameLabel);
             final ColumnListTable columnListTable = new ColumnListTable(inputColumns, _analysisJobBuilder,
                     true, false, _windowContext);
 
-            DCPanel outputDataStreamPanel = new DCPanel();
-            outputDataStreamPanel.add(columnListTable, BorderLayout.AFTER_LAST_LINE);
-            add(outputDataStreamPanel, BorderLayout.AFTER_LAST_LINE);
+            add(headerPanel);
+            add(columnListTable);
         }
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -19,11 +19,11 @@
  */
 package org.datacleaner.panels;
 
-import java.awt.FlowLayout;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JLabel;
+import javax.swing.border.EmptyBorder;
 
 import org.apache.metamodel.schema.Column;
 import org.datacleaner.api.InputColumn;
@@ -69,17 +69,16 @@ public final class OutputDataStreamsViewer extends DCPanel {
                 MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);
                 inputColumns.add(inputColumn);
             }
-            final DCPanel headerPanel = new DCPanel();
-            headerPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
             final JLabel tableNameLabel = new JLabel(outputDataStream.getName(), ImageManager.get().getImageIcon(
                     IconUtils.MODEL_COLUMN, IconUtils.ICON_SIZE_SMALL), JLabel.LEFT);
             tableNameLabel.setOpaque(false);
             tableNameLabel.setFont(WidgetUtils.FONT_HEADER1);
-            headerPanel.add(tableNameLabel);
+            tableNameLabel.setBorder(new EmptyBorder(5, 5, 0, 5));
             final ColumnListTable columnListTable = new ColumnListTable(inputColumns, _analysisJobBuilder,
                     true, false, _windowContext);
+            columnListTable.setBorder(new EmptyBorder(0, 5, 5, 5));
 
-            add(headerPanel);
+            add(tableNameLabel);
             add(columnListTable);
         }
     }

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -58,10 +58,9 @@ public final class OutputDataStreamsViewer extends DCPanel {
         for (OutputDataStream outputDataStream : _componentBuilder.getOutputDataStreams()) {
             setEnabled(true);
             
-            List<InputColumn<?>> inputColumns = new ArrayList<>();
+            final List<InputColumn<?>> inputColumns = new ArrayList<>();
             for (Column column : outputDataStream.getTable().getColumns()) {
-                MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);
-                inputColumns.add(inputColumn);
+                inputColumns.add(new MetaModelInputColumn(column));
             }
             final JLabel tableNameLabel = new JLabel(outputDataStream.getName(), ImageManager.get().getImageIcon(
                     IconUtils.OUTPUT_DATA_STREAM_PATH, IconUtils.ICON_SIZE_SMALL), JLabel.LEFT);

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -28,9 +28,7 @@ import javax.swing.border.EmptyBorder;
 import org.apache.metamodel.schema.Column;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.OutputDataStream;
-import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.data.MetaModelInputColumn;
-import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
@@ -44,15 +42,11 @@ public final class OutputDataStreamsViewer extends DCPanel {
 
     private static final long serialVersionUID = 1L;
 
-    private final AnalysisJobBuilder _analysisJobBuilder;
     private final ComponentBuilder _componentBuilder;
-    private final  WindowContext _windowContext;
 
-    public OutputDataStreamsViewer(AnalysisJobBuilder analysisJobBuilder, ComponentBuilder componentBuilder, WindowContext windowsContext) {
+    public OutputDataStreamsViewer(ComponentBuilder componentBuilder) {
         super();
-        _analysisJobBuilder = analysisJobBuilder;
         _componentBuilder = componentBuilder;
-        _windowContext = windowsContext;
         
         setLayout(new VerticalLayout(4));
     }
@@ -74,8 +68,8 @@ public final class OutputDataStreamsViewer extends DCPanel {
             tableNameLabel.setOpaque(false);
             tableNameLabel.setFont(WidgetUtils.FONT_HEADER1);
             tableNameLabel.setBorder(new EmptyBorder(5, 5, 0, 5));
-            final ColumnListTable columnListTable = new ColumnListTable(inputColumns, _analysisJobBuilder,
-                    true, false, _windowContext);
+            final ColumnListTable columnListTable = new ColumnListTable(inputColumns, _componentBuilder.getAnalysisJobBuilder(),
+                    true, false, null);
             columnListTable.setBorder(new EmptyBorder(0, 5, 5, 5));
 
             add(tableNameLabel);

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -55,14 +55,15 @@ public final class OutputDataStreamsViewer extends DCPanel {
         _windowContext = windowsContext;
         
         setLayout(new VerticalLayout(4));
-        
-        refresh();
     }
 
     public void refresh() {
         removeAll();
         
+        setEnabled(false);
         for (OutputDataStream outputDataStream : _componentBuilder.getOutputDataStreams()) {
+            setEnabled(true);
+            
             List<InputColumn<?>> inputColumns = new ArrayList<>();
             for (Column column : outputDataStream.getTable().getColumns()) {
                 MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);

--- a/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/OutputDataStreamsViewer.java
@@ -1,0 +1,71 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.panels;
+
+import java.awt.BorderLayout;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.metamodel.schema.Column;
+import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.OutputDataStream;
+import org.datacleaner.bootstrap.WindowContext;
+import org.datacleaner.data.MetaModelInputColumn;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.ComponentBuilder;
+
+/**
+ * Panel that displays {@link OutputDataStream}s published by the component.
+ */
+public final class OutputDataStreamsViewer extends DCPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final AnalysisJobBuilder _analysisJobBuilder;
+    private final ComponentBuilder _componentBuilder;
+    private final  WindowContext _windowContext;
+
+    public OutputDataStreamsViewer(AnalysisJobBuilder analysisJobBuilder, ComponentBuilder componentBuilder, WindowContext windowsContext) {
+        super();
+        _analysisJobBuilder = analysisJobBuilder;
+        _componentBuilder = componentBuilder;
+        _windowContext = windowsContext;
+        refresh();
+    }
+
+    public void refresh() {
+        removeAll();
+
+        for (OutputDataStream outputDataStream : _componentBuilder.getOutputDataStreams()) {
+            List<InputColumn<?>> inputColumns = new ArrayList<>();
+            for (Column column : outputDataStream.getTable().getColumns()) {
+                MetaModelInputColumn inputColumn = new MetaModelInputColumn(column);
+                inputColumns.add(inputColumn);
+            }
+            final ColumnListTable columnListTable = new ColumnListTable(inputColumns, _analysisJobBuilder,
+                    true, false, _windowContext);
+
+            DCPanel outputDataStreamPanel = new DCPanel();
+            outputDataStreamPanel.add(columnListTable, BorderLayout.AFTER_LAST_LINE);
+            add(outputDataStreamPanel, BorderLayout.AFTER_LAST_LINE);
+        }
+    }
+
+}


### PR DESCRIPTION
There is one issue I am struggling with. When a component is connected via "Link to...", the "Output data streams" appears as the first task pane. Every change in the input columns forces a refresh and a task pane is added at the end. I would like to have it always at the end, but cannot find an easy way to accomplish that.

Screenshot of the overall design
![melons task pane](https://cloud.githubusercontent.com/assets/1483194/10019056/5bcec302-613b-11e5-9ce0-82fc5c07d503.png)
:


Fixes #664 

