### PR TITLE
Update and prettify to the Component library documentation 'index'

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/HasNameComparator.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/HasNameComparator.java
@@ -1,0 +1,39 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.util;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import org.apache.metamodel.util.HasName;
+
+/**
+ * Comparator of {@link HasName} objects, which sorts based on the name.
+ */
+public class HasNameComparator implements Comparator<HasName>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public int compare(HasName o1, HasName o2) {
+        return o1.getName().compareTo(o2.getName());
+    }
+
+}

--- a/desktop/ui/src/main/java/org/datacleaner/actions/ComponentReferenceDocumentationActionListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/actions/ComponentReferenceDocumentationActionListener.java
@@ -26,8 +26,8 @@ import java.io.File;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerHomeFolder;
 import org.datacleaner.descriptors.ComponentDescriptor;
+import org.datacleaner.documentation.ComponentDocumentationWrapper;
 import org.datacleaner.documentation.ComponentReferenceDocumentationBuilder;
-import org.datacleaner.documentation.IndexDocumentationBuilder;
 import org.jdesktop.swingx.action.OpenBrowserAction;
 
 /**
@@ -55,8 +55,10 @@ public class ComponentReferenceDocumentationActionListener implements ActionList
             docDirectory.mkdir();
         }
 
-        final File documentationFile = new File(docDirectory,
-                IndexDocumentationBuilder.getFilename(_componentDescriptor));
+        final ComponentDocumentationWrapper componentDocumentationWrapper = new ComponentDocumentationWrapper(
+                _componentDescriptor);
+
+        final File documentationFile = new File(docDirectory, componentDocumentationWrapper.getHref());
         if (!documentationFile.exists()) {
             final ComponentReferenceDocumentationBuilder builder = new ComponentReferenceDocumentationBuilder(
                     _configuration.getEnvironment().getDescriptorProvider());

--- a/desktop/ui/src/main/java/org/datacleaner/documentation/CategoryDocumentationWrapper.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/CategoryDocumentationWrapper.java
@@ -1,0 +1,29 @@
+package org.datacleaner.documentation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.datacleaner.api.ComponentCategory;
+
+public class CategoryDocumentationWrapper {
+
+    private final List<ComponentDocumentationWrapper> _components;
+    private final ComponentCategory _componentCategory;
+
+    public CategoryDocumentationWrapper(ComponentCategory componentCategory) {
+        _componentCategory = componentCategory;
+        _components = new ArrayList<>();
+    }
+    
+    public String getName() {
+        return _componentCategory.getName();
+    }
+
+    public void addComponent(ComponentDocumentationWrapper component) {
+        _components.add(component);
+    }
+
+    public List<ComponentDocumentationWrapper> getComponents() {
+        return _components;
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/documentation/CategoryDocumentationWrapper.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/CategoryDocumentationWrapper.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.documentation;
 
 import java.util.ArrayList;
@@ -5,6 +24,11 @@ import java.util.List;
 
 import org.datacleaner.api.ComponentCategory;
 
+/**
+ * A wrapper around the {@link ComponentCategory} object to make it easier for
+ * the documentation template to get to certain aspects that should be presented
+ * in the documentation.
+ */
 public class CategoryDocumentationWrapper {
 
     private final List<ComponentDocumentationWrapper> _components;
@@ -14,7 +38,7 @@ public class CategoryDocumentationWrapper {
         _componentCategory = componentCategory;
         _components = new ArrayList<>();
     }
-    
+
     public String getName() {
         return _componentCategory.getName();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/documentation/ComponentReferenceDocumentationBuilder.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/ComponentReferenceDocumentationBuilder.java
@@ -68,11 +68,13 @@ public class ComponentReferenceDocumentationBuilder {
                 .getComponentDescriptors();
         for (final ComponentDescriptor<?> componentDescriptor : componentDescriptors) {
             try {
-                final String filename = IndexDocumentationBuilder.getFilename(componentDescriptor);
+                final ComponentDocumentationWrapper componentWrapper = new ComponentDocumentationWrapper(
+                        componentDescriptor);
+                final String filename = componentWrapper.getHref();
                 final RepositoryFile file = createOrUpdateFile(folder, filename, new Action<OutputStream>() {
                     @Override
                     public void run(OutputStream out) throws Exception {
-                        componentDocumentationBuilder.write(componentDescriptor, out);
+                        componentDocumentationBuilder.write(componentWrapper, out);
                     }
                 });
                 logger.info("Wrote: {}", file);

--- a/desktop/ui/src/main/java/org/datacleaner/documentation/SuperCategoryDocumentationWrapper.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/SuperCategoryDocumentationWrapper.java
@@ -1,0 +1,55 @@
+package org.datacleaner.documentation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.datacleaner.api.ComponentCategory;
+import org.datacleaner.api.ComponentSuperCategory;
+import org.datacleaner.util.HasNameComparator;
+
+public class SuperCategoryDocumentationWrapper implements Comparable<SuperCategoryDocumentationWrapper> {
+
+    private final ComponentSuperCategory _superCategory;
+    private final List<ComponentDocumentationWrapper> _components;
+    private final Map<ComponentCategory, CategoryDocumentationWrapper> _categories;
+
+    public SuperCategoryDocumentationWrapper(ComponentSuperCategory superCategory) {
+        _superCategory = superCategory;
+        _components = new ArrayList<>();
+        _categories = new TreeMap<>(new HasNameComparator());
+    }
+
+    @Override
+    public int compareTo(SuperCategoryDocumentationWrapper o) {
+        return _superCategory.compareTo(o._superCategory);
+    }
+
+    public void addComponent(ComponentDocumentationWrapper component) {
+        _components.add(component);
+    }
+
+    public List<ComponentDocumentationWrapper> getComponents() {
+        return _components;
+    }
+
+    public String getName() {
+        return _superCategory.getName();
+    }
+
+    public Collection<CategoryDocumentationWrapper> getCategories() {
+        return _categories.values();
+    }
+
+    public void addComponent(ComponentCategory componentCategory, ComponentDocumentationWrapper component) {
+        CategoryDocumentationWrapper categoryWrapper = _categories.get(componentCategory);
+        if (categoryWrapper == null) {
+            categoryWrapper = new CategoryDocumentationWrapper(componentCategory);
+            _categories.put(componentCategory, categoryWrapper);
+        }
+        categoryWrapper.addComponent(component);
+    }
+
+}

--- a/desktop/ui/src/main/java/org/datacleaner/documentation/SuperCategoryDocumentationWrapper.java
+++ b/desktop/ui/src/main/java/org/datacleaner/documentation/SuperCategoryDocumentationWrapper.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.documentation;
 
 import java.util.ArrayList;
@@ -10,6 +29,11 @@ import org.datacleaner.api.ComponentCategory;
 import org.datacleaner.api.ComponentSuperCategory;
 import org.datacleaner.util.HasNameComparator;
 
+/**
+ * A wrapper around the {@link ComponentSuperCategory} object to make it easier
+ * for the documentation template to get to certain aspects that should be
+ * presented in the documentation.
+ */
 public class SuperCategoryDocumentationWrapper implements Comparable<SuperCategoryDocumentationWrapper> {
 
     private final ComponentSuperCategory _superCategory;

--- a/desktop/ui/src/main/resources/org/datacleaner/documentation/template_component.html
+++ b/desktop/ui/src/main/resources/org/datacleaner/documentation/template_component.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<title>${component.name}</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -64,7 +69,7 @@ h3 {
 			<div class="panel-body">
 				<#if breadcrumbs>
 				<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>${component.superCategory}</li> <#list component.categories as
@@ -76,7 +81,7 @@ h3 {
 				</#if>
 				<div class="jumbotron">
 					<h1>
-						<img src="${icon}" alt="" /> <span>${component.name}</span>
+						<img src="${component.iconSrc}" alt="" /> <span>${component.name}</span>
 					</h1>
 					<div>${component.description}</div>
 					

--- a/desktop/ui/src/main/resources/org/datacleaner/documentation/template_index.html
+++ b/desktop/ui/src/main/resources/org/datacleaner/documentation/template_index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Component library</title>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Ubuntu:400,500,700" type="text/css" />
+<link rel="stylesheet"
+	href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
+<link rel="stylesheet"
+	href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css" />
+
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+
+<style type="text/css">
+body {
+	font-family: 'Ubuntu', sans-serif;
+}
+
+h1, .jumbotron h1 {
+	font-size: 30px;
+}
+
+h2 {
+	font-size: 22px;
+}
+
+h3 {
+	font-size: 16px;
+}
+
+.panel {
+	border-radius: 2px;
+}
+
+.container .jumbotron {
+	padding: 20px;
+	border-radius: 2px;
+}
+
+.jumbotron p {
+	font-size: inherit;
+}
+
+.label {
+	font-size: 0.9em;
+	font-weight: normal;
+	border-radius: 2px;
+}
+
+.panel-heading {
+	background-image: none !important;
+}
+</style>
+</head>
+<body>
+	<script
+		src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+	<script
+		src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+	<div class="container">
+		<div class="panel panel-default">
+			<div class="panel-body">
+				<div class="jumbotron">
+					<h1>
+						<img src="http://datacleaner.org/resources/dc-logo-100.png" alt="" />
+						Component library
+					</h1>
+				</div>
+			</div>
+		</div>
+
+		<#list superCategories as superCategory>
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h2>
+					<a data-toggle="collapse" href="#superCategoryPanel_${superCategory.name}" aria-controls="superCategoryPanel_${superCategory.name}">${superCategory.name}</a>
+				</h2>
+			</div>
+			<div class="panel-body collapse in" id="superCategoryPanel_${superCategory.name}"
+				aria-expanded="true">
+				
+				<#if superCategory.categories?has_content>
+					<#list superCategory.categories as category>
+							<h3>${category.name}</h3>
+							
+							<ul class="list-group">
+							<#list category.components as component>
+								<li class="list-group-item componentItem">
+									<a href="${component.href}">
+										<img src="${component.iconSrc}" width="16" height="16" alt="" />
+										<span>${component.name}</span>
+									</a>
+								</li>
+							</#list>
+							</ul>
+					</#list>
+				</#if>
+				<#if superCategory.components?has_content>
+					<ul class="list-group">
+					<#list superCategory.components as component>
+						<li class="list-group-item componentItem">
+							<a href="${component.href}">
+								<img src="${component.iconSrc}" width="16" height="16" alt="" />
+								<span>${component.name}</span>
+							</a>
+						</li>
+					</#list>
+					</ul>
+				</#if>
+			</div>
+			</div>
+		</#list>
+	</div>
+</body>
+</html>

--- a/desktop/ui/src/test/java/org/datacleaner/documentation/ComponentReferenceDocumentationBuilderTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/documentation/ComponentReferenceDocumentationBuilderTest.java
@@ -27,6 +27,8 @@ import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.datacleaner.beans.CharacterSetDistributionAnalyzer;
 import org.datacleaner.beans.ReferenceDataMatcherAnalyzer;
+import org.datacleaner.beans.transform.ConcatenatorTransformer;
+import org.datacleaner.beans.transform.TokenizerTransformer;
 import org.datacleaner.descriptors.Descriptors;
 import org.datacleaner.descriptors.SimpleDescriptorProvider;
 import org.junit.Test;
@@ -43,6 +45,9 @@ public class ComponentReferenceDocumentationBuilderTest {
         final SimpleDescriptorProvider descriptorProvider = new SimpleDescriptorProvider();
         descriptorProvider.addAnalyzerBeanDescriptor(Descriptors.ofAnalyzer(CharacterSetDistributionAnalyzer.class));
         descriptorProvider.addAnalyzerBeanDescriptor(Descriptors.ofAnalyzer(ReferenceDataMatcherAnalyzer.class));
+        
+        descriptorProvider.addTransformerBeanDescriptor(Descriptors.ofTransformer(ConcatenatorTransformer.class));
+        descriptorProvider.addTransformerBeanDescriptor(Descriptors.ofTransformer(TokenizerTransformer.class));
 
         final ComponentReferenceDocumentationBuilder docBuilder = new ComponentReferenceDocumentationBuilder(
                 descriptorProvider);
@@ -50,6 +55,6 @@ public class ComponentReferenceDocumentationBuilderTest {
         assertTrue(success);
 
         assertTrue(new File(directory, "index.html").exists());
-        assertEquals(3, directory.list().length);
+        assertEquals(5, directory.list().length);
     }
 }

--- a/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
+++ b/desktop/ui/src/test/resources/documentation/completeness_analyzer.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Completeness analyzer</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Analyze</li> 

--- a/desktop/ui/src/test/resources/documentation/concatenator.html
+++ b/desktop/ui/src/test/resources/documentation/concatenator.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Concatenator</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Transform</li> 					<li>Text</li>

--- a/desktop/ui/src/test/resources/documentation/equals_filter.html
+++ b/desktop/ui/src/test/resources/documentation/equals_filter.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Equals</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Transform</li> 					<li>Filter</li>

--- a/desktop/ui/src/test/resources/documentation/pattern_finder.html
+++ b/desktop/ui/src/test/resources/documentation/pattern_finder.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Pattern finder</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Analyze</li> 

--- a/desktop/ui/src/test/resources/documentation/synonym_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/synonym_lookup.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Synonym lookup</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Improve</li> 					<li>Reference data</li>

--- a/desktop/ui/src/test/resources/documentation/table_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/table_lookup.html
@@ -1,6 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
+<title>Table lookup</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -52,6 +53,10 @@ h3 {
 	font-weight: normal;
 	border-radius: 2px;
 }
+
+.panel-heading {
+	background-image: none !important;
+}
 </style>
 </head>
 <body>
@@ -62,8 +67,8 @@ h3 {
 	<div class="container">
 		<div class="panel panel-default">
 			<div class="panel-body">
-								<ol class="breadcrumb">
-					<li><a href="index.html">Library</a></li>
+				<ol class="breadcrumb">
+					<li><a href="index.html">Component library</a></li>
 
 					<!-- categorization -->
 					<li>Improve</li> 					<li>Reference data</li>


### PR DESCRIPTION
Here's my suggested fix to have a much better index page in the Component library docs.

Screenshots below:

![image](https://cloud.githubusercontent.com/assets/291450/10535816/4ebfd30a-73e6-11e5-9265-017e4e21f6f6.png)

The super-categories are collapsible:

![image](https://cloud.githubusercontent.com/assets/291450/10535822/5d6e2884-73e6-11e5-9d8f-741e968e74b6.png)

And here's how a super-category without any sub-categories look like:

![image](https://cloud.githubusercontent.com/assets/291450/10535833/70c1d110-73e6-11e5-827c-03dbdbf61a8a.png)
