### PR TITLE
Do not use injected RowAnnotations

### DIFF
--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -111,18 +111,13 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     InputColumn<?>[] _additionalOutputValueColumns;
 
     // Do not inject the shared RowAnnotations, available rows are always needed.
-    final RowAnnotationFactory _annotationFactory = new InMemoryRowAnnotationFactory2();
-    final RowAnnotation _invalidRecords;
+    private final RowAnnotationFactory _annotationFactory = new InMemoryRowAnnotationFactory2();
+    private final RowAnnotation _invalidRecords = _annotationFactory.createAnnotation();
+    private final AtomicInteger _rowCount = new AtomicInteger();
 
-    private final AtomicInteger _rowCount;
     private OutputRowCollector _completeRowCollector;
     private OutputRowCollector _incompleteRowCollector;
     private List<InputColumn<?>> _outputDataStreamColumns;
-
-    public CompletenessAnalyzer() {
-        _invalidRecords = _annotationFactory.createAnnotation();
-        _rowCount = new AtomicInteger();
-    }
 
     @Initialize
     public void init() {

--- a/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
+++ b/components/basic-analyzers/src/main/java/org/datacleaner/beans/CompletenessAnalyzer.java
@@ -43,6 +43,7 @@ import org.datacleaner.api.OutputRowCollector;
 import org.datacleaner.api.Provided;
 import org.datacleaner.job.output.OutputDataStreamBuilder;
 import org.datacleaner.job.output.OutputDataStreams;
+import org.datacleaner.storage.InMemoryRowAnnotationFactory2;
 import org.datacleaner.storage.RowAnnotation;
 import org.datacleaner.storage.RowAnnotationFactory;
 import org.datacleaner.util.StringUtils;
@@ -109,13 +110,9 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     @Description("Optional additional values to add to output data streams")
     InputColumn<?>[] _additionalOutputValueColumns;
 
-    @Inject
-    @Provided
-    RowAnnotation _invalidRecords;
-
-    @Inject
-    @Provided
-    RowAnnotationFactory _annotationFactory;
+    // Do not inject the shared RowAnnotations, available rows are always needed.
+    final RowAnnotationFactory _annotationFactory = new InMemoryRowAnnotationFactory2();
+    final RowAnnotation _invalidRecords;
 
     private final AtomicInteger _rowCount;
     private OutputRowCollector _completeRowCollector;
@@ -123,6 +120,7 @@ public class CompletenessAnalyzer implements Analyzer<CompletenessAnalyzerResult
     private List<InputColumn<?>> _outputDataStreamColumns;
 
     public CompletenessAnalyzer() {
+        _invalidRecords = _annotationFactory.createAnnotation();
         _rowCount = new AtomicInteger();
     }
 

--- a/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
+++ b/components/basic-analyzers/src/test/java/org/datacleaner/beans/CompletenessAnalyzerTest.java
@@ -65,15 +65,11 @@ public class CompletenessAnalyzerTest extends TestCase {
     }
 
     public void testAllFieldsEvaluationMode() throws Exception {
-        final RowAnnotationFactory annotationFactory = RowAnnotations.getDefaultFactory();
-
         final InputColumn<?> col1 = new MockInputColumn<String>("foo");
         final InputColumn<?> col2 = new MockInputColumn<String>("bar");
 
         final CompletenessAnalyzer analyzer = new CompletenessAnalyzer();
         analyzer._evaluationMode = CompletenessAnalyzer.EvaluationMode.ALL_FIELDS;
-        analyzer._annotationFactory = annotationFactory;
-        analyzer._invalidRecords = annotationFactory.createAnnotation();
         analyzer._valueColumns = new InputColumn[] { col1, col2 };
         analyzer._conditions = new CompletenessAnalyzer.Condition[] { CompletenessAnalyzer.Condition.NOT_NULL,
                 CompletenessAnalyzer.Condition.NOT_NULL };
@@ -105,15 +101,11 @@ public class CompletenessAnalyzerTest extends TestCase {
     }
 
     public void testSimpleScenario() throws Exception {
-        final RowAnnotationFactory annotationFactory = RowAnnotations.getDefaultFactory();
-
         final InputColumn<?> col1 = new MockInputColumn<String>("foo");
         final InputColumn<?> col2 = new MockInputColumn<String>("bar");
         final InputColumn<?> col3 = new MockInputColumn<String>("baz");
 
         final CompletenessAnalyzer analyzer = new CompletenessAnalyzer();
-        analyzer._annotationFactory = annotationFactory;
-        analyzer._invalidRecords = annotationFactory.createAnnotation();
         analyzer._valueColumns = new InputColumn[] { col1, col2, col3 };
         analyzer._conditions = new CompletenessAnalyzer.Condition[] { CompletenessAnalyzer.Condition.NOT_NULL,
                 CompletenessAnalyzer.Condition.NOT_BLANK_OR_NULL, CompletenessAnalyzer.Condition.NOT_NULL };


### PR DESCRIPTION
As the CompletenessAnalyzer must always get row annotations for the result to show, we cannot use the shared row annotations.

Fixes #837 