### PR TITLE
Removed and banned dependency on apache-log4j-extras

### DIFF
--- a/engine/env/spark/pom.xml
+++ b/engine/env/spark/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.eobjects.datacleaner</groupId>
@@ -103,6 +104,10 @@
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
 					<groupId>commons-logging</groupId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils-core</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,9 @@
 										<exclude>org.eobjects.metamodel:*</exclude>
 										<exclude>log4j:apache-log4j-extras:*</exclude>
 										<exclude>org.apache.logging.log4j:*</exclude>
+										
+										<!-- commons-beanutils-core is redundant when we already depend on commons-beanutils -->
+										<exclude>commons-beanutils:commons-beanutils-core:*</exclude>
 
 										<!-- JAXB is included in Java 7 and upwards, so no longer needed -->
 										<exclude>com.sun.xml.bind:jaxb-impl:*:jar:compile</exclude>
@@ -619,6 +622,12 @@
 				<groupId>org.apache.metamodel</groupId>
 				<artifactId>MetaModel-hadoop</artifactId>
 				<version>${metamodel.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-beanutils</groupId>
+						<artifactId>commons-beanutils-core</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.metamodel</groupId>
@@ -643,6 +652,10 @@
 					<exclusion>
 						<groupId>jdk.tools</groupId>
 						<artifactId>jdk.tools</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>commons-beanutils</groupId>
+						<artifactId>commons-beanutils-core</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -868,6 +881,11 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>2.6</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.8.3</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-pool</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,8 @@
 										<exclude>org.mortbay.jetty:jetty:*:jar:compile</exclude>
 										<exclude>org.codehaus.jackson:*</exclude>
 										<exclude>org.eobjects.metamodel:*</exclude>
+										<exclude>log4j:apache-log4j-extras:*</exclude>
+										<exclude>org.apache.logging.log4j:*</exclude>
 
 										<!-- JAXB is included in Java 7 and upwards, so no longer needed -->
 										<exclude>com.sun.xml.bind:jaxb-impl:*:jar:compile</exclude>
@@ -854,6 +856,10 @@
 					<exclusion>
 						<groupId>javax.xml.bind</groupId>
 						<artifactId>jaxb-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>log4j</groupId>
+						<artifactId>apache-log4j-extras</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
Fixes #707 by removing and banning the apache-log4j-extras dependency.

Please review and ensure that this makes it into the next release.