### PR TITLE
Column name always showing as "none" in Ref. Integrity analyzer dialog

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleColumnNamePropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleColumnNamePropertyWidget.java
@@ -22,6 +22,8 @@ package org.datacleaner.widgets.properties;
 import javax.inject.Inject;
 
 import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.MutableColumn;
+import org.apache.metamodel.schema.MutableTable;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.MutableRef;
@@ -100,8 +102,18 @@ public final class SingleColumnNamePropertyWidget extends AbstractPropertyWidget
     protected void setValue(String value) {
         if (value == null) {
             _comboBox.setSelectedItem(null);
+            return;
         }
+
+        if (_comboBox.getTable() == null) {
+            final MutableTable placeholderTable = new MutableTable("table");
+            placeholderTable.addColumn(new MutableColumn(value, placeholderTable));
+            _comboBox.setModel(placeholderTable);
+        }
+
         _comboBox.setSelectedItem(value);
+        
+        fireValueChanged(value);
     }
 
 }


### PR DESCRIPTION
Fixes #747 

This was basically an issue of making sure that the combobox would accept a column name before it had been instrumented with a table. The order of instrumenting it with the table is out of the property widget's hands.

I also added a fireValueChanged(...) in the end to ensure that UI is updated if the setValue(...) call is coming from the back instead of the front end.