### PR TITLE
check if there are sample rows for "null" values of value distribution.

### DIFF
--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/SingleValueDistributionResult.java
@@ -110,13 +110,17 @@ public class SingleValueDistributionResult extends ValueDistributionAnalyzerResu
         }
 
         if (value == null) {
-            return _nullValueAnnotation != null;
+            if (_nullValueAnnotation != null) {
+                return annotationFactory.hasSampleRows(_nullValueAnnotation);
+            } else {
+                return false;
+            }
         }
         final RowAnnotation annotation = _annotations.get(value);
         if (annotation == null) {
             return false;
         }
-        
+
         return annotationFactory.hasSampleRows(annotation);
     }
 
@@ -171,7 +175,7 @@ public class SingleValueDistributionResult extends ValueDistributionAnalyzerResu
         }
         return _bottomValues;
     }
-    
+
     public InputColumn<?>[] getHighlightedColumns() {
         return _highlightedColumns;
     }


### PR DESCRIPTION
Fixes #743  
check if there are sample rows for "null" values of value distribution.
The method did not check if there are annotated Rows for null values. 
It returned true and it created an window with no row sample examples.
 
![screen shot 2015-10-08 at 1 32 05 pm](https://cloud.githubusercontent.com/assets/6339923/10365146/38f60c22-6dc1-11e5-80d2-03fc6e0b5885.png)
