### PR TITLE
Issue #611: Added 'additional output fields' to Completeness Analyzer

### DIFF
--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -90,22 +90,22 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     }
 
     @Inject
-    @Configured(PROPERTY_VALUES)
+    @Configured(order=1, value=PROPERTY_VALUES)
     @Description("Values to check for completeness")
     InputColumn<?>[] _valueColumns;
 
     @Inject
-    @Configured(PROPERTY_CONDITIONS)
+    @Configured(order=1, value=PROPERTY_CONDITIONS)
     @Description("The conditions of which a value is determined to be filled or not")
     @MappedProperty(PROPERTY_VALUES)
     Condition[] _conditions;
 
     @Inject
-    @Configured(PROPERTY_EVALUATION_MODE)
+    @Configured(order=3, value=PROPERTY_EVALUATION_MODE)
     EvaluationMode _evaluationMode = EvaluationMode.ANY_FIELD;
 
     @Inject
-    @Configured(value = PROPERTY_ADDITIONAL_OUTPUT_VALUES, required = false)
+    @Configured(order=100, value= PROPERTY_ADDITIONAL_OUTPUT_VALUES, required = false)
     @Description("Optional additional values to add to output data streams")
     InputColumn<?>[] _additionalOutputValueColumns;
 

--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -19,7 +19,10 @@
  */
 package org.datacleaner.beans;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Inject;
@@ -53,6 +56,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     public static final String PROPERTY_VALUES = "Values";
     public static final String PROPERTY_CONDITIONS = "Conditions";
     public static final String PROPERTY_EVALUATION_MODE = "Evaluation mode";
