### PR TITLE
Feature/remote components default values

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedEnumsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedEnumsPropertyWidget.java
@@ -35,7 +35,6 @@ import org.datacleaner.api.InputColumn;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.descriptors.EnumerationProvider;
 import org.datacleaner.descriptors.EnumerationValue;
-import org.datacleaner.descriptors.JsonSchemaConfiguredPropertyDescriptorImpl;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.util.DefaultEnumMatcher;
@@ -74,7 +73,7 @@ public class MultipleMappedEnumsPropertyWidget extends MultipleInputColumnsPrope
         @Override
         public Object[] getValue() {
             EnumerationValue[] values = getMappedEnums();
-            if(_mappedEnumsProperty instanceof JsonSchemaConfiguredPropertyDescriptorImpl) {
+            if(_mappedEnumsProperty instanceof EnumerationProvider) {
                 return values;
             } else {
                 Object[] enumValues = (Object[]) Array.newInstance(_mappedEnumsProperty.getBaseType(), values.length);
@@ -179,8 +178,8 @@ public class MultipleMappedEnumsPropertyWidget extends MultipleInputColumnsPrope
      * @return
      */
     protected EnumerationValue[] getEnumConstants(InputColumn<?> inputColumn, ConfiguredPropertyDescriptor mappedEnumsProperty) {
-        if(mappedEnumsProperty instanceof JsonSchemaConfiguredPropertyDescriptorImpl) {
-            return ((JsonSchemaConfiguredPropertyDescriptorImpl)mappedEnumsProperty).getEnumValues();
+        if(mappedEnumsProperty instanceof EnumerationProvider) {
+            return ((EnumerationProvider)mappedEnumsProperty).values();
         } else {
             return EnumerationValue.fromArray(mappedEnumsProperty.getBaseType().getEnumConstants());
         }
@@ -257,8 +256,8 @@ public class MultipleMappedEnumsPropertyWidget extends MultipleInputColumnsPrope
      * @return
      */
     protected EnumMatcher<EnumerationValue> createEnumMatcher() {
-        if(_mappedEnumsProperty instanceof JsonSchemaConfiguredPropertyDescriptorImpl) {
-            return new DefaultEnumMatcher((JsonSchemaConfiguredPropertyDescriptorImpl)_mappedEnumsProperty);
+        if(_mappedEnumsProperty instanceof EnumerationProvider) {
+            return new DefaultEnumMatcher((EnumerationProvider)_mappedEnumsProperty);
         } else {
             EnumerationProvider prov = EnumerationValue.providerFromEnumClass((Class<? extends Enum>) _mappedEnumsProperty.getBaseType());
             return new DefaultEnumMatcher(prov);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleRemoteEnumPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleRemoteEnumPropertyWidget.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.metamodel.util.HasName;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
-import org.datacleaner.descriptors.JsonSchemaConfiguredPropertyDescriptorImpl;
+import org.datacleaner.descriptors.EnumerationProvider;
 import org.datacleaner.descriptors.EnumerationValue;
 import org.datacleaner.job.builder.ComponentBuilder;
 
@@ -41,7 +41,7 @@ public class MultipleRemoteEnumPropertyWidget extends AbstractMultipleCheckboxes
 
     @Override
     protected EnumerationValue[] getAvailableValues() {
-        return ((JsonSchemaConfiguredPropertyDescriptorImpl)getPropertyDescriptor()).getEnumValues();
+        return ((EnumerationProvider)getPropertyDescriptor()).values();
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/PropertyWidgetFactoryImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/PropertyWidgetFactoryImpl.java
@@ -38,6 +38,7 @@ import org.datacleaner.connection.DatastoreCatalog;
 import org.datacleaner.connection.UpdateableDatastore;
 import org.datacleaner.descriptors.ComponentDescriptor;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
+import org.datacleaner.descriptors.EnumerationProvider;
 import org.datacleaner.descriptors.EnumerationValue;
 import org.datacleaner.desktop.api.HiddenProperty;
 import org.datacleaner.guice.DCModule;
@@ -283,7 +284,7 @@ public final class PropertyWidgetFactoryImpl implements PropertyWidgetFactory {
                 widgetClass = MultipleSynonymCatalogsPropertyWidget.class;
             } else if (type == StringPattern.class) {
                 widgetClass = MultipleStringPatternPropertyWidget.class;
-            } else if(type == EnumerationValue.class) {
+            } else if(type == EnumerationValue.class && propertyDescriptor instanceof EnumerationProvider) {
                 widgetClass = MultipleRemoteEnumPropertyWidget.class;
             } else if (type.isEnum()) {
                 widgetClass = MultipleEnumPropertyWidget.class;
@@ -327,7 +328,7 @@ public final class PropertyWidgetFactoryImpl implements PropertyWidgetFactory {
                 widgetClass = SingleSynonymCatalogPropertyWidget.class;
             } else if (type == StringPattern.class) {
                 widgetClass = SingleStringPatternPropertyWidget.class;
-            } else if(type == EnumerationValue.class) {
+            } else if(type == EnumerationValue.class && propertyDescriptor instanceof EnumerationProvider) {
                 widgetClass = SingleRemoteEnumPropertyWidget.class;
             } else if (type.isEnum()) {
                 widgetClass = SingleEnumPropertyWidget.class;

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleRemoteEnumPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleRemoteEnumPropertyWidget.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.metamodel.util.CollectionUtils;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
-import org.datacleaner.descriptors.JsonSchemaConfiguredPropertyDescriptorImpl;
+import org.datacleaner.descriptors.EnumerationProvider;
 import org.datacleaner.descriptors.EnumerationValue;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.widgets.DCComboBox;
@@ -41,7 +41,7 @@ public class SingleRemoteEnumPropertyWidget extends AbstractPropertyWidget<Enume
                                     ComponentBuilder componentBuilder) {
         super(componentBuilder, propertyDescriptor);
 
-        EnumerationValue[] enumConstants = ((JsonSchemaConfiguredPropertyDescriptorImpl)propertyDescriptor).getEnumValues();
+        EnumerationValue[] enumConstants = ((EnumerationProvider)propertyDescriptor).values();
 
         if (!propertyDescriptor.isRequired()) {
             enumConstants = CollectionUtils.array(new EnumerationValue[]{null}, enumConstants);

--- a/engine/remote-components/src/main/java/org/datacleaner/components/remote/RemoteTransformer.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/components/remote/RemoteTransformer.java
@@ -46,6 +46,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
+ * Transformer that is actually a proxy to a remote transformer sitting at DataCleaner Monitor server.
+ * Instances of this transformer can be created only by
+ * {@link org.datacleaner.descriptors.RemoteTransformerDescriptorImpl} component descriptors.
+ *
  * @Since 9/1/15
  */
 public class RemoteTransformer implements Transformer {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/AnnotationProxy.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/AnnotationProxy.java
@@ -28,10 +28,24 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * This tricky class allows us to create new annotations dynamically. Java api doesn't provide anything like this, annotations can be
+ * created either via source code, or specific class can be defined. But to create a dynamic annotation of specific interface
+ * by reflection, that is not available in standard java api.
+ *
  * @Since 21.9.15
  */
 public class AnnotationProxy {
 
+    /**
+     * Factory method for annotations which is able to create an instance of any annotation class.
+     *
+     * @param anClass Annotation interface that should be instantiated
+     * @param properties map of values for the annotation. The name (key) of a property is interpreted as a name of
+     *                   a method from the annotation interface. The created annotation proxy then returns this value
+     *                   when this method is called.
+     * @param <A>
+     * @return An annotation instance providing given values by its interface methods.
+     */
     public static <A extends Annotation> A newAnnotation(Class<A> anClass, Map<String, Object> properties) {
         return (A)Proxy.newProxyInstance(AnnotationProxy.class.getClassLoader(), new Class[] {anClass}, new InvHandler(properties));
     }

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/JsonSchemaConfiguredPropertyDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/JsonSchemaConfiguredPropertyDescriptorImpl.java
@@ -35,6 +35,10 @@ import java.util.Map;
 import java.util.Set;
 
 /**
+ * Property descriptor for properties of RemoteTransformer, which has no appropriate class on the client side.
+ * (Class is available only on server, but is not part of standard DataCleaner installation).
+ * The data type of the property is represented by Json Schema. Special care was taken to support enumerations.
+ *
  * @Since 9/1/15
  */
 public class JsonSchemaConfiguredPropertyDescriptorImpl extends RemoteConfiguredPropertyDescriptor implements EnumerationProvider {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/JsonSchemaConfiguredPropertyDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/JsonSchemaConfiguredPropertyDescriptorImpl.java
@@ -37,29 +37,20 @@ import java.util.Set;
 /**
  * @Since 9/1/15
  */
-public class JsonSchemaConfiguredPropertyDescriptorImpl implements ConfiguredPropertyDescriptor, EnumerationProvider {
+public class JsonSchemaConfiguredPropertyDescriptorImpl extends RemoteConfiguredPropertyDescriptor implements EnumerationProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonSchemaConfiguredPropertyDescriptorImpl.class);
 
-    private String name;
-    private String description;
     private JsonSchema schema;
-    private ComponentDescriptor component;
     private boolean isInputColumn;
-    private boolean required;
     private boolean isArray;
     private Class baseType;
     private EnumerationValue[] enumValues;
-    Map<Class<Annotation>, Annotation> annotations = new HashMap<>();
 
-    public JsonSchemaConfiguredPropertyDescriptorImpl(String name, JsonSchema schema, boolean isInputColumn, String description, boolean required, ComponentDescriptor component, Map<Class<Annotation>, Annotation> annotations) {
-        this.name = name;
-        this.description = description;
+    public JsonSchemaConfiguredPropertyDescriptorImpl(String name, JsonSchema schema, boolean isInputColumn, String description, boolean required, ComponentDescriptor component, Map<Class<Annotation>, Annotation> annotations, JsonNode defaultValue) {
+        super(name, description, required, component, annotations, defaultValue);
         this.schema = schema;
         this.isInputColumn = isInputColumn;
-        this.component = component;
-        this.required = required;
-        this.annotations = annotations;
         init();
     }
 
@@ -101,38 +92,6 @@ public class JsonSchemaConfiguredPropertyDescriptorImpl implements ConfiguredPro
         // must be called after enums are initialized
         baseType = schemaToJavaType(baseSchema);
     }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public void setValue(Object component, Object value) throws IllegalArgumentException {
-        if(!(component instanceof RemoteTransformer)) {
-            throw new IllegalArgumentException("Cannot set remote property to non-remote transformer");
-        }
-        ((RemoteTransformer)component).setPropertyValue(this.getName(), value);
-    }
-
-    @Override
-    public Object getValue(Object component) throws IllegalArgumentException {
-        if(!(component instanceof RemoteTransformer)) {
-            throw new IllegalArgumentException("Cannot set remote property to non-remote transformer");
-        }
-        return ((RemoteTransformer)component).getPropertyValue(this.getName());
-    }
-
-    @Override
-    public Set<Annotation> getAnnotations() {
-        return new HashSet<>(annotations.values());
-    }
-
-    @Override
-    public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
-        return (A) annotations.get(annotationClass);
-    }
-
     @Override
     public Class<?> getType() {
         if(isArray()) {
@@ -152,50 +111,9 @@ public class JsonSchemaConfiguredPropertyDescriptorImpl implements ConfiguredPro
     }
 
     @Override
-    public ComponentDescriptor<?> getComponentDescriptor() {
-        return component;
-    }
-
-    @Override
-    public int getTypeArgumentCount() {
-        return 0;
-    }
-
-    @Override
-    public Class<?> getTypeArgument(int i) throws IndexOutOfBoundsException {
-        return null;
-    }
-
-    @Override
-    public int compareTo(PropertyDescriptor o) {
-        return getName().compareTo(o.getName());
-    }
-
-    @Override
     public boolean isInputColumn() {
         return isInputColumn;
     }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    @Override
-    public Class<? extends Converter<?>> getCustomConverter() {
-        return null;
-    }
-
-    @Override
-    public String[] getAliases() {
-        return new String[0];
-    }
-
     private Class<?> schemaToJavaType(JsonSchema schema) {
         // try to convert
         if(isEnum()) {
@@ -211,10 +129,6 @@ public class JsonSchemaConfiguredPropertyDescriptorImpl implements ConfiguredPro
 
     public boolean isEnum() {
         return enumValues != null && enumValues.length > 0;
-    }
-
-    public EnumerationValue[] getEnumValues() {
-        return enumValues;
     }
 
     @Override

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
@@ -1,16 +1,16 @@
 /**
  * DataCleaner (community edition)
  * Copyright (C) 2014 Neopost - Customer Information Management
- * <p>
+ *
  * This copyrighted material is made available to anyone wishing to use, modify,
  * copy, or redistribute it subject to the terms and conditions of the GNU
  * Lesser General Public License, as published by the Free Software Foundation.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
  * for more details.
- * <p>
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this distribution; if not, write to:
  * Free Software Foundation, Inc.
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
+ * A Base class for property descriptors of remote transformers, implementing common functions. See the child classes for details.
+ *
  * @Since 25.9.15
  */
 public abstract class RemoteConfiguredPropertyDescriptor implements ConfiguredPropertyDescriptor {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
@@ -95,6 +95,14 @@ public abstract class RemoteConfiguredPropertyDescriptor implements ConfiguredPr
     }
 
     private Object createDefaultValue() {
+        // TODO: this is code duplicate with ComponentHandler.convertPropertyValue
+        // (which is used to deserialize properties values on the server side).
+        // TODO: But on server side a StringConverter is used for string values,
+        // which is not fully available on client
+        // side (some extenstions providing custom converters may be not available on client classpath).
+        // We must unify how values are serialized on client as well as server side. Maybe use pure JSON string?
+        // Maybe it is enough to support JsonNode in StringConverter? That should fit the unknown values...
+
         try {
             return Serializator.getJacksonObjectMapper().treeToValue(defaultValue, getType());
         } catch (Exception e) {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
@@ -1,0 +1,144 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ * <p>
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.descriptors;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.datacleaner.api.Converter;
+import org.datacleaner.api.InputColumn;
+import org.datacleaner.components.remote.RemoteTransformer;
+import org.datacleaner.restclient.Serializator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @Since 25.9.15
+ */
+public abstract class RemoteConfiguredPropertyDescriptor implements ConfiguredPropertyDescriptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteConfiguredPropertyDescriptor.class);
+
+    private final String name;
+    private final String description;
+    private final boolean required;
+    private final ComponentDescriptor component;
+    private final Map<Class<Annotation>, Annotation> annotations;
+    private final JsonNode defaultValue;
+
+    RemoteConfiguredPropertyDescriptor(String name, String description, boolean required, ComponentDescriptor component, Map<Class<Annotation>, Annotation> annotations, JsonNode defaultValue) {
+        this.name = name;
+        this.annotations = annotations;
+        this.defaultValue = defaultValue;
+        this.description = description;
+        this.required = required;
+        this.component = component;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean isRequired() {
+        return required;
+    }
+
+    @Override
+    public Class<? extends Converter<?>> getCustomConverter() {
+        return null;
+    }
+
+    @Override
+    public String[] getAliases() {
+        return new String[0];  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setValue(Object component, Object value) throws IllegalArgumentException {
+        ((RemoteTransformer)component).setPropertyValue(getName(), value);
+    }
+
+    public void setDefaultValue(Object component) {
+        if(defaultValue != null) {
+            ((RemoteTransformer) component).setPropertyValue(getName(), createDefaultValue());
+        }
+    }
+
+    private Object createDefaultValue() {
+        try {
+            return Serializator.getJacksonObjectMapper().treeToValue(defaultValue, getType());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isInputColumn() {
+        return InputColumn.class.isAssignableFrom(getBaseType());
+    }
+
+
+    @Override
+    public Object getValue(Object component) throws IllegalArgumentException {
+        return ((RemoteTransformer)component).getPropertyValue(getName());
+    }
+
+    @Override
+    public Set<Annotation> getAnnotations() {
+        return new HashSet<>(annotations.values());
+    }
+
+    @Override
+    public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
+        return (A) annotations.get(annotationClass);
+    }
+
+    @Override
+    public ComponentDescriptor<?> getComponentDescriptor() {
+        return component;
+    }
+
+    @Override
+    public int getTypeArgumentCount() {
+        return 0;
+    }
+
+    @Override
+    public Class<?> getTypeArgument(int i) throws IndexOutOfBoundsException {
+        return null;
+    }
+
+    @Override
+    public int compareTo(PropertyDescriptor o) {
+        return getName().compareTo(o.getName());
+    }
+
+}

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteDescriptorProvider.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteDescriptorProvider.java
@@ -110,20 +110,19 @@ public class RemoteDescriptorProvider extends AbstractDescriptorProvider {
                             String propertyName = propE.getKey();
                             ComponentList.PropertyInfo propInfo = propE.getValue();
                             String className = propInfo.getClassName();
-                            ConfiguredPropertyDescriptor propDesc;
                             try {
                                 Class cl = findClass(className);
-                                transformer.addPropertyDescriptor(propDesc = new TypeBasedConfiguredPropertyDescriptorImpl(
+                                transformer.addPropertyDescriptor(new TypeBasedConfiguredPropertyDescriptorImpl(
                                         propertyName,
                                         propInfo.getDescription(),
                                         cl,
                                         propInfo.isRequired(),
                                         transformer,
                                         initAnnotations(component.getName(), propertyName, propInfo.getAnnotations()), propInfo.getDefaultValue()));
-                            } catch(Exception e) {
+                            } catch(ClassNotFoundException e) {
                                 logger.debug("Cannot initialize typed property descriptor '{}'.'{}'", component.getName(), propertyName, e);
                                 // class not available on this server.
-                                transformer.addPropertyDescriptor(propDesc = new JsonSchemaConfiguredPropertyDescriptorImpl(
+                                transformer.addPropertyDescriptor(new JsonSchemaConfiguredPropertyDescriptorImpl(
                                         propertyName,
                                         propInfo.getSchema(),
                                         propInfo.isInputColumn(),
@@ -164,8 +163,4 @@ public class RemoteDescriptorProvider extends AbstractDescriptorProvider {
         }
         return annotations;
     }
-
-    public static void main(String[] args) throws Exception {
-    }
-
 }

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteDescriptorProvider.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteDescriptorProvider.java
@@ -36,6 +36,10 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
+ * Provides descriptors of components that are available for remote calls on a DataCleaner Monitor server.
+ * The list of them is downloaded and appropriate descriptors are created for them
+ * ({@link RemoteTransformerDescriptorImpl}).
+ *
  * @Since 9/8/15
  */
 public class RemoteDescriptorProvider extends AbstractDescriptorProvider {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteTransformerDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteTransformerDescriptorImpl.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Transformer descriptor that represents a remote transformer sitting on a DataCleaner Monitor server. This descriptor
+ * is created by {@link RemoteDescriptorProvider} when it downloads a transformers list from the server.
  @Since 9/1/15
  */
 public class RemoteTransformerDescriptorImpl extends SimpleComponentDescriptor implements TransformerDescriptor, HasIcon {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteTransformerDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteTransformerDescriptorImpl.java
@@ -116,6 +116,11 @@ public class RemoteTransformerDescriptorImpl extends SimpleComponentDescriptor i
     @Override
     public Object newInstance() {
         RemoteTransformer t = new RemoteTransformer(baseUrl, remoteDisplayName, tenant, username, password);
+        for(ConfiguredPropertyDescriptor prop: (Set<ConfiguredPropertyDescriptor>)_configuredProperties) {
+            if(prop instanceof RemoteConfiguredPropertyDescriptor) {
+                ((RemoteConfiguredPropertyDescriptor)prop).setDefaultValue(t);
+            }
+        }
         return t;
     }
 

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/TypeBasedConfiguredPropertyDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/TypeBasedConfiguredPropertyDescriptorImpl.java
@@ -22,6 +22,7 @@ package org.datacleaner.descriptors;
 import org.datacleaner.api.Converter;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.components.remote.RemoteTransformer;
+import org.datacleaner.restclient.Serializator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,77 +33,20 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * @Since 9/9/15
  */
-public class TypeBasedConfiguredPropertyDescriptorImpl implements ConfiguredPropertyDescriptor {
+public class TypeBasedConfiguredPropertyDescriptorImpl extends RemoteConfiguredPropertyDescriptor {
 
     private static final Logger logger = LoggerFactory.getLogger(TypeBasedConfiguredPropertyDescriptorImpl.class);
-
     private Class type;
-    private String name;
-    private String description;
-    private boolean required;
-    private ComponentDescriptor component;
-    Map<Class<Annotation>, Annotation> annotations = new HashMap<>();
 
-    public TypeBasedConfiguredPropertyDescriptorImpl(String name, String description, Class type, boolean required, ComponentDescriptor component, Map<Class<Annotation>, Annotation> annotations) {
+    public TypeBasedConfiguredPropertyDescriptorImpl(String name, String description, Class type, boolean required, ComponentDescriptor component, Map<Class<Annotation>, Annotation> annotations, JsonNode defaultValue) {
+        super(name, description, required, component, annotations, defaultValue);
         this.type = type;
-        this.name = name;
-        this.description = description;
-        this.required = required;
-        this.component = component;
-        this.annotations = annotations;
-    }
-
-    @Override
-    public boolean isInputColumn() {
-        return InputColumn.class.isAssignableFrom(getBaseType());
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    @Override
-    public Class<? extends Converter<?>> getCustomConverter() {
-        return null;
-    }
-
-    @Override
-    public String[] getAliases() {
-        return new String[0];  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public void setValue(Object component, Object value) throws IllegalArgumentException {
-        ((RemoteTransformer)component).setPropertyValue(getName(), value);
-    }
-
-    @Override
-    public Object getValue(Object component) throws IllegalArgumentException {
-        return ((RemoteTransformer)component).getPropertyValue(getName());
-    }
-
-    @Override
-    public Set<Annotation> getAnnotations() {
-        return new HashSet<>(annotations.values());
-    }
-
-    @Override
-    public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
-        return (A) annotations.get(annotationClass);
     }
 
     @Override
@@ -123,23 +67,4 @@ public class TypeBasedConfiguredPropertyDescriptorImpl implements ConfiguredProp
         return type;
     }
 
-    @Override
-    public ComponentDescriptor<?> getComponentDescriptor() {
-        return component;
-    }
-
-    @Override
-    public int getTypeArgumentCount() {
-        return 0;
-    }
-
-    @Override
-    public Class<?> getTypeArgument(int i) throws IndexOutOfBoundsException {
-        return null;
-    }
-
-    @Override
-    public int compareTo(PropertyDescriptor o) {
-        return getName().compareTo(o.getName());
-    }
 }

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/TypeBasedConfiguredPropertyDescriptorImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/TypeBasedConfiguredPropertyDescriptorImpl.java
@@ -37,6 +37,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
+ * Representation of configured property of remote transformer, in case that the property value class is available on
+ * the client side like on the server. For example property of type String.class can be represented by a String.class
+ * on server as well as on the client. But if server has some exotic class for property values, that is not
+ * available on client classpath, such a property must be represented by {@link JsonSchemaConfiguredPropertyDescriptorImpl}.
+ *
+ * @see RemoteTransformer
  * @Since 9/9/15
  */
 public class TypeBasedConfiguredPropertyDescriptorImpl extends RemoteConfiguredPropertyDescriptor {

--- a/engine/rest-client/src/main/java/org/datacleaner/restclient/ComponentList.java
+++ b/engine/rest-client/src/main/java/org/datacleaner/restclient/ComponentList.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 
 /**
@@ -136,6 +137,7 @@ public class ComponentList {
         private boolean required;
         private boolean isInputColumn;
         private Map<String, Map<String, Object>> annotations = new HashMap<>();
+        private JsonNode defaultValue;
 
         public void setIsInputColumn(boolean inputColumn) {
             isInputColumn = inputColumn;
@@ -201,5 +203,12 @@ public class ComponentList {
 
         public void setAnnotations(Map<String, Map<String, Object>> annotations) { this.annotations = annotations; }
 
+        public JsonNode getDefaultValue() {
+            return defaultValue;
+        }
+
+        public void setDefaultValue(JsonNode defaultValue) {
+            this.defaultValue = defaultValue;
+        }
     }
 }


### PR DESCRIPTION
Created tranformer instance can initialize its properties in constructor. These initial values are then visible by user and he regards them as the default values. We want similar behaviour when using the remote components.
So server must provide these values in component info and client should use them when creating new instance of remote transformer.