### PR TITLE
Enable ElasticSearchDatastore SSL without keystore set

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
@@ -33,6 +33,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.node.Node;
 
+import com.google.common.base.Strings;
+
 /**
  * Datastore providing access to an ElasticSearch index.
  */
@@ -113,7 +115,7 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
             if (!StringUtils.isNullOrEmpty(_username) && !StringUtils.isNullOrEmpty(_password)) {
                 settingsBuilder.put("shield.user", _username + ":" + _password);
                 if (_ssl) {
-                    if(_keystorePath != null && !_keystorePath.isEmpty()) {
+                    if(!Strings.isNullOrEmpty(_keystorePath)) {
                         settingsBuilder.put("shield.ssl.keystore.path", _keystorePath);
                         settingsBuilder.put("shield.ssl.keystore.password", _keystorePassword);
                     }

--- a/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
@@ -113,8 +113,10 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
             if (!StringUtils.isNullOrEmpty(_username) && !StringUtils.isNullOrEmpty(_password)) {
                 settingsBuilder.put("shield.user", _username + ":" + _password);
                 if (_ssl) {
-                    settingsBuilder.put("shield.ssl.keystore.path", _keystorePath);
-                    settingsBuilder.put("shield.ssl.keystore.password", _keystorePassword);
+                    if(_keystorePath != null && !_keystorePath.isEmpty()) {
+                        settingsBuilder.put("shield.ssl.keystore.path", _keystorePath);
+                        settingsBuilder.put("shield.ssl.keystore.password", _keystorePassword);
+                    }
                     settingsBuilder.put("shield.transport.ssl", "true");
                 }
             }


### PR DESCRIPTION
This will ensure a user can enable SSL without having a keystore set.

Fixes #688 