+    public static final String PROPERTY_ADDITIONAL_OUTPUT_VALUES = "Additional output values";
 
     public static enum Condition implements HasName {
         NOT_BLANK_OR_NULL("Not <blank> or <null>"), NOT_NULL("Not <null>");
@@ -101,6 +105,11 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     EvaluationMode _evaluationMode = EvaluationMode.ANY_FIELD;
 
     @Inject
+    @Configured(value = PROPERTY_ADDITIONAL_OUTPUT_VALUES, required = false)
+    @Description("Optional additional values to add to output data streams")
+    InputColumn<?>[] _additionalOutputValueColumns;
+
+    @Inject
     @Provided
     RowAnnotation _invalidRecords;
 
@@ -111,6 +120,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     private final AtomicInteger _rowCount;
     private OutputRowCollector _completeRowCollector;
     private OutputRowCollector _incompleteRowCollector;
+    private List<InputColumn<?>> _outputDataStreamColumns;
 
     public CompletenessAnalyzer() {
         _rowCount = new AtomicInteger();
@@ -119,6 +129,20 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     @Initialize
     public void init() {
         _rowCount.set(0);
+        _outputDataStreamColumns = createOutputDataStreamColumns();
+    }
+
+    private List<InputColumn<?>> createOutputDataStreamColumns() {
+        final List<InputColumn<?>> outputDataStreamColumns = new ArrayList<>();
+        Collections.addAll(outputDataStreamColumns, _valueColumns);
+        if (_additionalOutputValueColumns != null) {
+            for (InputColumn<?> inputColumn : _additionalOutputValueColumns) {
+                if (!outputDataStreamColumns.contains(inputColumn)) {
+                    outputDataStreamColumns.add(inputColumn);
+                }
+            }
+        }
+        return outputDataStreamColumns;
     }
 
     @Override
@@ -136,7 +160,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
             if (_evaluationMode == EvaluationMode.ANY_FIELD && !valid) {
                 _annotationFactory.annotate(row, distinctCount, _invalidRecords);
                 if (_incompleteRowCollector != null) {
-                    _incompleteRowCollector.putValues(row.getValues(_valueColumns).toArray());
+                    _incompleteRowCollector.putValues(row.getValues(_outputDataStreamColumns).toArray());
                 }
                 return;
             }
@@ -148,13 +172,13 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
         if (_evaluationMode == EvaluationMode.ALL_FIELDS && allInvalid) {
             _annotationFactory.annotate(row, distinctCount, _invalidRecords);
             if (_incompleteRowCollector != null) {
-                _incompleteRowCollector.putValues(row.getValues(_valueColumns).toArray());
+                _incompleteRowCollector.putValues(row.getValues(_outputDataStreamColumns).toArray());
             }
             return;
         }
 
         if (_completeRowCollector != null) {
-            _completeRowCollector.putValues(row.getValues(_valueColumns).toArray());
+            _completeRowCollector.putValues(row.getValues(_outputDataStreamColumns).toArray());
         }
     }
 
@@ -191,7 +215,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
         final OutputDataStreamBuilder incompleteStreamBuilder = OutputDataStreams
                 .pushDataStream(OUTPUT_STREAM_INCOMPLETE);
 
-        for (InputColumn<?> column : _valueColumns) {
+        for (InputColumn<?> column : createOutputDataStreamColumns()) {
             completeStreamBuilder.withColumnLike(column);
             incompleteStreamBuilder.withColumnLike(column);
         }

--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -95,7 +95,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     InputColumn<?>[] _valueColumns;
 
     @Inject
-    @Configured(order=1, value=PROPERTY_CONDITIONS)
+    @Configured(order=2, value=PROPERTY_CONDITIONS)
     @Description("The conditions of which a value is determined to be filled or not")
     @MappedProperty(PROPERTY_VALUES)
     Condition[] _conditions;

--- a/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
+++ b/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
@@ -143,8 +143,7 @@ public class CompletenessAnalyzerTest extends TestCase {
 
     public void testOutputDataStream() throws Throwable {
         final MultiThreadedTaskRunner taskRunner = new MultiThreadedTaskRunner(16);
-        final DataCleanerEnvironment environment = new DataCleanerEnvironmentImpl()
-                .withTaskRunner(taskRunner);
+        final DataCleanerEnvironment environment = new DataCleanerEnvironmentImpl().withTaskRunner(taskRunner);
         final Resource file = new UrlResource(this.getClass().getResource("/completeness_output_stream_test.csv"));
         final Datastore datastore = new CsvDatastore("testoutputdatastream", file);
         final DataCleanerConfiguration configuration = new DataCleanerConfigurationImpl().withDatastores(datastore)
@@ -163,36 +162,44 @@ public class CompletenessAnalyzerTest extends TestCase {
             final List<MetaModelInputColumn> sourceColumns = ajb.getSourceColumns();
             analyzer1.setName("analyzer1");
             analyzer1.addInputColumns(sourceColumns);
-            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_EVALUATION_MODE, CompletenessAnalyzer.EvaluationMode.ANY_FIELD);
-            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_CONDITIONS, new CompletenessAnalyzer.Condition[] {
-                    Condition.NOT_BLANK_OR_NULL, Condition.NOT_BLANK_OR_NULL, Condition.NOT_BLANK_OR_NULL });
+            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_EVALUATION_MODE,
+                    CompletenessAnalyzer.EvaluationMode.ANY_FIELD);
+            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_CONDITIONS,
+                    new CompletenessAnalyzer.Condition[] { Condition.NOT_BLANK_OR_NULL, Condition.NOT_BLANK_OR_NULL,
+                            Condition.NOT_BLANK_OR_NULL });
 
             assertTrue(analyzer1.isConfigured());
-            final OutputDataStream completeStream = analyzer1.getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE);
+            final OutputDataStream completeStream = analyzer1
+                    .getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE);
             assertNotNull(completeStream);
-            final OutputDataStream incompleteStream = analyzer1.getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE);
+            final OutputDataStream incompleteStream = analyzer1
+                    .getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE);
             assertNotNull(incompleteStream);
 
-            final AnalysisJobBuilder completeDataStreamJobBuilder = analyzer1.getOutputDataStreamJobBuilder(completeStream);
-            final List<MetaModelInputColumn> completeDataStreamColumns = completeDataStreamJobBuilder.getSourceColumns();
+            final AnalysisJobBuilder completeDataStreamJobBuilder = analyzer1
+                    .getOutputDataStreamJobBuilder(completeStream);
+            final List<MetaModelInputColumn> completeDataStreamColumns = completeDataStreamJobBuilder
+                    .getSourceColumns();
             assertEquals(3, completeDataStreamColumns.size());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE +
-                    ".A]", completeDataStreamColumns.get(0).toString());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE +
-                    ".B]", completeDataStreamColumns.get(1).toString());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE +
-                    ".C]", completeDataStreamColumns.get(2).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE + ".A]",
+                    completeDataStreamColumns.get(0).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE + ".B]",
+                    completeDataStreamColumns.get(1).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE + ".C]",
+                    completeDataStreamColumns.get(2).toString());
 
