### PR TITLE
Bug #858 REST client cache map

### DIFF
--- a/engine/rest-client/src/test/java/org/datacleaner/restclient/RESTClientImplTest.java
+++ b/engine/rest-client/src/test/java/org/datacleaner/restclient/RESTClientImplTest.java
@@ -19,10 +19,9 @@
  */
 package org.datacleaner.restclient;
 
+import com.sun.jersey.api.client.Client;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.sun.jersey.api.client.Client;
 
 public class RESTClientImplTest {
     private static final String USERNAME = "admin";


### PR DESCRIPTION
In REST client there is a cache for instances which is implemented by a map. Buggy version contained a map with an Integer as a key which was computed by hashCode() method. This could cause collisions so now SHA-1 is used for key creation. 