### PR TITLE
Equals filter outcome naming

### DIFF
--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/EqualsFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/EqualsFilter.java
@@ -54,7 +54,13 @@ import com.google.common.base.Joiner;
 @Description("A filter that excludes values that are not equal (=) to specific set of valid values")
 @Categorized(FilterCategory.class)
 @Distributed(true)
-public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, HasLabelAdvice {
+public class EqualsFilter implements QueryOptimizedFilter<EqualsFilter.Category>, HasLabelAdvice {
+
+    public static enum Category {
+        @Alias({ "Valid", "VALID" }) EQUALS,
+
+        @Alias({ "Invalid", "INVALID" }) NOT_EQUALS;
+    }
 
     @Inject
     @Configured(order = 1)
@@ -168,7 +174,7 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
     }
 
     @Override
-    public ValidationCategory categorize(InputRow inputRow) {
+    public EqualsFilter.Category categorize(InputRow inputRow) {
         Object inputValue = inputRow.getValue(inputColumn);
 
         final Object compareValue;
@@ -181,11 +187,11 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
         return filter(inputValue, compareValue);
     }
 
-    public ValidationCategory filter(final Object v) {
+    public EqualsFilter.Category filter(final Object v) {
         return filter(v, null);
     }
 
-    public ValidationCategory filter(final Object v, final Object compareValue) {
+    public EqualsFilter.Category filter(final Object v, final Object compareValue) {
         if (compareColumn != null) {
             operands[0] = toOperand(compareValue);
         }
@@ -193,10 +199,10 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
         if (v == null) {
             for (Object obj : operands) {
                 if (obj == null) {
-                    return ValidationCategory.VALID;
+                    return Category.EQUALS;
                 }
             }
-            return ValidationCategory.INVALID;
+            return Category.NOT_EQUALS;
         } else {
             for (Object operand : operands) {
                 if (operand != null) {
@@ -205,18 +211,18 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
                         Number n1 = (Number) operand;
                         Number n2 = (Number) v;
                         if (equals(n1, n2)) {
-                            return ValidationCategory.VALID;
+                            return Category.EQUALS;
                         }
                     } else {
                         if (operand.equals(v)) {
-                            return ValidationCategory.VALID;
+                            return Category.EQUALS;
                         }
                         if (operand instanceof String) {
                             // convert to string to check
                             String str1 = operand.toString();
                             String str2 = v.toString();
                             if (str1.equals(str2)) {
-                                return ValidationCategory.VALID;
+                                return Category.EQUALS;
                             }
                         }
                     }
@@ -224,7 +230,7 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
             }
         }
 
-        return ValidationCategory.INVALID;
+        return Category.NOT_EQUALS;
     }
 
     private boolean equals(Number n1, Number n2) {
@@ -237,7 +243,7 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
     }
 
     @Override
-    public boolean isOptimizable(ValidationCategory category) {
+    public boolean isOptimizable(Category category) {
         if (compareColumn != null && compareValues != null && compareValues.length > 0) {
             boolean hasCompareValues = false;
             for (String compareValue : compareValues) {
@@ -251,9 +257,9 @@ public class EqualsFilter implements QueryOptimizedFilter<ValidationCategory>, H
     }
 
     @Override
-    public Query optimizeQuery(Query q, ValidationCategory category) {
+    public Query optimizeQuery(Query q, Category category) {
         final Column inputPhysicalColumn = inputColumn.getPhysicalColumn();
-        if (category == ValidationCategory.VALID) {
+        if (category == Category.EQUALS) {
             if (compareColumn == null) {
                 final SelectItem selectItem = new SelectItem(inputPhysicalColumn);
                 final List<FilterItem> filterItems = new ArrayList<FilterItem>();

--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/EqualsFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/EqualsFilter.java
@@ -57,9 +57,9 @@ import com.google.common.base.Joiner;
 public class EqualsFilter implements QueryOptimizedFilter<EqualsFilter.Category>, HasLabelAdvice {
 
     public static enum Category {
-        @Alias({ "Valid", "VALID" }) EQUALS,
+        @Alias("VALID") @Description("Outcome when the operands of the filter are equal.") EQUALS,
 
-        @Alias({ "Invalid", "INVALID" }) NOT_EQUALS;
+        @Alias("INVALID") @Description("Outcome when the operands of the filter are not equal.") NOT_EQUALS;
     }
 
     @Inject

--- a/components/basic-filters/src/test/java/org/datacleaner/beans/filter/EqualsFilterTest.java
+++ b/components/basic-filters/src/test/java/org/datacleaner/beans/filter/EqualsFilterTest.java
@@ -31,62 +31,62 @@ import org.datacleaner.data.MockInputColumn;
 import org.datacleaner.test.TestHelper;
 
 public class EqualsFilterTest extends TestCase {
-    
+
     private Datastore datastore = TestHelper.createSampleDatabaseDatastore("ds");
-    
+
     public void testCompareToEnum() throws Exception {
-        EqualsFilter f = new EqualsFilter(new String[] { "VALID" }, new MockInputColumn<String>("col", String.class));
-        assertEquals(ValidationCategory.VALID, f.filter(ValidationCategory.VALID));
-        assertEquals(ValidationCategory.INVALID, f.filter(ValidationCategory.INVALID));
+        EqualsFilter f = new EqualsFilter(new String[] { "EQUALS" }, new MockInputColumn<String>("col", String.class));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(EqualsFilter.Category.EQUALS));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(EqualsFilter.Category.NOT_EQUALS));
     }
 
     public void testSingleString() throws Exception {
         EqualsFilter f = new EqualsFilter(new String[] { "hello" }, new MockInputColumn<String>("col", String.class));
-        assertEquals(ValidationCategory.VALID, f.filter("hello"));
-        assertEquals(ValidationCategory.INVALID, f.filter("Hello"));
-        assertEquals(ValidationCategory.INVALID, f.filter(""));
-        assertEquals(ValidationCategory.INVALID, f.filter(null));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter("hello"));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter("Hello"));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(""));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(null));
     }
 
     public void testSingleNumber() throws Exception {
         EqualsFilter f = new EqualsFilter(new String[] { "1234" }, new MockInputColumn<Number>("col", Number.class));
-        assertEquals(ValidationCategory.VALID, f.filter(1234));
-        assertEquals(ValidationCategory.VALID, f.filter(1234.0));
-        assertEquals(ValidationCategory.INVALID, f.filter(2));
-        assertEquals(ValidationCategory.INVALID, f.filter(-2));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1234));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1234.0));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(2));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(-2));
     }
 
     public void testMultipleStrings() throws Exception {
-        EqualsFilter f = new EqualsFilter(new String[] { "hello", "Hello", "World" }, new MockInputColumn<String>(
-                "col", String.class));
-        assertEquals(ValidationCategory.VALID, f.filter("hello"));
-        assertEquals(ValidationCategory.VALID, f.filter("Hello"));
-        assertEquals(ValidationCategory.INVALID, f.filter(""));
-        assertEquals(ValidationCategory.INVALID, f.filter("world"));
-        assertEquals(ValidationCategory.INVALID, f.filter(null));
+        EqualsFilter f = new EqualsFilter(new String[] { "hello", "Hello", "World" },
+                new MockInputColumn<String>("col", String.class));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter("hello"));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter("Hello"));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(""));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter("world"));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(null));
     }
 
     public void testCompareValueColumnNumbers() throws Exception {
         EqualsFilter f = new EqualsFilter(new MockInputColumn<Object>("col1", Number.class),
                 new MockInputColumn<Object>("col2", Object.class));
 
-        assertEquals(ValidationCategory.VALID, f.filter(1234, 1234));
-        assertEquals(ValidationCategory.VALID, f.filter(1234.0, 1234));
-        assertEquals(ValidationCategory.VALID, f.filter(1235, "1235"));
-        assertEquals(ValidationCategory.VALID, f.filter(1235, "1235.0"));
-        
-        assertEquals(ValidationCategory.INVALID, f.filter(2, 3));
-        assertEquals(ValidationCategory.INVALID, f.filter(-2, "2000"));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1234, 1234));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1234.0, 1234));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1235, "1235"));
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter(1235, "1235.0"));
+
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(2, 3));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter(-2, "2000"));
     }
 
     public void testCompareValueColumnStrings() throws Exception {
         EqualsFilter f = new EqualsFilter(new MockInputColumn<Object>("col1", String.class),
                 new MockInputColumn<Object>("col2", Object.class));
-        
-        assertEquals(ValidationCategory.VALID, f.filter("foo", "foo"));
-        assertEquals(ValidationCategory.INVALID, f.filter("foo", "bar"));
+
+        assertEquals(EqualsFilter.Category.EQUALS, f.filter("foo", "foo"));
+        assertEquals(EqualsFilter.Category.NOT_EQUALS, f.filter("foo", "bar"));
     }