-            final AnalysisJobBuilder incompleteDataStreamJobBuilder = analyzer1.getOutputDataStreamJobBuilder(incompleteStream);
-            final List<MetaModelInputColumn> incompleteDataStreamColumns = incompleteDataStreamJobBuilder.getSourceColumns();
+            final AnalysisJobBuilder incompleteDataStreamJobBuilder = analyzer1
+                    .getOutputDataStreamJobBuilder(incompleteStream);
+            final List<MetaModelInputColumn> incompleteDataStreamColumns = incompleteDataStreamJobBuilder
+                    .getSourceColumns();
             assertEquals(3, incompleteDataStreamColumns.size());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE +
-                    ".A]", incompleteDataStreamColumns.get(0).toString());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE +
-                    ".B]", incompleteDataStreamColumns.get(1).toString());
-            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE +
-                    ".C]", incompleteDataStreamColumns.get(2).toString());
-            
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE + ".A]",
+                    incompleteDataStreamColumns.get(0).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE + ".B]",
+                    incompleteDataStreamColumns.get(1).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE + ".C]",
+                    incompleteDataStreamColumns.get(2).toString());
+
             final AnalyzerComponentBuilder<MockAnalyzer> analyzer2 = completeDataStreamJobBuilder
                     .addAnalyzer(MockAnalyzer.class);
             analyzer2.addInputColumns(completeDataStreamColumns);
@@ -241,4 +248,107 @@ public class CompletenessAnalyzerTest extends TestCase {
         assertEquals("MetaModelInputRow[Row[values=[, , ]]]", result3.getValues().get(0).toString());
     }
 
+    public void testOutputDataStreamWithAdditionalFields() throws Throwable {
+        final MultiThreadedTaskRunner taskRunner = new MultiThreadedTaskRunner(16);
+        final DataCleanerEnvironment environment = new DataCleanerEnvironmentImpl().withTaskRunner(taskRunner);
+        final Resource file = new UrlResource(this.getClass().getResource("/completeness_output_stream_test.csv"));
+        final Datastore datastore = new CsvDatastore("testoutputdatastream", file);
+        final DataCleanerConfiguration configuration = new DataCleanerConfigurationImpl().withDatastores(datastore)
+                .withEnvironment(environment);
+
+        final AnalysisJob job;
+        try (final AnalysisJobBuilder ajb = new AnalysisJobBuilder(configuration)) {
+            ajb.setDatastore(datastore);
+            ajb.addSourceColumns("A");
+            ajb.addSourceColumns("B");
+            ajb.addSourceColumns("C");
+
+            final AnalyzerComponentBuilder<CompletenessAnalyzer> analyzer1 = ajb
+                    .addAnalyzer(CompletenessAnalyzer.class);
+
+            analyzer1.setName("analyzer1");
+            analyzer1.addInputColumns(ajb.getSourceColumnByName("A"));
+            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_ADDITIONAL_OUTPUT_VALUES, new InputColumn[] {
+                    ajb.getSourceColumnByName("A"), ajb.getSourceColumnByName("C") });
+            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_EVALUATION_MODE,
+                    CompletenessAnalyzer.EvaluationMode.ANY_FIELD);
+            analyzer1.setConfiguredProperty(CompletenessAnalyzer.PROPERTY_CONDITIONS,
+                    new CompletenessAnalyzer.Condition[] { Condition.NOT_BLANK_OR_NULL, Condition.NOT_BLANK_OR_NULL,
+                            Condition.NOT_BLANK_OR_NULL });
+
+            assertTrue(analyzer1.isConfigured());
+            final OutputDataStream completeStream = analyzer1
+                    .getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE);
+            assertNotNull(completeStream);
+            final OutputDataStream incompleteStream = analyzer1
+                    .getOutputDataStream(CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE);
+            assertNotNull(incompleteStream);
+
+            final AnalysisJobBuilder completeDataStreamJobBuilder = analyzer1
+                    .getOutputDataStreamJobBuilder(completeStream);
+            final List<MetaModelInputColumn> completeDataStreamColumns = completeDataStreamJobBuilder
+                    .getSourceColumns();
+            assertEquals(2, completeDataStreamColumns.size());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE + ".A]",
+                    completeDataStreamColumns.get(0).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_COMPLETE + ".C]",
+                    completeDataStreamColumns.get(1).toString());
+
+            final AnalysisJobBuilder incompleteDataStreamJobBuilder = analyzer1
+                    .getOutputDataStreamJobBuilder(incompleteStream);
+            final List<MetaModelInputColumn> incompleteDataStreamColumns = incompleteDataStreamJobBuilder
+                    .getSourceColumns();
+            assertEquals(2, incompleteDataStreamColumns.size());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE + ".A]",
+                    incompleteDataStreamColumns.get(0).toString());
+            assertEquals("MetaModelInputColumn[" + CompletenessAnalyzer.OUTPUT_STREAM_INCOMPLETE + ".C]",
+                    incompleteDataStreamColumns.get(1).toString());
+
+            final AnalyzerComponentBuilder<MockAnalyzer> analyzer2 = completeDataStreamJobBuilder
+                    .addAnalyzer(MockAnalyzer.class);
+            analyzer2.addInputColumns(completeDataStreamColumns);
+            analyzer2.setName("analyzer2");
+            assertTrue(analyzer2.isConfigured());
+            assertTrue(analyzer1.isOutputDataStreamConsumed(completeStream));
+
+            final AnalyzerComponentBuilder<MockAnalyzer> analyzer3 = incompleteDataStreamJobBuilder
+                    .addAnalyzer(MockAnalyzer.class);
+            analyzer3.addInputColumns(incompleteDataStreamColumns);
+            analyzer3.setName("analyzer2");
+            assertTrue(analyzer2.isConfigured());
+            assertTrue(analyzer1.isOutputDataStreamConsumed(incompleteStream));
+
+            job = ajb.toAnalysisJob();
+        }
+
+        final AnalyzerJob analyzerJob1 = job.getAnalyzerJobs().get(0);
+        final OutputDataStreamJob[] outputDataStreamJobs = analyzerJob1.getOutputDataStreamJobs();
+        final AnalyzerJob analyzerJob2 = outputDataStreamJobs[0].getJob().getAnalyzerJobs().get(0);
+        final AnalyzerJob analyzerJob3 = outputDataStreamJobs[1].getJob().getAnalyzerJobs().get(0);
+
+        // now run the job(s)
+        final AnalysisRunnerImpl runner = new AnalysisRunnerImpl(configuration);
+        final AnalysisResultFuture resultFuture = runner.run(job);
+        resultFuture.await();
+
+        if (resultFuture.isErrornous()) {
+            throw resultFuture.getErrors().get(0);
+        }
+
+        assertEquals(3, resultFuture.getResults().size());
+
+        final CompletenessAnalyzerResult result1 = (CompletenessAnalyzerResult) resultFuture.getResult(analyzerJob1);
+        assertNotNull(result1);
+        assertEquals(1, result1.getValidRowCount());
+        assertEquals(1, result1.getInvalidRowCount());
+        final ListResult<?> result2 = (ListResult<?>) resultFuture.getResult(analyzerJob2);
+        assertNotNull(result2);
+        assertEquals(1, result2.getValues().size());
+        assertEquals("MetaModelInputRow[Row[values=[a, c]]]", result2.getValues().get(0).toString());
+
+        final ListResult<?> result3 = (ListResult<?>) resultFuture.getResult(analyzerJob3);
+        assertNotNull(result3);
+        assertEquals(1, result3.getValues().size());
+        assertEquals("MetaModelInputRow[Row[values=[, ]]]", result3.getValues().get(0).toString());
+    }
 }

