### PR TITLE
Show Travis build status on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-DataCleaner
-===========
+# DataCleaner
 
+[![Build Status: Linux](https://travis-ci.org/datacleaner/DataCleaner.svg?branch=master)](https://travis-ci.org/datacleaner/DataCleaner)
 <div>
 <img src="http://datacleaner.org/resources/dc-logo-100.png" alt="DataCleaner logo" />
 </div>


### PR DESCRIPTION
This adds a Travis SVG image (and link) that will show the build status of master.