-    
+
     public void testNonOptimizeableQuery() throws Exception {
         DatastoreConnection con = datastore.openConnection();
         Column column1 = con.getSchemaNavigator().convertToColumn("PUBLIC.EMPLOYEES.FIRSTNAME");
@@ -96,9 +96,9 @@ public class EqualsFilterTest extends TestCase {
 
         EqualsFilter filter = new EqualsFilter(inputColumn1, inputColumn2);
         filter.setValues(new String[] { "foobar" });
-        
-        assertFalse(filter.isOptimizable(ValidationCategory.VALID));
-        assertFalse(filter.isOptimizable(ValidationCategory.INVALID));
+
+        assertFalse(filter.isOptimizable(EqualsFilter.Category.EQUALS));
+        assertFalse(filter.isOptimizable(EqualsFilter.Category.NOT_EQUALS));
     }
 
     public void testOptimizeQueryValueColumn() throws Exception {
@@ -109,18 +109,19 @@ public class EqualsFilterTest extends TestCase {
         InputColumn<?> inputColumn2 = new MetaModelInputColumn(column2);
 
         EqualsFilter filter = new EqualsFilter(inputColumn1, inputColumn2);
-        assertTrue(filter.isOptimizable(ValidationCategory.VALID));
-        assertTrue(filter.isOptimizable(ValidationCategory.INVALID));
+        assertTrue(filter.isOptimizable(EqualsFilter.Category.EQUALS));
+        assertTrue(filter.isOptimizable(EqualsFilter.Category.NOT_EQUALS));
 
         Query query = con.getDataContext().query().from(column1.getTable()).select(column1, column2).toQuery();
         String originalSql = query.toSql();
-        assertEquals("SELECT \"EMPLOYEES\".\"FIRSTNAME\", \"EMPLOYEES\".\"LASTNAME\" FROM PUBLIC.\"EMPLOYEES\"", originalSql);
+        assertEquals("SELECT \"EMPLOYEES\".\"FIRSTNAME\", \"EMPLOYEES\".\"LASTNAME\" FROM PUBLIC.\"EMPLOYEES\"",
+                originalSql);
 
         Query result;
-        result = filter.optimizeQuery(query.clone(), ValidationCategory.VALID);
+        result = filter.optimizeQuery(query.clone(), EqualsFilter.Category.EQUALS);
         assertEquals(originalSql + " WHERE \"EMPLOYEES\".\"FIRSTNAME\" = \"EMPLOYEES\".\"LASTNAME\"", result.toSql());
 
-        result = filter.optimizeQuery(query.clone(), ValidationCategory.INVALID);
+        result = filter.optimizeQuery(query.clone(), EqualsFilter.Category.NOT_EQUALS);
         assertEquals(originalSql + " WHERE \"EMPLOYEES\".\"FIRSTNAME\" <> \"EMPLOYEES\".\"LASTNAME\"", result.toSql());
 
         con.close();
@@ -132,18 +133,18 @@ public class EqualsFilterTest extends TestCase {
         InputColumn<?> inputColumn = new MetaModelInputColumn(column);
 
         EqualsFilter filter = new EqualsFilter(new String[] { "foobar" }, inputColumn);
-        assertTrue(filter.isOptimizable(ValidationCategory.VALID));
-        assertTrue(filter.isOptimizable(ValidationCategory.INVALID));
+        assertTrue(filter.isOptimizable(EqualsFilter.Category.EQUALS));
+        assertTrue(filter.isOptimizable(EqualsFilter.Category.NOT_EQUALS));
 
         Query query = con.getDataContext().query().from(column.getTable()).select(column).toQuery();
         String originalSql = query.toSql();
         assertEquals("SELECT \"EMPLOYEES\".\"FIRSTNAME\" FROM PUBLIC.\"EMPLOYEES\"", originalSql);
 
         Query result;
-        result = filter.optimizeQuery(query.clone(), ValidationCategory.VALID);
+        result = filter.optimizeQuery(query.clone(), EqualsFilter.Category.EQUALS);
         assertEquals(originalSql + " WHERE (\"EMPLOYEES\".\"FIRSTNAME\" = 'foobar')", result.toSql());
 
-        result = filter.optimizeQuery(query.clone(), ValidationCategory.INVALID);
+        result = filter.optimizeQuery(query.clone(), EqualsFilter.Category.NOT_EQUALS);
         assertEquals(originalSql + " WHERE \"EMPLOYEES\".\"FIRSTNAME\" <> 'foobar'", result.toSql());
 
         con.close();

--- a/desktop/ui/src/main/java/org/datacleaner/panels/equalsfilter/EqualsFilterComponentBuilderPresenterRenderer.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/equalsfilter/EqualsFilterComponentBuilderPresenterRenderer.java
@@ -25,7 +25,6 @@ import org.datacleaner.api.Renderer;
 import org.datacleaner.api.RendererBean;
 import org.datacleaner.api.RendererPrecedence;
 import org.datacleaner.beans.filter.EqualsFilter;
-import org.datacleaner.beans.filter.ValidationCategory;
 import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.guice.DCModule;
 import org.datacleaner.job.builder.FilterComponentBuilder;
@@ -34,12 +33,12 @@ import org.datacleaner.panels.FilterComponentBuilderPresenter;
 import org.datacleaner.widgets.properties.PropertyWidgetFactory;
 
 /**
- * Specialized {@link Renderer} for a {@link FilterComponentBuilderPresenter} for
- * {@link EqualsFilter}.
+ * Specialized {@link Renderer} for a {@link FilterComponentBuilderPresenter}
+ * for {@link EqualsFilter}.
  */
 @RendererBean(ComponentBuilderPresenterRenderingFormat.class)
 public class EqualsFilterComponentBuilderPresenterRenderer implements
-        Renderer<FilterComponentBuilder<EqualsFilter, ValidationCategory>, FilterComponentBuilderPresenter> {
+        Renderer<FilterComponentBuilder<EqualsFilter, EqualsFilter.Category>, FilterComponentBuilderPresenter> {
 
     @Inject
     WindowContext windowContext;
@@ -48,7 +47,7 @@ public class EqualsFilterComponentBuilderPresenterRenderer implements
     DCModule dcModule;
 
     @Override
-    public RendererPrecedence getPrecedence(FilterComponentBuilder<EqualsFilter, ValidationCategory> fjb) {
+    public RendererPrecedence getPrecedence(FilterComponentBuilder<EqualsFilter, EqualsFilter.Category> fjb) {
         if (fjb.getDescriptor().getComponentClass() == EqualsFilter.class) {
             return RendererPrecedence.HIGH;
         }
@@ -56,9 +55,9 @@ public class EqualsFilterComponentBuilderPresenterRenderer implements
     }
 
     @Override
-    public FilterComponentBuilderPresenter render(FilterComponentBuilder<EqualsFilter, ValidationCategory> fjb) {
-        final PropertyWidgetFactory propertyWidgetFactory = dcModule.createChildInjectorForComponent(fjb).getInstance(
-                PropertyWidgetFactory.class);
+    public FilterComponentBuilderPresenter render(FilterComponentBuilder<EqualsFilter, EqualsFilter.Category> fjb) {
+        final PropertyWidgetFactory propertyWidgetFactory = dcModule.createChildInjectorForComponent(fjb)
+                .getInstance(PropertyWidgetFactory.class);
 
         return new EqualsFilterComponentBuilderPresenter(fjb, windowContext, propertyWidgetFactory);
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
@@ -27,12 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JFileChooser;
-import javax.swing.event.DocumentEvent;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Resource;
-import org.datacleaner.util.DCDocumentListener;
 import org.datacleaner.util.StringUtils;
 import org.datacleaner.util.WidgetUtils;
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
@@ -247,7 +247,7 @@ public class JobGraphLinkPainter {
                         componentBuilder.addInputColumns(getRelevantSourceColumns(sourceColumns, inputProperty),
                                 inputProperty);
                     } else {
-                        final InputColumn firstRelevantSourceColumn =
+                        final InputColumn<?> firstRelevantSourceColumn =
                                 getFirstRelevantSourceColumn(sourceColumns, inputProperty);
                         if(firstRelevantSourceColumn != null){
                             componentBuilder.setConfiguredProperty(inputProperty, firstRelevantSourceColumn);
@@ -310,7 +310,7 @@ public class JobGraphLinkPainter {
         componentBuilder.setComponentRequirement(requirement);
     }
 
-    private InputColumn getFirstRelevantSourceColumn(List<? extends InputColumn<?>> sourceColumns,
+    private InputColumn<?> getFirstRelevantSourceColumn(List<? extends InputColumn<?>> sourceColumns,
             ConfiguredPropertyDescriptor inputProperty){
         assert inputProperty.isInputColumn();
 

--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingMetricsImplTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingMetricsImplTest.java
@@ -19,12 +19,9 @@
  */
 package org.datacleaner.job.runner;
 
-import junit.framework.TestCase;
-
 import org.datacleaner.beans.NumberAnalyzer;
 import org.datacleaner.beans.filter.EqualsFilter;
 import org.datacleaner.beans.filter.NullCheckFilter;
-import org.datacleaner.beans.filter.ValidationCategory;
 import org.datacleaner.components.maxrows.MaxRowsFilter;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
@@ -39,6 +36,8 @@ import org.datacleaner.job.tasks.Task;
 import org.datacleaner.lifecycle.LifeCycleHelper;
 import org.datacleaner.test.TestHelper;
 import org.junit.Assert;
+
+import junit.framework.TestCase;
 
 public class RowProcessingMetricsImplTest extends TestCase {
 
@@ -78,11 +77,11 @@ public class RowProcessingMetricsImplTest extends TestCase {
     public void testGetExpectedRowCountEquals() throws Exception {
         AnalysisJobBuilder ajb = createAnalysisJobBuilder();
 
-        FilterComponentBuilder<EqualsFilter, ValidationCategory> filter = ajb.addFilter(EqualsFilter.class);
+        FilterComponentBuilder<EqualsFilter, EqualsFilter.Category> filter = ajb.addFilter(EqualsFilter.class);
         filter.addInputColumns(ajb.getSourceColumns());
         filter.getComponentInstance().setValues(new String[] { "1002", "1165" });
 
-        ajb.setDefaultRequirement(filter.getFilterOutcome(ValidationCategory.VALID));
+        ajb.setDefaultRequirement(filter.getFilterOutcome(EqualsFilter.Category.EQUALS));
 
         job = ajb.toAnalysisJob();
 
@@ -93,7 +92,7 @@ public class RowProcessingMetricsImplTest extends TestCase {
         AnalysisJobBuilder ajb = createAnalysisJobBuilder();
 
         // there's 21 records that are not 1056 or 1165
-        FilterComponentBuilder<EqualsFilter, ValidationCategory> filter1 = ajb.addFilter(EqualsFilter.class);
+        FilterComponentBuilder<EqualsFilter, EqualsFilter.Category> filter1 = ajb.addFilter(EqualsFilter.class);
         filter1.addInputColumns(ajb.getSourceColumns());
         filter1.getComponentInstance().setValues(new String[] { "1056", "1165" });
 
@@ -103,7 +102,7 @@ public class RowProcessingMetricsImplTest extends TestCase {
         ajb.addSourceColumns("PUBLIC.EMPLOYEES.REPORTSTO");
         filter2.addInputColumn(ajb.getSourceColumnByName("reportsto"));
         filter2.getComponentInstance().setConsiderEmptyStringAsNull(true);
-        filter2.setRequirement(filter1.getFilterOutcome(ValidationCategory.INVALID));
+        filter2.setRequirement(filter1.getFilterOutcome(EqualsFilter.Category.NOT_EQUALS));
 
         ajb.getAnalyzerComponentBuilders().get(0)
                 .setRequirement(filter2.getFilterOutcome(NullCheckFilter.NullCheckCategory.NOT_NULL));

--- a/desktop/ui/src/test/resources/documentation/equals_filter.html
+++ b/desktop/ui/src/test/resources/documentation/equals_filter.html
@@ -116,13 +116,13 @@ h3 {
 					<li class="list-group-item">
 						<h3>
 							<span class="glyphicon glyphicon-share" aria-hidden="true"></span>
-							<span class="text-info">VALID</span>
-						</h3> 
+							<span class="text-info">EQUALS</span>
+						</h3> <p>Outcome when the operands of the filter are equal.</p>
 					</li> 					<li class="list-group-item">
 						<h3>
 							<span class="glyphicon glyphicon-share" aria-hidden="true"></span>
-							<span class="text-info">INVALID</span>
-						</h3> 
+							<span class="text-info">NOT_EQUALS</span>
+						</h3> <p>Outcome when the operands of the filter are not equal.</p>
 					</li> 
 				</ul>
 			</div>

--- a/engine/core/src/main/java/org/datacleaner/data/MetaModelInputRow.java
+++ b/engine/core/src/main/java/org/datacleaner/data/MetaModelInputRow.java
@@ -70,7 +70,7 @@ public final class MetaModelInputRow extends AbstractInputRow {
         Column physicalColumn = inputColumn.getPhysicalColumn();
         SelectItem[] selectItems = _row.getSelectItems();
         for (SelectItem selectItem : selectItems) {
-            if (selectItem.getColumn() != null && selectItem.getFunction() == null) {
+            if (selectItem.getColumn() != null && selectItem.getAggregateFunction() == null) {
                 Column column = selectItem.getColumn();
                 if (physicalColumn.equals(column)) {
                     return true;
@@ -133,7 +133,7 @@ public final class MetaModelInputRow extends AbstractInputRow {
         List<InputColumn<?>> result = new ArrayList<InputColumn<?>>();
         SelectItem[] selectItems = _row.getSelectItems();
         for (SelectItem selectItem : selectItems) {
-            if (selectItem.getColumn() != null && selectItem.getFunction() == null) {
+            if (selectItem.getColumn() != null && selectItem.getAggregateFunction() == null) {
                 result.add(new MetaModelInputColumn(selectItem.getColumn()));
             }
         }

--- a/engine/core/src/main/java/org/datacleaner/metamodel/datahub/DataHubDataSet.java
+++ b/engine/core/src/main/java/org/datacleaner/metamodel/datahub/DataHubDataSet.java
@@ -179,7 +179,7 @@ public class DataHubDataSet extends AbstractDataSet {
         }
         final SelectClause selectClause = query.getSelectClause();
         for (SelectItem selectItem : selectClause.getItems()) {
-            if (selectItem.getFunction() != null) {
+            if (selectItem.getAggregateFunction() != null) {
                 return false;
             }
         }

--- a/engine/env/cluster/src/test/java/org/datacleaner/cluster/ClusterTestHelper.java
+++ b/engine/env/cluster/src/test/java/org/datacleaner/cluster/ClusterTestHelper.java
@@ -38,7 +38,6 @@ import org.datacleaner.beans.NumberAnalyzerResult;
 import org.datacleaner.beans.StringAnalyzer;
 import org.datacleaner.beans.StringAnalyzerResult;
 import org.datacleaner.beans.filter.EqualsFilter;
-import org.datacleaner.beans.filter.ValidationCategory;
 import org.datacleaner.beans.transform.ConcatenatorTransformer;
 import org.datacleaner.beans.valuematch.ValueMatchAnalyzer;
 import org.datacleaner.beans.valuematch.ValueMatchAnalyzerResult;
@@ -493,7 +492,7 @@ public class ClusterTestHelper {
                 jobBuilder.addSourceColumns("CUSTOMERS.CUSTOMERNUMBER", "CUSTOMERS.CONTACTFIRSTNAME",
                         "CUSTOMERS.CONTACTLASTNAME");
 
-                final FilterComponentBuilder<EqualsFilter, ValidationCategory> equalsFilter = jobBuilder
+                final FilterComponentBuilder<EqualsFilter, EqualsFilter.Category> equalsFilter = jobBuilder
                         .addFilter(EqualsFilter.class);
                 equalsFilter.addInputColumn(jobBuilder.getSourceColumnByName("CUSTOMERNUMBER"));
                 equalsFilter.getComponentInstance().setValues(new String[] { "-1000000" });
@@ -501,7 +500,7 @@ public class ClusterTestHelper {
                 final AnalyzerComponentBuilder<StringAnalyzer> stringAnalyzer = jobBuilder
                         .addAnalyzer(StringAnalyzer.class);
                 stringAnalyzer.addInputColumns(jobBuilder.getAvailableInputColumns(String.class));
-                stringAnalyzer.setRequirement(equalsFilter, ValidationCategory.VALID);
+                stringAnalyzer.setRequirement(equalsFilter, EqualsFilter.Category.EQUALS);
 
                 job = jobBuilder.toAnalysisJob();
             } finally {

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/TenantInfoController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/TenantInfoController.java
@@ -21,12 +21,8 @@ package org.datacleaner.monitor.server.controllers;
 
 import org.datacleaner.monitor.server.security.TenantResolver;
 import org.datacleaner.monitor.server.security.UserBean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -38,8 +34,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 @RequestMapping("/_user")
 public class TenantInfoController {
-
-    private static final Logger logger = LoggerFactory.getLogger(TenantInfoController.class);
 
     @Autowired
     private TenantResolver _tenantResolver;

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/components/ComponentInfoTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/components/ComponentInfoTest.java
@@ -19,30 +19,24 @@
  */
 package org.datacleaner.monitor.server.components;
 
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertTrue;
+
 import org.datacleaner.restclient.ComponentConfiguration;
 import org.datacleaner.restclient.ComponentList.ComponentInfo;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertTrue;
 
 public class ComponentInfoTest {
     private ComponentInfo componentInfo = new ComponentInfo();
     private String name = "name";
     private String description = "description";
     private String createURL = "create URL";
-    private List<String[]> propertyList = null;
     private ComponentConfiguration componentConfigurationMock = null;
 
     @Before
     public void setUp() {
-        String[][] properties = { { "propertyName", "property description", "required" } };
-        propertyList = Arrays.asList(properties);
         componentConfigurationMock = createNiceMock(ComponentConfiguration.class);
 
         replay(componentConfigurationMock);

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/components/ComponentListTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/components/ComponentListTest.java
@@ -47,6 +47,7 @@ import org.datacleaner.restclient.ComponentList.ComponentInfo;
 import org.easymock.IExpectationSetters;
 import org.junit.Test;
 
+@SuppressWarnings("rawtypes")
 public class ComponentListTest {
     private static final int COMPONENTS_COUNT = 5;
     private static final String tenant = "demo";
@@ -94,6 +95,8 @@ public class ComponentListTest {
 
     private ComponentSuperCategory getComponentSuperCategoryMock() {
         ComponentSuperCategory componentSuperCategory = new ComponentSuperCategory() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public String getName() {
                 return "superCategory";
@@ -118,6 +121,7 @@ public class ComponentListTest {
         return componentSuperCategory;
     }
 
+    @SuppressWarnings("unchecked")
     private Set<ConfiguredPropertyDescriptor> getConfiguredPropertiesMock() {
         configuredPropertyDescriptorMock = createNiceMock(ConfiguredPropertyDescriptor.class);
         expect(configuredPropertyDescriptorMock.getName()).andReturn("propertyName").anyTimes();
@@ -158,7 +162,6 @@ public class ComponentListTest {
         componentInfo.setName("name" + id);
         componentInfo.setDescription("description of " + id);
         componentInfo.setCreateURL("create URL" + id);
-        String[][] properties = { { "propertyName" + id, "propertyDescription" + id, "required" } };
         Map<String, ComponentList.PropertyInfo> props = new HashMap<>();
         ComponentList.PropertyInfo prop = new ComponentList.PropertyInfo();
         prop.setName("propertyName" + id);


### PR DESCRIPTION
This fixes #797 and in general I am quite happy with the change.

BUT I would be lying if I said this PR also didn't have any negative consequences. That would be on compatibility of code that is programmatically using the Equals filter. Basically such code needs to be adapted, as can be seen by the diff. I know we have it in use here and there in commercial editions of DC, so that would need to be updated as well.

The ```@Alias``` on the new enum ensures that at least .analysis.xml files are still backwards compatible. The only non-backward compatible change here is that programmatic instantiation of the component has changed.