--- a/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
+++ b/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
@@ -210,7 +210,7 @@ public class CompletenessAnalyzerTest extends TestCase {
             final AnalyzerComponentBuilder<MockAnalyzer> analyzer3 = incompleteDataStreamJobBuilder
                     .addAnalyzer(MockAnalyzer.class);
             analyzer3.addInputColumns(incompleteDataStreamColumns);
-            analyzer3.setName("analyzer2");
+            analyzer3.setName("analyzer3");
             assertTrue(analyzer2.isConfigured());
             assertTrue(analyzer1.isOutputDataStreamConsumed(incompleteStream));
 
@@ -314,7 +314,7 @@ public class CompletenessAnalyzerTest extends TestCase {
             final AnalyzerComponentBuilder<MockAnalyzer> analyzer3 = incompleteDataStreamJobBuilder
                     .addAnalyzer(MockAnalyzer.class);
             analyzer3.addInputColumns(incompleteDataStreamColumns);
-            analyzer3.setName("analyzer2");
+            analyzer3.setName("analyzer3");
             assertTrue(analyzer2.isConfigured());
             assertTrue(analyzer1.isOutputDataStreamConsumed(incompleteStream));
 

--- a/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
+++ b/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
@@ -211,7 +211,7 @@ public class CompletenessAnalyzerTest extends TestCase {
                     .addAnalyzer(MockAnalyzer.class);
             analyzer3.addInputColumns(incompleteDataStreamColumns);
             analyzer3.setName("analyzer3");
-            assertTrue(analyzer2.isConfigured());
+            assertTrue(analyzer3.isConfigured());
             assertTrue(analyzer1.isOutputDataStreamConsumed(incompleteStream));
 
             job = ajb.toAnalysisJob();
@@ -315,7 +315,7 @@ public class CompletenessAnalyzerTest extends TestCase {
                     .addAnalyzer(MockAnalyzer.class);
             analyzer3.addInputColumns(incompleteDataStreamColumns);
             analyzer3.setName("analyzer3");
-            assertTrue(analyzer2.isConfigured());
+            assertTrue(analyzer3.isConfigured());
             assertTrue(analyzer1.isOutputDataStreamConsumed(incompleteStream));
 
             job = ajb.toAnalysisJob();

--- a/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
+++ b/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -160,6 +160,16 @@ h3 {
 						class="label label-info">Required</span> 
 					</li> 					<li class="list-group-item">
 						<h3>
+							 <span
+								class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+							 Values
+						</h3> <p>Values to check for completeness</p> <!-- type --> <span
+						class="label label-primary">List of InputColumn&lt;Object&gt;</span>  
+
+						<!-- required/optional -->  <span
+						class="label label-info">Required</span> 
+					</li> 					<li class="list-group-item">
+						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
 							 Evaluation mode
 						</h3>  <!-- type --> <span
@@ -173,12 +183,12 @@ h3 {
 						<h3>
 							 <span
 								class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-							 Values
-						</h3> <p>Values to check for completeness</p> <!-- type --> <span
+							 Additional output values
+						</h3> <p>Optional additional values to add to output data streams</p> <!-- type --> <span
 						class="label label-primary">List of InputColumn&lt;Object&gt;</span>  
 
 						<!-- required/optional -->  <span
-						class="label label-info">Required</span> 
+						class="label label-info">Optional</span> 
 					</li> 
 				</ul>
 

--- a/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
+++ b/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
@@ -149,22 +149,22 @@ h3 {
 				<ul class="list-group">
 					<li class="list-group-item">
 						<h3>
+							 <span
+								class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+							 Values
+						</h3> <p>Values to check for completeness</p> <!-- type --> <span
+						class="label label-primary">List of InputColumn&lt;Object&gt;</span>  
+
+						<!-- required/optional -->  <span
+						class="label label-info">Required</span> 
+					</li> 					<li class="list-group-item">
+						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
 							 Conditions
 						</h3> <p>The conditions of which a value is determined to be filled or not</p> <!-- type --> <span
 						class="label label-primary">List of Choice:</span>  <span class="label label-default">Not &lt;blank&gt; or &lt;null&gt;</span>
 						 <span class="label label-default">Not &lt;null&gt;</span>
 						 <span class="label label-primary">Mapped with <i>Values</i></span>
-
-						<!-- required/optional -->  <span
-						class="label label-info">Required</span> 
-					</li> 					<li class="list-group-item">
-						<h3>
-							 <span
-								class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-							 Values
-						</h3> <p>Values to check for completeness</p> <!-- type --> <span
-						class="label label-primary">List of InputColumn&lt;Object&gt;</span>  
 
 						<!-- required/optional -->  <span
 						class="label label-info">Required</span> 

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-testNameClashInMelonAndDefaultScope.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-testNameClashInMelonAndDefaultScope.xml
@@ -19,7 +19,7 @@
                 <property name="Conditions" value="[NOT_BLANK_OR_NULL]"/>
                 <property name="Evaluation mode" value="ANY_FIELD"/>
             </properties>
-            <input ref="col_firstname"/>
+            <input ref="col_firstname" name="Values"/>
             <output-data-stream name="Complete rows">
                 <job>
                     <source>

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-testReadAndWriteOutputDataStreamsJob.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-testReadAndWriteOutputDataStreamsJob.xml
@@ -31,8 +31,8 @@
                 <property name="Conditions" value="[NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL]"/>
                 <property name="Evaluation mode" value="ALL_FIELDS"/>
             </properties>
-            <input ref="col_concatoffirstnamelastname3"/>
-            <input ref="col_reportsto"/>
+            <input ref="col_concatoffirstnamelastname3" name="Values"/>
+            <input ref="col_reportsto" name="Values"/>
             <output-data-stream name="Complete rows">
                 <job>
                     <source>


### PR DESCRIPTION
Fixes #611 

Here's a screenshot where I am doing analysis only on firstname+lastname, but then following it with processing of jobtitle (an additional field).

![image](https://cloud.githubusercontent.com/assets/291450/10484768/550154d8-7287-11e5-87a1-716f178260e9.png)
