### PR TITLE
Avoid potentially losing lines

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -69,14 +70,11 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
     private final DCPanel _unitContainerPanel;
 
     private final Set<InputColumn<?>> _pickedInputColumns;
-    private final Set<InputColumn<?>> _hiddenInputColumns;
-
     public ColumnListMultipleCoalesceUnitPropertyWidget(ComponentBuilder componentBuilder,
             ConfiguredPropertyDescriptor inputProperty, ConfiguredPropertyDescriptor unitProperty) {
         super(componentBuilder, inputProperty);
         _unitProperty = unitProperty;
-        _pickedInputColumns = new HashSet<InputColumn<?>>();
-        _hiddenInputColumns = new HashSet<InputColumn<?>>();
+        _pickedInputColumns = new HashSet<>();
         _unitContainerPanel = new DCPanel();
         _unitContainerPanel.setLayout(new VerticalLayout(2));
 
@@ -134,7 +132,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
     public void onPanelRemove() {
         super.onPanelRemove();
         getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
-        getAnalysisJobBuilder().addTransformerChangeListener(this);
+        getAnalysisJobBuilder().removeTransformerChangeListener(this);
     }
 
     public void removeCoalesceUnit() {
@@ -216,7 +214,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
     }
 
     private List<CoalesceUnitPanel> getCoalesceUnitPanels() {
-        List<CoalesceUnitPanel> result = new ArrayList<CoalesceUnitPanel>();
+        List<CoalesceUnitPanel> result = new ArrayList<>();
         Component[] components = _unitContainerPanel.getComponents();
         for (Component component : components) {
             if (component instanceof CoalesceUnitPanel) {
@@ -240,7 +238,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
 
     public CoalesceUnit[] getCoalesceUnits() {
         final List<CoalesceUnitPanel> panels = getCoalesceUnitPanels();
-        final List<CoalesceUnit> result = new ArrayList<CoalesceUnit>();
+        final List<CoalesceUnit> result = new ArrayList<>();
         for (final CoalesceUnitPanel panel : panels) {
             if (panel.isSet()) {
                 final CoalesceUnit unit = panel.getCoalesceUnit();
@@ -256,7 +254,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
                 Object.class);
         final InputColumn<?>[] allInputColumns = availableInputColumns.toArray(new InputColumn[availableInputColumns
                 .size()]);
-        final List<InputColumn<?>> resultList = new ArrayList<InputColumn<?>>();
+        final List<InputColumn<?>> resultList = new ArrayList<>();
 
         final CoalesceUnit[] units = getCoalesceUnits();
         if (units.length == 0) {
@@ -266,9 +264,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
 
         for (CoalesceUnit unit : units) {
             final InputColumn<?>[] inputColumns = unit.getInputColumns(allInputColumns);
-            for (final InputColumn<?> inputColumn : inputColumns) {
-                resultList.add(inputColumn);
-            }
+            Collections.addAll(resultList, inputColumns);
         }
 
         logger.debug("Returning Input.value = {}", resultList);
@@ -342,11 +338,6 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
 
     @Override
     public void onVisibilityChanged(MutableInputColumn<?> inputColumn, boolean hidden) {
-        if (hidden) {
-            _hiddenInputColumns.add(inputColumn);
-        } else {
-            _hiddenInputColumns.remove(inputColumn);
-        }
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
@@ -167,7 +167,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
     @Override
     public void onPanelRemove() {
         super.onPanelRemove();
-        getAnalysisJobBuilder().addTransformerChangeListener(this);
+        getAnalysisJobBuilder().removeTransformerChangeListener(this);
     }
 
     public PropertyWidget<?> getUnitPropertyWidget() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
@@ -74,7 +74,8 @@ import org.slf4j.LoggerFactory;
  * Property widget for multiple input columns. Displays these as checkboxes.
  */
 public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<InputColumn<?>[]> implements
-        SourceColumnChangeListener, TransformerChangeListener, MutableInputColumn.Listener, ReorderColumnsActionListener.ReorderColumnsCallback {
+        SourceColumnChangeListener, TransformerChangeListener, MutableInputColumn.Listener,
+        ReorderColumnsActionListener.ReorderColumnsCallback {
 
     private static final Logger logger = LoggerFactory.getLogger(MultipleInputColumnsPropertyWidget.class);
 
@@ -116,16 +117,18 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
             ConfiguredPropertyDescriptor propertyDescriptor) {
         super(componentBuilder, propertyDescriptor);
         // setBorder(WidgetUtils.BORDER_LIST_ITEM);
-        _checkBoxes = new LinkedHashMap<InputColumn<?>, DCCheckBox<InputColumn<?>>>();
-        _checkBoxDecorations = new IdentityHashMap<DCCheckBox<InputColumn<?>>, JComponent>();
+        _checkBoxes = new LinkedHashMap<>();
+        _checkBoxDecorations = new IdentityHashMap<>();
         _firstUpdate = true;
         _dataType = propertyDescriptor.getTypeArgument(0);
         getAnalysisJobBuilder().addSourceColumnChangeListener(this);
         getAnalysisJobBuilder().addTransformerChangeListener(this);
+
         setLayout(new VerticalLayout(2));
 
         _searchDatastoreTextField = WidgetFactory.createTextField("Search/filter columns");
-        _searchDatastoreTextField.setBorder(new CompoundBorder(WidgetUtils.BORDER_CHECKBOX_LIST_INDENTATION, WidgetUtils.BORDER_THIN));
+        _searchDatastoreTextField.setBorder(
+                new CompoundBorder(WidgetUtils.BORDER_CHECKBOX_LIST_INDENTATION, WidgetUtils.BORDER_THIN));
         _searchDatastoreTextField.getDocument().addDocumentListener(new DCDocumentListener() {
             @Override
             protected void onChange(DocumentEvent event) {
@@ -141,17 +144,17 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
                     text = text.trim().toLowerCase();
                     for (JCheckBox cb : _checkBoxes.values()) {
                         String name = cb.getText().toLowerCase();
-                        cb.setVisible(name.indexOf(text) != -1);
+                        cb.setVisible(name.contains(text));
                     }
                 }
             }
         });
 
         if (_dataType == null || _dataType == Object.class) {
-            _notAvailableCheckBox = new DCCheckBox<InputColumn<?>>(
+            _notAvailableCheckBox = new DCCheckBox<>(
                     "<html><font color=\"gray\">- no columns available -</font></html>", false);
         } else {
-            _notAvailableCheckBox = new DCCheckBox<InputColumn<?>>("<html><font color=\"gray\">- no <i>"
+            _notAvailableCheckBox = new DCCheckBox<>("<html><font color=\"gray\">- no <i>"
                     + LabelUtils.getDataTypeLabel(_dataType) + "</i> columns available -</font></html>", false);
         }
         _notAvailableCheckBox.setEnabled(false);
@@ -228,7 +231,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
         final List<InputColumn<?>> availableColumns = getAnalysisJobBuilder().getAvailableInputColumns(
                 getComponentBuilder(), _dataType);
 
-        final Set<InputColumn<?>> inputColumnsToBeRemoved = new HashSet<InputColumn<?>>();
+        final Set<InputColumn<?>> inputColumnsToBeRemoved = new HashSet<>();
         inputColumnsToBeRemoved.addAll(_checkBoxes.keySet());
 
         if (value != null) {
@@ -272,7 +275,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
      * Method that allows decorating a checkbox for an input column. Subclasses
      * can eg. wrap the checkbox in a panel, in order to make additional widgets
      * available.
-     * 
+     *
      * @param checkBox
      * @return a {@link JComponent} to add to the widget's parent.
      */
@@ -323,7 +326,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     }
 
     protected List<InputColumn<?>> getSelectedInputColumns() {
-        final List<InputColumn<?>> result = new ArrayList<InputColumn<?>>();
+        final List<InputColumn<?>> result = new ArrayList<>();
         final Collection<DCCheckBox<InputColumn<?>>> checkBoxes = _checkBoxes.values();
         for (final DCCheckBox<InputColumn<?>> cb : checkBoxes) {
             if (cb.isSelected()) {
@@ -362,13 +365,15 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     public void onPanelRemove() {
         super.onPanelRemove();
         getAnalysisJobBuilder().removeSourceColumnChangeListener(this);
-        getAnalysisJobBuilder().addTransformerChangeListener(this);
+        getAnalysisJobBuilder().removeTransformerChangeListener(this);
     }
 
     @Override
     public void onOutputChanged(TransformerComponentBuilder<?> transformerJobBuilder,
             List<MutableInputColumn<?>> outputColumns) {
-        if (transformerJobBuilder == getComponentBuilder()) {
+
+        // Makes sure it makes sense to do this (rather destructive) update
+        if (transformerJobBuilder == getComponentBuilder() || transformerJobBuilder.getAnalysisJobBuilder() != getAnalysisJobBuilder()) {
             return;
         }
 
@@ -445,7 +450,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     /**
      * Overrideable method for subclasses to get informed when values have been
      * selected in a batch update
-     * 
+     *
      * @param values
      */
     protected void onValuesBatchSelected(List<InputColumn<?>> values) {
@@ -514,12 +519,12 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
             fireValueChanged();
         }
     }
-    
+
     @Override
     public void reorderColumns(InputColumn<?>[] newValue) {
         reorderValue(newValue);
     }
-    
+
     @Override
     public InputColumn<?>[] getColumns() {
         return getValue();
@@ -527,7 +532,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
 
     /**
      * Reorders the values
-     * 
+     *
      * @param sortedValue
      */
     public void reorderValue(final InputColumn<?>[] sortedValue) {
@@ -543,8 +548,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
         updateUI();
 
         // recreate the _checkBoxes map
-        final TreeMap<InputColumn<?>, DCCheckBox<InputColumn<?>>> checkBoxesCopy = new TreeMap<InputColumn<?>, DCCheckBox<InputColumn<?>>>(
-                _checkBoxes);
+        final TreeMap<InputColumn<?>, DCCheckBox<InputColumn<?>>> checkBoxesCopy = new TreeMap<>(_checkBoxes);
         _checkBoxes.clear();
         for (InputColumn<?> inputColumn : sortedValue) {
             final DCCheckBox<InputColumn<?>> checkBox = checkBoxesCopy.get(inputColumn);
@@ -558,7 +562,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
         DCCheckBox<InputColumn<?>> checkBox = _checkBoxes.get(inputColumn);
         if (checkBox == null) {
             final String name = inputColumn.getName();
-            checkBox = new DCCheckBox<InputColumn<?>>(name, selected);
+            checkBox = new DCCheckBox<>(name, selected);
             checkBox.addListener(checkBoxListener);
             checkBox.setValue(inputColumn);
             _checkBoxes.put(inputColumn, checkBox);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1074,7 +1074,9 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void addSourceColumnChangeListener(SourceColumnChangeListener sourceColumnChangeListener) {
-        _sourceColumnListeners.add(sourceColumnChangeListener);
+        if(!_sourceColumnListeners.contains(sourceColumnChangeListener)) {
+            _sourceColumnListeners.add(sourceColumnChangeListener);
+        }
     }
 
     public void removeSourceColumnChangeListener(SourceColumnChangeListener sourceColumnChangeListener) {
@@ -1082,7 +1084,9 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void addTransformerChangeListener(TransformerChangeListener transformerChangeListener) {
-        _transformerChangeListeners.add(transformerChangeListener);
+        if(!_transformerChangeListeners.contains(transformerChangeListener)) {
+            _transformerChangeListeners.add(transformerChangeListener);
+        }
     }
 
     public void removeTransformerChangeListener(TransformerChangeListener transformerChangeListener) {
@@ -1090,7 +1094,9 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void addAnalyzerChangeListener(AnalyzerChangeListener analyzerChangeListener) {
-        _analyzerChangeListeners.add(analyzerChangeListener);
+        if(!_analyzerChangeListeners.contains(analyzerChangeListener)) {
+            _analyzerChangeListeners.add(analyzerChangeListener);
+        }
     }
 
     public void removeAnalyzerChangeListener(AnalyzerChangeListener analyzerChangeListener) {
@@ -1106,7 +1112,9 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void addAnalysisJobChangeListener(AnalysisJobChangeListener analysisJobChangeListener) {
-        _analysisJobChangeListeners.add(analysisJobChangeListener);
+        if(!_analysisJobChangeListeners.contains(analysisJobChangeListener)){
+            _analysisJobChangeListeners.add(analysisJobChangeListener);
+        }
     }
 
     public void removeAnalysisJobChangeListener(AnalysisJobChangeListener analysisJobChangeListener) {


### PR DESCRIPTION
This is more of a workaround than a proper fix, but a proper fix is a bit limited by our interface. The main issue is that the property widgets all have their own listeners directly connected to the builders, making it hard to control listeners without yanking the entire dialog window (which is actually still not bullet-proof). A proper fix would probably only allow (or strongly encourage) listeners to listen to their dialog, which would then have a general component listener (also not currently supported) on the component and/or analysisJobListener.

Luckily, only MultipleInputColumnsPropertyWidget seems to have been directly looking at the input from the listener, instead of just updatingfrom the general state, which should make the other TransformerChangeListener-implementing PropertyWidgets immune. Heavy testing is still recommended, though.

Fixes #667
Also contains a fix for re-adding listeners, as well as a wrong addTransformerChangeListener on panel close (none of them actually .