### PR TITLE
Fix file resource property widget

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
@@ -126,9 +126,8 @@ public final class FilenameTextField extends AbstractResourceTextField<FileResou
         final File file = getFile();
         if (file != null) {
             notifySelectionListeners(file);
-        } else {
-            super.notifyListeners(text);
         }
+        super.notifyListeners(text);
     }
 
     private void notifySelectionListeners(final File file) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/FilenameTextField.java
@@ -27,12 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JFileChooser;
-import javax.swing.event.DocumentEvent;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Resource;
-import org.datacleaner.util.DCDocumentListener;
 import org.datacleaner.util.StringUtils;
 import org.datacleaner.util.WidgetUtils;
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/HdfsResourceTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/HdfsResourceTextField.java
@@ -28,19 +28,18 @@ import org.datacleaner.windows.HdfsUrlChooser;
 public class HdfsResourceTextField extends AbstractResourceTextField<HdfsResource> {
 
     private static final long serialVersionUID = 1L;
-    
-    String _hdfsUri;
+
+    private String _hdfsUri;
 
     public HdfsResourceTextField(String uri, final HdfsUrlChooser.OpenType openType) {
         _hdfsUri = uri;
 
         getBrowseButton().addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(final ActionEvent e) {
-                    HdfsUrlChooser.showDialog(HdfsResourceTextField.this, null, openType);
-                }
+            @Override
+            public void actionPerformed(final ActionEvent e) {
+                HdfsUrlChooser.showDialog(HdfsResourceTextField.this, null, openType);
             }
-        );
+        });
     }
 
     HdfsResourceTextField(HdfsUrlChooser.OpenType openType) {

--- a/desktop/ui/src/test/java/org/datacleaner/widgets/FilenameTextFieldTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/widgets/FilenameTextFieldTest.java
@@ -1,0 +1,57 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */package org.datacleaner.widgets;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.apache.metamodel.util.FileResource;
+import org.apache.metamodel.util.Resource;
+import org.junit.Test;
+
+public class FilenameTextFieldTest {
+
+    @Test
+    public void testAvoidListenerMutations() throws Exception {
+        final FilenameTextField filenameTextField = new FilenameTextField(new File("."), true);
+        
+        // create some silly listeners that re-set the value of the widget.
+        filenameTextField.addFileSelectionListener(new FileSelectionListener() {
+            @Override
+            public void onSelected(FilenameTextField filenameTextField, File file) {
+                filenameTextField.setFile(file);
+            }
+        });
+        filenameTextField.addListener(new ResourceTypePresenter.Listener() {
+            
+            @Override
+            public void onResourceSelected(ResourceTypePresenter<?> presenter, Resource resource) {
+                filenameTextField.setResource((FileResource) resource);
+            }
+            
+            @Override
+            public void onPathEntered(ResourceTypePresenter<?> presenter, String path) {
+            }
+        });
+        
+        filenameTextField.setFilename("src/foo.txt");
+        assertEquals("src/foo.txt", filenameTextField.getFile().getPath().replace('\\', '/'));
+    }
+}

--- a/desktop/ui/src/test/java/org/datacleaner/widgets/FilenameTextFieldTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/widgets/FilenameTextFieldTest.java
@@ -16,11 +16,14 @@
  * Free Software Foundation, Inc.
  * 51 Franklin Street, Fifth Floor
  * Boston, MA  02110-1301  USA
- */package org.datacleaner.widgets;
+ */
+package org.datacleaner.widgets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Resource;
@@ -31,7 +34,7 @@ public class FilenameTextFieldTest {
     @Test
     public void testAvoidListenerMutations() throws Exception {
         final FilenameTextField filenameTextField = new FilenameTextField(new File("."), true);
-        
+
         // create some silly listeners that re-set the value of the widget.
         filenameTextField.addFileSelectionListener(new FileSelectionListener() {
             @Override
@@ -40,18 +43,50 @@ public class FilenameTextFieldTest {
             }
         });
         filenameTextField.addListener(new ResourceTypePresenter.Listener() {
-            
+
             @Override
             public void onResourceSelected(ResourceTypePresenter<?> presenter, Resource resource) {
                 filenameTextField.setResource((FileResource) resource);
             }
-            
+
             @Override
             public void onPathEntered(ResourceTypePresenter<?> presenter, String path) {
             }
         });
-        
+
         filenameTextField.setFilename("src/foo.txt");
         assertEquals("src/foo.txt", filenameTextField.getFile().getPath().replace('\\', '/'));
+    }
+
+    @Test
+    public void testDifferentListenersAllGetsNotification() throws Exception {
+        final FilenameTextField filenameTextField = new FilenameTextField(new File("."), true);
+
+        final AtomicBoolean fileSelectionListenerInvoked = new AtomicBoolean(false);
+        final AtomicBoolean resourceListenerInvoked = new AtomicBoolean(false);
+
+        // create some silly listeners that re-set the value of the widget.
+        filenameTextField.addFileSelectionListener(new FileSelectionListener() {
+            @Override
+            public void onSelected(FilenameTextField filenameTextField, File file) {
+                fileSelectionListenerInvoked.set(true);
+            }
+        });
+        filenameTextField.addListener(new ResourceTypePresenter.Listener() {
+
+            @Override
+            public void onResourceSelected(ResourceTypePresenter<?> presenter, Resource resource) {
+                resourceListenerInvoked.set(true);
+            }
+
+            @Override
+            public void onPathEntered(ResourceTypePresenter<?> presenter, String path) {
+            }
+        });
+
+        filenameTextField.setFilename("src/foo.txt");
+
+        assertTrue(fileSelectionListenerInvoked.get());
+        assertTrue(resourceListenerInvoked.get());
     }
 }


### PR DESCRIPTION
Fixes #830

This was essentially a mixup from our previous story of refactoring FilenameTextField. This time I made the code a bit more robust by adding some unittests to ensure we don't mess up the listener expectations again.