### PR TITLE
Make ImmutableOutputDataStreamJob serializable

### DIFF
--- a/components/html-rendering/src/test/scala/org/datacleaner/result/html/HtmlAnalysisResultWriterTest.scala
+++ b/components/html-rendering/src/test/scala/org/datacleaner/result/html/HtmlAnalysisResultWriterTest.scala
@@ -11,9 +11,9 @@ import scala.xml.XML
 class HtmlAnalysisResultWriterTest extends AssertionsForJUnit {
 
   @Test
-  def testEmptyRendering = {
+  def testEmptyRendering() = {
     val writer = new HtmlAnalysisResultWriter();
-    val analysisResult = new SimpleAnalysisResult(new java.util.HashMap());
+    val analysisResult = new SimpleAnalysisResult();
     val configuration = new DataCleanerConfigurationImpl();
     val stringWriter = new StringWriter();
 

--- a/engine/core/src/main/java/org/datacleaner/job/ImmutableOutputDataStreamJob.java
+++ b/engine/core/src/main/java/org/datacleaner/job/ImmutableOutputDataStreamJob.java
@@ -26,7 +26,7 @@ public class ImmutableOutputDataStreamJob implements OutputDataStreamJob {
     private static final long serialVersionUID = 1L;
 
     private final OutputDataStream _outputDataStream;
-    private final AnalysisJob _job;
+    private transient final AnalysisJob _job;
 
     public ImmutableOutputDataStreamJob(OutputDataStream outputDataStream, AnalysisJob job) {
         _outputDataStream = outputDataStream;

--- a/engine/core/src/main/java/org/datacleaner/result/SimpleAnalysisResult.java
+++ b/engine/core/src/main/java/org/datacleaner/result/SimpleAnalysisResult.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +41,10 @@ public class SimpleAnalysisResult extends AbstractAnalysisResult implements Seri
 
     private final Map<ComponentJob, AnalyzerResult> _results;
     private final Date _creationDate;
+
+    public SimpleAnalysisResult() {
+        this(new HashMap<ComponentJob, AnalyzerResult>());
+    }
 
     public SimpleAnalysisResult(AnalysisResult result){
         this(result.getResultMap(), new Date());

--- a/engine/core/src/main/java/org/datacleaner/result/SimpleAnalysisResult.java
+++ b/engine/core/src/main/java/org/datacleaner/result/SimpleAnalysisResult.java
@@ -41,6 +41,10 @@ public class SimpleAnalysisResult extends AbstractAnalysisResult implements Seri
     private final Map<ComponentJob, AnalyzerResult> _results;
     private final Date _creationDate;
 
+    public SimpleAnalysisResult(AnalysisResult result){
+        this(result.getResultMap(), new Date());
+    }
+
     public SimpleAnalysisResult(Map<ComponentJob, AnalyzerResult> results) {
         this(results, new Date());
     }

--- a/engine/core/src/test/java/org/datacleaner/test/full/scenarios/JobWithOutputDataStreamsTest.java
+++ b/engine/core/src/test/java/org/datacleaner/test/full/scenarios/JobWithOutputDataStreamsTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.apache.commons.lang.SerializationUtils;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
@@ -41,6 +42,7 @@ import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.job.runner.AnalysisResultFuture;
 import org.datacleaner.job.runner.AnalysisRunnerImpl;
 import org.datacleaner.result.ListResult;
+import org.datacleaner.result.SimpleAnalysisResult;
 import org.datacleaner.test.MockAnalyzer;
 import org.datacleaner.test.MockOutputDataStreamAnalyzer;
 import org.datacleaner.test.TestEnvironment;
@@ -146,14 +148,18 @@ public class JobWithOutputDataStreamsTest {
 
         assertEquals(2, resultFuture.getResults().size());
 
+        final byte[] serialized = SerializationUtils.serialize(new SimpleAnalysisResult(resultFuture.getResultMap()));
+
+        SimpleAnalysisResult deSerializedResult = (SimpleAnalysisResult) SerializationUtils.deserialize(serialized);
+
         // the first result should be trivial - it was also there before issue
         // #224
-        final ListResult<?> result1 = (ListResult<?>) resultFuture.getResult(analyzerJob1);
+        final ListResult<?> result1 = (ListResult<?>) deSerializedResult.getResult(analyzerJob1);
         assertNotNull(result1);
         assertEquals(40, result1.getValues().size());
 
         // this result is the "new part" of issue #224
-        final ListResult<?> result2 = (ListResult<?>) resultFuture.getResult(analyzerJob2);
+        final ListResult<?> result2 = (ListResult<?>) deSerializedResult.getResult(analyzerJob2);
         assertNotNull(result2);
         assertEquals(83, result2.getValues().size());
         final Object lastElement = result2.getValues().get(result2.getValues().size() - 1);

--- a/engine/core/src/test/java/org/datacleaner/test/full/scenarios/JobWithOutputDataStreamsTest.java
+++ b/engine/core/src/test/java/org/datacleaner/test/full/scenarios/JobWithOutputDataStreamsTest.java
@@ -150,7 +150,7 @@ public class JobWithOutputDataStreamsTest {
 
         final byte[] serialized = SerializationUtils.serialize(new SimpleAnalysisResult(resultFuture.getResultMap()));
 
-        SimpleAnalysisResult deSerializedResult = (SimpleAnalysisResult) SerializationUtils.deserialize(serialized);
+        final SimpleAnalysisResult deSerializedResult = (SimpleAnalysisResult) SerializationUtils.deserialize(serialized);
 
         // the first result should be trivial - it was also there before issue
         // #224


### PR DESCRIPTION
It used to be impossible to serialize jobs with output datastreams, because ImmutableOutputDataStreamJob contains a non-transient reference to AnalysisJob. Making it transient fixes that without breaking the serialized result.

Fixes #842 