### PR TITLE
Made search work on whole tree panel. Search alias+category.

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
@@ -23,8 +23,8 @@ import java.awt.BorderLayout;
 import java.awt.Cursor;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
@@ -32,12 +32,13 @@ import javax.inject.Inject;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
-import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
 
 import org.datacleaner.connection.Datastore;
 import org.datacleaner.guice.InjectorBuilder;
+import org.datacleaner.util.DCDocumentListener;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.LoadingIcon;
 import org.datacleaner.widgets.tree.SchemaTree;
@@ -46,6 +47,10 @@ import org.jdesktop.swingx.JXTextField;
 import com.google.common.base.Strings;
 import com.google.inject.Injector;
 
+/**
+ * Panel that wraps the {@link SchemaTree} as well as actions around it for
+ * searching/filtering etc.
+ */
 public class SchemaTreePanel extends DCPanel {
 
     private static final long serialVersionUID = 1L;
@@ -53,15 +58,23 @@ public class SchemaTreePanel extends DCPanel {
     private static final String DEFAULT_SEARCH_FIELD_TEXT = "Search component library...";
 
     private final InjectorBuilder _injectorBuilder;
+    private final JXTextField _searchTextField;
+    private final JComponent _resetSearchButton;
     private JComponent _updatePanel;
+    private SchemaTree _schemaTree;
 
     @Inject
     protected SchemaTreePanel(InjectorBuilder injectorBuilder) {
         super(WidgetUtils.COLOR_DEFAULT_BACKGROUND);
         _injectorBuilder = injectorBuilder;
+        _searchTextField = createSearchTextField();
+        _resetSearchButton = createResetSearchButton();
+
         setLayout(new BorderLayout());
         setBorder(new EmptyBorder(4, 4, 4, 4));
         setDatastore(null, false);
+
+        setFocusable(true);
     }
 
     public void setDatastore(final Datastore datastore, final boolean expandTree) {
@@ -85,25 +98,40 @@ public class SchemaTreePanel extends DCPanel {
 
             protected void done() {
                 try {
-                    final SchemaTree schemaTree = get();
-                    final JScrollPane schemaTreeScroll = WidgetUtils.scrolleable(schemaTree);
+                    _schemaTree = get();
+                    final JScrollPane schemaTreeScroll = WidgetUtils.scrolleable(_schemaTree);
                     schemaTreeScroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-                    schemaTree.addComponentListener(new ComponentAdapter() {
+                    _schemaTree.addComponentListener(new ComponentAdapter() {
                         @Override
                         public void componentResized(ComponentEvent e) {
                             updateParentPanel();
                         }
-
+                    });
+                    _schemaTree.setFocusable(true);
+                    _schemaTree.addKeyListener(new KeyAdapter() {
+                        @Override
+                        public void keyPressed(KeyEvent e) {
+                            if (!e.isActionKey() && !_searchTextField.isFocusOwner()) {
+                                final char keyChar = e.getKeyChar();
+                                if (Character.isLetter(keyChar)) {
+                                    _searchTextField.requestFocus();
+                                    _searchTextField.setText("" + keyChar);
+                                }
+                            }
+                        }
                     });
                     removeAll();
                     add(schemaTreeScroll, BorderLayout.CENTER);
 
-                    final JComponent searchComponent = createSearchTextField(schemaTree);
+                    final DCPanel searchComponent = new DCPanel(WidgetUtils.BG_COLOR_BRIGHTEST);
+                    searchComponent.setLayout(new BorderLayout());
+                    searchComponent.add(_searchTextField, BorderLayout.CENTER);
+                    searchComponent.add(_resetSearchButton, BorderLayout.EAST);
 
                     add(searchComponent, BorderLayout.SOUTH);
-                    schemaTree.expandStandardPaths();
+                    _schemaTree.expandStandardPaths();
                     if (expandTree) {
-                        schemaTree.expandSelectedData();
+                        _schemaTree.expandSelectedData();
                     }
                     updateParentPanel();
                 } catch (Exception e) {
@@ -114,49 +142,35 @@ public class SchemaTreePanel extends DCPanel {
         }.execute();
     }
 
-    protected JComponent createSearchTextField(final SchemaTree schemaTree) {
-        final JXTextField searchTextField = new JXTextField(DEFAULT_SEARCH_FIELD_TEXT);
-        searchTextField.addKeyListener(new KeyListener() {
-
-            @Override
-            public void keyTyped(KeyEvent e) {
-            }
-
-            @Override
-            public void keyReleased(KeyEvent e) {
-                JTextField source = (JTextField) e.getSource();
-                schemaTree.filter(source.getText());
-            }
-
-            @Override
-            public void keyPressed(KeyEvent e) {
-            }
-        });
-
+    private JComponent createResetSearchButton() {
         final JLabel resetSearchFieldIcon = new JLabel("X");
         resetSearchFieldIcon.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         resetSearchFieldIcon.setBorder(WidgetUtils.BORDER_EMPTY);
         resetSearchFieldIcon.addMouseListener(new MouseAdapter() {
-
             @Override
             public void mouseReleased(MouseEvent e) {
-                final String currentText = searchTextField.getText();
+                final String currentText = _searchTextField.getText();
                 if (Strings.isNullOrEmpty(currentText)) {
                     // do nothing
                     return;
                 }
-                searchTextField.setText("");
-                schemaTree.filter("");
+                _searchTextField.setText("");
+                _schemaTree.filter("");
             }
-            
+        });
+        return resetSearchFieldIcon;
+    }
+
+    protected JXTextField createSearchTextField() {
+        final JXTextField searchTextField = new JXTextField(DEFAULT_SEARCH_FIELD_TEXT);
+        searchTextField.getDocument().addDocumentListener(new DCDocumentListener() {
+            @Override
+            protected void onChange(DocumentEvent event) {
+                _schemaTree.filter(searchTextField.getText());
+            }
         });
         searchTextField.setBorder(WidgetUtils.BORDER_EMPTY);
-
-        final DCPanel searchPanel = new DCPanel(WidgetUtils.BG_COLOR_BRIGHTEST);
-        searchPanel.setLayout(new BorderLayout());
-        searchPanel.add(searchTextField, BorderLayout.CENTER);
-        searchPanel.add(resetSearchFieldIcon, BorderLayout.EAST);
-        return searchPanel;
+        return searchTextField;
     }
 
     private void updateParentPanel() {

--- a/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
@@ -111,7 +111,9 @@ public class SchemaTreePanel extends DCPanel {
                     _schemaTree.addKeyListener(new KeyAdapter() {
                         @Override
                         public void keyPressed(KeyEvent e) {
-                            if (!e.isActionKey() && !_searchTextField.isFocusOwner()) {
+                            if (e.getKeyChar() == KeyEvent.VK_ESCAPE) {
+                                _searchTextField.setText("");
+                            } else if (!e.isActionKey() && !_searchTextField.isFocusOwner()) {
                                 final char keyChar = e.getKeyChar();
                                 if (Character.isLetter(keyChar)) {
                                     _searchTextField.requestFocus();
@@ -167,6 +169,14 @@ public class SchemaTreePanel extends DCPanel {
             @Override
             protected void onChange(DocumentEvent event) {
                 _schemaTree.filter(searchTextField.getText());
+            }
+        });
+        searchTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyChar() == KeyEvent.VK_ESCAPE) {
+                    searchTextField.setText("");
+                }
             }
         });
         searchTextField.setBorder(WidgetUtils.BORDER_EMPTY);


### PR DESCRIPTION
Fixes #758 

In addition to making the search box catch keystrokes from the whole tree panel, I also made the searching more broad because I think it was being too strict before. So now the search is ignoring whitespaces and it searches also aliases and category names. Thus if you search on e.g. 'Text' you get:

![image](https://cloud.githubusercontent.com/assets/291450/10379861/efa8da68-6e10-11e5-93ad-fc2daae08799.png)

Or searching "refere":

![image](https://cloud.githubusercontent.com/assets/291450/10379870/08ced52e-6e11-11e5-9cbc-92714a086959.png)

I also made it easy to clear the text field by clicking Esc.