### PR TITLE
Spark create CSV file

### DIFF
--- a/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
+++ b/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
@@ -77,6 +77,7 @@ public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implemen
     public static final String PROPERTY_FILE = "File";
     public static final String PROPERTY_OVERWRITE_FILE_IF_EXISTS = "Overwrite file if exists";
     public static final String PROPERTY_COLUMN_TO_BE_SORTED_ON = "Column to be sorted on";
+    public static final String PROPERTY_INCLUDE_HEADER = "Include header";
 
     @Inject
     @Configured(value = PROPERTY_FILE, order = 1)
@@ -96,7 +97,7 @@ public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implemen
     Character escapeChar = '\\';
 
     @Inject
-    @Configured(order = 5, required = false)
+    @Configured(order = 5, required = false, value = PROPERTY_INCLUDE_HEADER)
     boolean includeHeader = true;
 
     @Inject

--- a/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
+++ b/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
@@ -71,7 +71,7 @@ import com.google.common.base.Strings;
 @Alias("Write to CSV file")
 @Description("Write data to a CSV file on your harddrive. CSV file writing is extremely fast and the file format is commonly used in many tools. But CSV files do not preserve data types.")
 @Categorized(superCategory = WriteSuperCategory.class)
-@Distributed(false)
+@Distributed(true)
 public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implements HasLabelAdvice {
 
     public static final String PROPERTY_FILE = "File";

--- a/engine/core/src/main/java/org/datacleaner/connection/JsonDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/JsonDatastore.java
@@ -63,6 +63,10 @@ public class JsonDatastore extends UsageAwareDatastore<JsonDataContext> implemen
         }
         return new DatastoreConnectionImpl<JsonDataContext>(dataContext, this);
     }
+    
+    public SchemaBuilder getSchemaBuilder() {
+        return _schemaBuilderRef.get();
+    }
 
     @Override
     public Resource getResource() {

--- a/engine/core/src/main/java/org/datacleaner/descriptors/AnnotationBasedAnalyzerComponentDescriptor.java
+++ b/engine/core/src/main/java/org/datacleaner/descriptors/AnnotationBasedAnalyzerComponentDescriptor.java
@@ -78,6 +78,10 @@ final class AnnotationBasedAnalyzerComponentDescriptor<A extends Analyzer<?>> ex
 
     @Override
     public boolean isDistributable() {
+        final Distributed annotation = getAnnotation(Distributed.class);
+        if (annotation != null) {
+            return annotation.value();
+        }
         return getResultReducerClass() != null;
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/descriptors/ClasspathScanDescriptorProvider.java
+++ b/engine/core/src/main/java/org/datacleaner/descriptors/ClasspathScanDescriptorProvider.java
@@ -269,12 +269,12 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
         final TaskListener listener = new TaskListener() {
             @Override
             public void onBegin(Task task) {
-                logger.info("Scan of '{}' beginning", packageName);
+                logger.debug("Scan of '{}' beginning", packageName);
             }
 
             @Override
             public void onComplete(Task task) {
-                logger.info("Scan of '{}' complete", packageName);
+                logger.debug("Scan of '{}' complete", packageName);
                 taskDone();
             }
 
@@ -291,9 +291,9 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
             public void execute() throws Exception {
                 final String packagePath = packageName.replace('.', '/');
                 if (recursive) {
-                    logger.info("Scanning package path '{}' (and subpackages recursively)", packagePath);
+                    logger.trace("Scanning package path '{}' (and subpackages recursively)", packagePath);
                 } else {
-                    logger.info("Scanning package path '{}'", packagePath);
+                    logger.trace("Scanning package path '{}'", packagePath);
                 }
 
                 logger.debug("Using ClassLoader: {}", classLoader);
@@ -303,7 +303,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
                         if (!file.exists()) {
                             logger.debug("Omitting JAR file because it does not exist: {}", file);
                         } else if (file.isDirectory()) {
-                            logger.info("Scanning subdirectory of: {}", file);
+                            logger.trace("Scanning subdirectory of: {}", file);
                             final File packageDirectory = new File(file, packagePath);
                             if (packageDirectory.exists()) {
                                 scanDirectory(packageDirectory, recursive, classLoader, strictClassLoader);
@@ -311,7 +311,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
                                 logger.debug("Omitting directory because it does not exist: {}", packageDirectory);
                             }
                         } else {
-                            logger.info("Scanning JAR file: {}", file);
+                            logger.trace("Scanning JAR file: {}", file);
 
                             try (JarFile jarFile = new JarFile(file)) {
                                 scanJar(jarFile, classLoader, packagePath, recursive, strictClassLoader);
@@ -328,7 +328,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
                     while (resources.hasMoreElements()) {
                         count++;
                         final URL resource = resources.nextElement();
-                        logger.debug("Scanning resource/URL no. {}: {}", count, resource);
+                        logger.trace("Scanning resource/URL no. {}: {}", count, resource);
 
                         try {
                             scanUrl(resource, classLoader, packagePath, recursive, strictClassLoader);
@@ -355,13 +355,13 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
 
         final File dir = new File(file.replaceAll("\\%20", " "));
         if (dir.isDirectory()) {
-            logger.info("Resource is a directory, scanning for files: {}", dir.getAbsolutePath());
+            logger.trace("Resource is a directory, scanning for files: {}", dir.getAbsolutePath());
             scanDirectory(dir, recursive, classLoader, strictClassLoader);
         } else {
 
             URLConnection connection = resource.openConnection();
             if (connection instanceof JarURLConnection) {
-                logger.info("Getting JarFile from JarURLConnection: {}", connection);
+                logger.debug("Getting JarFile from JarURLConnection: {}", connection);
                 JarFile jarFile = ((JarURLConnection) connection).getJarFile();
                 // note: We are NOT closing this JarFile, because it is still
                 // used by the JarURLConnection
@@ -384,7 +384,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
                         rootEntryPath = file.substring(separatorIndex + "!/".length());
                         jarFile = getJarFile(jarFileUrl);
                     } else {
-                        logger.info("Creating JarFile based on URI (without '!/'): {}", file);
+                        logger.debug("Creating JarFile based on URI (without '!/'): {}", file);
                         jarFile = new JarFile(file);
                         jarFileUrl = file;
                         rootEntryPath = "";
@@ -415,17 +415,17 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
             try {
                 final URI uri = new URI(jarFileUrl.replaceAll(" ", "\\%20"));
                 final String jarFileName = uri.getSchemeSpecificPart();
-                logger.info("Creating new JarFile based on URI-scheme filename: {}", jarFileName);
+                logger.debug("Creating new JarFile based on URI-scheme filename: {}", jarFileName);
                 return new JarFile(jarFileName);
             } catch (URISyntaxException ex) {
                 // Fallback for URLs that are not valid URIs (should hardly ever
                 // happen).
                 final String jarFileName = jarFileUrl.substring("file:".length());
-                logger.info("Creating new JarFile based on alternative filename: {}", jarFileName);
+                logger.debug("Creating new JarFile based on alternative filename: {}", jarFileName);
                 return new JarFile(jarFileName);
             }
         } else {
-            logger.info("Creating new JarFile based on URI (with '!/'): {}", jarFileUrl);
+            logger.debug("Creating new JarFile based on URI (with '!/'): {}", jarFileUrl);
             return new JarFile(jarFileUrl);
         }
     }
@@ -504,7 +504,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
         if (!dir.isDirectory()) {
             throw new IllegalArgumentException("The file '" + dir + "' is not a directory");
         }
-        logger.info("Scanning directory: {}", dir);
+        logger.debug("Scanning directory: {}", dir);
 
         final File[] classFiles = dir.listFiles(new FilenameFilter() {
             @Override
@@ -533,7 +533,7 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
             });
             if (subDirectories != null) {
                 if (logger.isInfoEnabled() && subDirectories.length > 0) {
-                    logger.info("Recursively scanning " + subDirectories.length + " subdirectories");
+                    logger.trace("Recursively scanning " + subDirectories.length + " subdirectories");
                 }
                 for (File subDir : subDirectories) {
                     scanDirectory(subDir, true, classLoader, strictClassLoader);
@@ -579,25 +579,25 @@ public final class ClasspathScanDescriptorProvider extends AbstractDescriptorPro
             if (visitor.isAnalyzer()) {
                 @SuppressWarnings("unchecked")
                 Class<? extends Analyzer<?>> analyzerClass = (Class<? extends Analyzer<?>>) beanClass;
-                logger.info("Adding analyzer class: {}", beanClass);
+                logger.debug("Adding analyzer class: {}", beanClass);
                 addAnalyzerClass(analyzerClass);
             }
             if (visitor.isTransformer()) {
                 @SuppressWarnings("unchecked")
                 Class<? extends Transformer> transformerClass = (Class<? extends Transformer>) beanClass;
-                logger.info("Adding transformer class: {}", beanClass);
+                logger.debug("Adding transformer class: {}", beanClass);
                 addTransformerClass(transformerClass);
             }
             if (visitor.isFilter()) {
                 @SuppressWarnings("unchecked")
                 Class<? extends Filter<? extends Enum<?>>> filterClass = (Class<? extends Filter<?>>) beanClass;
-                logger.info("Adding filter class: {}", beanClass);
+                logger.debug("Adding filter class: {}", beanClass);
                 addFilterClass(filterClass);
             }
             if (visitor.isRenderer()) {
                 @SuppressWarnings("unchecked")
                 Class<? extends Renderer<?, ?>> rendererClass = (Class<? extends Renderer<?, ?>>) beanClass;
-                logger.info("Adding renderer class: {}", beanClass);
+                logger.debug("Adding renderer class: {}", beanClass);
                 addRendererClass(rendererClass);
             }
         } finally {

--- a/engine/core/src/main/java/org/datacleaner/lifecycle/LifeCycleHelper.java
+++ b/engine/core/src/main/java/org/datacleaner/lifecycle/LifeCycleHelper.java
@@ -48,7 +48,7 @@ public final class LifeCycleHelper {
     private static final Logger logger = LoggerFactory.getLogger(LifeCycleHelper.class);
 
     private final InjectionManager _injectionManager;
-    private boolean _includeNonDistributedTasks;
+    private final boolean _includeNonDistributedTasks;
 
     /**
      * @param injectionManager

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
@@ -86,8 +86,6 @@ public class SparkAnalysisRunner implements AnalysisRunner {
 
     @Override
     public AnalysisResultFuture run(AnalysisJob job) {
-        assert job == _sparkJobContext.getAnalysisJob();
-
         final AnalysisJob analysisJob = _sparkJobContext.getAnalysisJob();
         final Datastore datastore = analysisJob.getDatastore();
 

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -121,11 +121,20 @@ public class SparkJobContext implements Serializable {
             });
             _analysisJobBuilder = jobBuilder;
         }
-        interceptJobBuilder(_analysisJobBuilder, new AtomicInteger(0));
+        applyComponentIndexForKeyLookups(_analysisJobBuilder, new AtomicInteger(0));
         return _analysisJobBuilder;
     }
 
-    private void interceptJobBuilder(AnalysisJobBuilder analysisJobBuilder, AtomicInteger currentComponentIndex) {
+    /**
+     * Appliesc compopnent indices via the component metadata to enable proper
+     * functioning of the {@link #getComponentByKey(String)} and
+     * {@link #getComponentKey(ComponentJob)} methods.
+     * 
+     * @param analysisJobBuilder
+     * @param currentComponentIndex
+     */
+    private void applyComponentIndexForKeyLookups(AnalysisJobBuilder analysisJobBuilder,
+            AtomicInteger currentComponentIndex) {
         final Collection<ComponentBuilder> componentBuilders = analysisJobBuilder.getComponentBuilders();
         for (ComponentBuilder componentBuilder : componentBuilders) {
             componentBuilder.setMetadataProperty(METADATA_PROPERTY_COMPONENT_INDEX,
@@ -134,7 +143,7 @@ public class SparkJobContext implements Serializable {
 
         final List<AnalysisJobBuilder> childJobBuilders = analysisJobBuilder.getConsumedOutputDataStreamsJobBuilders();
         for (AnalysisJobBuilder childJobBuilder : childJobBuilders) {
-            interceptJobBuilder(childJobBuilder, currentComponentIndex);
+            applyComponentIndexForKeyLookups(childJobBuilder, currentComponentIndex);
         }
     }
 

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/AnalyzerResultReduceFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/AnalyzerResultReduceFunction.java
@@ -51,9 +51,9 @@ public final class AnalyzerResultReduceFunction implements
 
         assert namedAnalyzerResult1.getName().equals(namedAnalyzerResult2.getName());
 
-        String key = namedAnalyzerResult1.getName();
+        final String key = namedAnalyzerResult1.getName();
 
-        ComponentJob componentJob = _sparkJobContext.getComponentByKey(key);
+        final ComponentJob componentJob = _sparkJobContext.getComponentByKey(key);
 
         final AnalyzerResult analyzerResult1 = namedAnalyzerResult1.getAnalyzerResult();
         final AnalyzerResult analyzerResult2 = namedAnalyzerResult2.getAnalyzerResult();
@@ -65,11 +65,11 @@ public final class AnalyzerResultReduceFunction implements
             throw new IllegalStateException("The analyzer (" + analyzerResult1 + ") is not distributable!");
         }
 
-        AnalyzerResultReducer<AnalyzerResult> reducer = initializeReducer(resultReducerClass);
-        
-        AnalyzerResult reducedAnalyzerResult = reducer.reduce(Arrays.asList(analyzerResult1, analyzerResult2));
+        final AnalyzerResultReducer<AnalyzerResult> reducer = initializeReducer(resultReducerClass);
 
-        NamedAnalyzerResult reducedTuple = new NamedAnalyzerResult(key, reducedAnalyzerResult);
+        final AnalyzerResult reducedAnalyzerResult = reducer.reduce(Arrays.asList(analyzerResult1, analyzerResult2));
+
+        final NamedAnalyzerResult reducedTuple = new NamedAnalyzerResult(key, reducedAnalyzerResult);
         return reducedTuple;
     }
 
@@ -83,13 +83,14 @@ public final class AnalyzerResultReduceFunction implements
 
         final ComponentDescriptor<? extends AnalyzerResultReducer<?>> reducerDescriptor = Descriptors
                 .ofComponent(resultReducerClass);
-        
+
         @SuppressWarnings("unchecked")
-        AnalyzerResultReducer<AnalyzerResult> reducer = (AnalyzerResultReducer<AnalyzerResult>) reducerDescriptor.newInstance();
-        
+        final AnalyzerResultReducer<AnalyzerResult> reducer = (AnalyzerResultReducer<AnalyzerResult>) reducerDescriptor
+                .newInstance();
+
         lifeCycleHelper.assignProvidedProperties(reducerDescriptor, reducer);
         lifeCycleHelper.initialize(reducerDescriptor, reducer);
-        
+
         return reducer;
     }
 

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
@@ -19,30 +19,60 @@
  */
 package org.datacleaner.spark.functions;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
+import org.apache.metamodel.csv.CsvConfiguration;
+import org.apache.metamodel.util.FileResource;
+import org.apache.metamodel.util.HdfsResource;
+import org.apache.metamodel.util.Resource;
+import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.AnalyzerResultFuture;
 import org.datacleaner.api.HasAnalyzerResult;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.configuration.DataCleanerConfiguration;
+import org.datacleaner.connection.CsvDatastore;
+import org.datacleaner.connection.Datastore;
+import org.datacleaner.connection.JsonDatastore;
+import org.datacleaner.connection.ResourceDatastore;
+import org.datacleaner.connection.UpdateableDatastore;
+import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.AnalysisJob;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.job.runner.ActiveOutputDataStream;
 import org.datacleaner.job.runner.ConsumeRowHandler;
 import org.datacleaner.job.runner.RowProcessingConsumer;
 import org.datacleaner.lifecycle.LifeCycleHelper;
 import org.datacleaner.spark.NamedAnalyzerResult;
+import org.datacleaner.spark.SparkAnalysisRunner;
 import org.datacleaner.spark.SparkJobContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import scala.Tuple2;
 
+/**
+ * The main Spark function which applies the DataCleaner row processing
+ * framework onto RDDs of InputRows.
+ * 
+ * The main vehicle used to do this is the {@link ConsumeRowHandler}.
+ * 
+ * This class implements two interfaces because it has two (quite similar)
+ * styles of usages in the {@link SparkAnalysisRunner}.
+ */
 public final class RowProcessingFunction implements
+        Function2<Integer, Iterator<InputRow>, Iterator<Tuple2<String, NamedAnalyzerResult>>>,
         PairFlatMapFunction<Iterator<InputRow>, String, NamedAnalyzerResult> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RowProcessingFunction.class);
 
     private static final long serialVersionUID = 1L;
     private final SparkJobContext _sparkJobContext;
@@ -52,11 +82,128 @@ public final class RowProcessingFunction implements
     }
 
     @Override
-    public Iterable<Tuple2<String, NamedAnalyzerResult>> call(Iterator<InputRow> inputRowIterator)
-            throws Exception {
-        final DataCleanerConfiguration configuration = _sparkJobContext.getConfiguration();
+    public Iterable<Tuple2<String, NamedAnalyzerResult>> call(Iterator<InputRow> inputRowIterator) throws Exception {
         final AnalysisJob analysisJob = _sparkJobContext.getAnalysisJob();
+        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = executePartition(inputRowIterator,
+                analysisJob);
+        return analyzerResults;
+    }
 
+    @Override
+    public Iterator<Tuple2<String, NamedAnalyzerResult>> call(Integer partitionNumber,
+            Iterator<InputRow> inputRowIterator) throws Exception {
+        final AnalysisJobBuilder jobBuilder = _sparkJobContext.getAnalysisJobBuilder();
+
+        interceptComponentsBeforeBuilding(jobBuilder, partitionNumber.intValue());
+
+        final AnalysisJob analysisJob = jobBuilder.toAnalysisJob();
+
+        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = executePartition(inputRowIterator,
+                analysisJob);
+
+        return analyzerResults.iterator();
+    }
+
+    private void interceptComponentsBeforeBuilding(AnalysisJobBuilder jobBuilder, int partitionNumber) {
+        // update datastores and resource properties to point to node-specific
+        // targets if possible. This way parallel writing to files on HDFS does
+        // not cause any inconsistencies because each node is writing to a
+        // separate file.
+        for (final ComponentBuilder cb : jobBuilder.getComponentBuilders()) {
+            // find any datastore properties that point to HDFS files
+            final Set<ConfiguredPropertyDescriptor> targetDatastoreProperties = cb.getDescriptor()
+                    .getConfiguredPropertiesByType(UpdateableDatastore.class, false);
+            for (final ConfiguredPropertyDescriptor targetDatastoreProperty : targetDatastoreProperties) {
+                final Object datastoreObject = cb.getConfiguredProperty(targetDatastoreProperty);
+                if (datastoreObject instanceof ResourceDatastore) {
+                    final ResourceDatastore resourceDatastore = (ResourceDatastore) datastoreObject;
+                    final Resource resource = resourceDatastore.getResource();
+                    final Resource replacementResource = createReplacementResource(resource, partitionNumber);
+                    if (replacementResource != null) {
+                        final ResourceDatastore replacementDatastore = createReplacementDatastore(cb,
+                                resourceDatastore, replacementResource);
+                        if (replacementDatastore != null) {
+                            cb.setConfiguredProperty(targetDatastoreProperty, replacementDatastore);
+                        }
+                    }
+                }
+            }
+
+            final Set<ConfiguredPropertyDescriptor> resourceProperties = cb.getDescriptor()
+                    .getConfiguredPropertiesByType(Resource.class, false);
+            for (final ConfiguredPropertyDescriptor resourceProperty : resourceProperties) {
+                final Resource resource = (Resource) cb.getConfiguredProperty(resourceProperty);
+                final Resource replacementResource = createReplacementResource(resource, partitionNumber);
+                if (replacementResource != null) {
+                    cb.setConfiguredProperty(resourceProperty, replacementResource);
+                }
+            }
+        }
+
+        // recursively apply this function also on output data stream jobs
+        final List<AnalysisJobBuilder> children = jobBuilder.getConsumedOutputDataStreamsJobBuilders();
+        for (AnalysisJobBuilder childJobBuilder : children) {
+            interceptComponentsBeforeBuilding(childJobBuilder, partitionNumber);
+        }
+    }
+
+    /**
+     * Creates a {@link Resource} replacement to use for configured properties.
+     * 
+     * @param resource
+     * @param partitionNumber
+     * @return a replacement resource, or null if it shouldn't be replaced
+     */
+    private Resource createReplacementResource(final Resource resource, int partitionNumber) {
+        final String formattedPartitionNumber = String.format("%05d", partitionNumber);
+        if (resource instanceof HdfsResource) {
+            final HdfsResource hdfsResource = (HdfsResource) resource;
+            final HdfsResource replacementResource = new HdfsResource(hdfsResource.getQualifiedPath() + "/part-"
+                    + formattedPartitionNumber);
+            return replacementResource;
+        }
+        if (resource instanceof FileResource) {
+            final File file = ((FileResource) resource).getFile();
+            if (file.exists() && file.isFile()) {
+                // a file already exists - we cannot just create a directory then
+                return resource;
+            }
+            if (!file.exists()) {
+                file.mkdirs();
+            }
+            final FileResource fileResource = new FileResource(resource.getQualifiedPath() + "/part-" + formattedPartitionNumber);
+            return fileResource;
+        }
+        return null;
+    }
+
+    /**
+     * Creates a {@link Datastore} replacement to use for configured properties
+     * 
+     * @param cb
+     * @param datastore
+     * @param replacementResource
+     * @return a replacement datastore, or null if it shouldn't be replaced
+     */
+    private ResourceDatastore createReplacementDatastore(ComponentBuilder cb, ResourceDatastore datastore,
+            Resource replacementResource) {
+        final String name = datastore.getName();
+        if (datastore instanceof CsvDatastore) {
+            final CsvConfiguration csvConfiguration = ((CsvDatastore) datastore).getCsvConfiguration();
+            return new CsvDatastore(name, replacementResource, csvConfiguration);
+        }
+        if (datastore instanceof JsonDatastore) {
+            return new JsonDatastore(name, replacementResource, ((JsonDatastore) datastore).getSchemaBuilder());
+        }
+
+        logger.warn("Could not replace datastore '{}' because it is of an unsupported type: ", name, datastore
+                .getClass().getSimpleName());
+        return datastore;
+    }
+
+    private List<Tuple2<String, NamedAnalyzerResult>> executePartition(Iterator<InputRow> inputRowIterator,
+            final AnalysisJob analysisJob) {
+        final DataCleanerConfiguration configuration = _sparkJobContext.getConfiguration();
         // set up processing stream (this also initializes the components)
         final ConsumeRowHandler consumeRowHandler;
         {
@@ -73,17 +220,18 @@ public final class RowProcessingFunction implements
         }
 
         // collect results
-        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = getAnalyzerResults(consumeRowHandler.getConsumers());
+        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = getAnalyzerResults(consumeRowHandler
+                .getConsumers());
 
         // await any future results
-        for (ListIterator<Tuple2<String, NamedAnalyzerResult>> it = analyzerResults.listIterator(); it
-                .hasNext();) {
+        for (ListIterator<Tuple2<String, NamedAnalyzerResult>> it = analyzerResults.listIterator(); it.hasNext();) {
             final Tuple2<String, NamedAnalyzerResult> tuple = it.next();
             final NamedAnalyzerResult namedAnalyzerResult = tuple._2;
             final AnalyzerResult analyzerResult = namedAnalyzerResult.getAnalyzerResult();
             if (analyzerResult instanceof AnalyzerResultFuture) {
                 final AnalyzerResult awaitedResult = ((AnalyzerResultFuture<?>) analyzerResult).get();
-                final NamedAnalyzerResult awaitedResultTuple = new NamedAnalyzerResult(namedAnalyzerResult.getName(), awaitedResult);
+                final NamedAnalyzerResult awaitedResultTuple = new NamedAnalyzerResult(namedAnalyzerResult.getName(),
+                        awaitedResult);
                 it.set(new Tuple2<>(tuple._1, awaitedResultTuple));
             }
         }
@@ -93,26 +241,26 @@ public final class RowProcessingFunction implements
         for (RowProcessingConsumer consumer : consumeRowHandler.getConsumers()) {
             lifeCycleHelper.close(consumer.getComponentJob().getDescriptor(), consumer.getComponent(), true);
         }
-
         return analyzerResults;
     }
 
-    private List<Tuple2<String, NamedAnalyzerResult>> getAnalyzerResults(Collection<RowProcessingConsumer> rowProcessingConsumers) {
-        List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = new ArrayList<>();
-        
+    private List<Tuple2<String, NamedAnalyzerResult>> getAnalyzerResults(
+            Collection<RowProcessingConsumer> rowProcessingConsumers) {
+        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = new ArrayList<>();
+
         for (RowProcessingConsumer consumer : rowProcessingConsumers) {
             if (consumer.isResultProducer()) {
                 final HasAnalyzerResult<?> resultProducer = (HasAnalyzerResult<?>) consumer.getComponent();
                 final AnalyzerResult analyzerResult = resultProducer.getResult();
                 final String key = _sparkJobContext.getComponentKey(consumer.getComponentJob());
                 final NamedAnalyzerResult namedAnalyzerResult = new NamedAnalyzerResult(key, analyzerResult);
-                final Tuple2<String, NamedAnalyzerResult> tuple = new Tuple2<>(key,
-                        namedAnalyzerResult);
+                final Tuple2<String, NamedAnalyzerResult> tuple = new Tuple2<>(key, namedAnalyzerResult);
                 analyzerResults.add(tuple);
             }
-            
+
             for (ActiveOutputDataStream activeOutputDataStream : consumer.getActiveOutputDataStreams()) {
-                List<RowProcessingConsumer> outputDataStreamConsumers = activeOutputDataStream.getPublisher().getConsumers();
+                List<RowProcessingConsumer> outputDataStreamConsumers = activeOutputDataStream.getPublisher()
+                        .getConsumers();
                 List<Tuple2<String, NamedAnalyzerResult>> outputDataStreamsAnalyzerResults = getAnalyzerResults(outputDataStreamConsumers);
                 analyzerResults.addAll(outputDataStreamsAnalyzerResults);
             }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
@@ -44,6 +44,7 @@ import org.datacleaner.connection.JsonDatastore;
 import org.datacleaner.connection.ResourceDatastore;
 import org.datacleaner.connection.UpdateableDatastore;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
+import org.datacleaner.extension.output.CreateCsvFileAnalyzer;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
@@ -128,7 +129,7 @@ public final class RowProcessingFunction implements
                     }
                 }
             }
-
+            
             final Set<ConfiguredPropertyDescriptor> resourceProperties = cb.getDescriptor()
                     .getConfiguredPropertiesByType(Resource.class, false);
             for (final ConfiguredPropertyDescriptor resourceProperty : resourceProperties) {
@@ -136,6 +137,14 @@ public final class RowProcessingFunction implements
                 final Resource replacementResource = createReplacementResource(resource, partitionNumber);
                 if (replacementResource != null) {
                     cb.setConfiguredProperty(resourceProperty, replacementResource);
+                }
+            }
+            
+            // special handlings of specific component types are handled here
+            if (cb.getComponentInstance() instanceof CreateCsvFileAnalyzer) {
+                if (partitionNumber > 0) {
+                    // ensure header is only created once
+                    cb.setConfiguredProperty(CreateCsvFileAnalyzer.PROPERTY_INCLUDE_HEADER, false);
                 }
             }
         }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/TuplesToTuplesFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/TuplesToTuplesFunction.java
@@ -17,36 +17,33 @@
  * 51 Franklin Street, Fifth Floor
  * Boston, MA  02110-1301  USA
  */
-package org.datacleaner.spark;
+package org.datacleaner.spark.functions;
 
-import java.io.Serializable;
+import java.util.Iterator;
 
-import org.datacleaner.api.AnalyzerResult;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
 
-public class NamedAnalyzerResult implements Serializable {
+import scala.Tuple2;
+
+/**
+ * A utility {@link PairFlatMapFunction} for conversion between a
+ * {@link JavaRDD} of {@link Tuple2} into a {@link JavaPairRDD} of that same
+ * tuple type.
+ */
+public class TuplesToTuplesFunction<K, V> implements PairFlatMapFunction<Iterator<Tuple2<K, V>>, K, V> {
 
     private static final long serialVersionUID = 1L;
 
-    private final String _name;
-    private final AnalyzerResult _analyzerResult;
-    
-    public NamedAnalyzerResult(final String name, final AnalyzerResult analyzerResult) {
-        if (name == null) {
-            throw new IllegalArgumentException("NamedAnalyzerResult name cannot be null");
-        }
-        if (analyzerResult == null) {
-            throw new IllegalArgumentException("NamedAnalyzerResult result cannot be null");
-        }
-        _name = name;
-        _analyzerResult = analyzerResult;
+    @Override
+    public Iterable<Tuple2<K, V>> call(final Iterator<Tuple2<K, V>> iterator) throws Exception {
+        return new Iterable<Tuple2<K, V>>() {
+            @Override
+            public Iterator<Tuple2<K, V>> iterator() {
+                return iterator;
+            }
+        };
     }
-    
-    public String getName() {
-        return _name;
-    }
-    
-    public AnalyzerResult getAnalyzerResult() {
-        return _analyzerResult;
-    }
-    
+
 }

--- a/engine/env/spark/src/test/resources/write-job.analysis.xml
+++ b/engine/env/spark/src/test/resources/write-job.analysis.xml
@@ -13,7 +13,7 @@
 		 <analyzer>
             <descriptor ref="Create CSV file"/>
             <properties>
-                <property name="File" value="target/out.csv"/>
+                <property name="File" value="target/write-job.csv"/>
                 <property name="Separator char" value="&amp;#44;"/>
                 <property name="Quote char" value="&amp;quot;"/>
                 <property name="Escape char" value="\"/>

--- a/engine/env/spark/src/test/resources/write-job.analysis.xml
+++ b/engine/env/spark/src/test/resources/write-job.analysis.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<source>
+		<data-context ref="person_names" />
+		<columns>
+			<column id="col_country" path="country" />
+			<column id="col_company" path="company" />
+		</columns>
+	</source>
+
+	<analysis>
+		 <analyzer>
+            <descriptor ref="Create CSV file"/>
+            <properties>
+                <property name="File" value="target/out.csv"/>
+                <property name="Separator char" value="&amp;#44;"/>
+                <property name="Quote char" value="&amp;quot;"/>
+                <property name="Escape char" value="\"/>
+                <property name="Include header" value="true"/>
+                <property name="Encoding" value="UTF-8"/>
+                <property name="Fields" value="[COUNTRY,CUSTOMERNUMBER]"/>
+                <property name="Overwrite file if exists" value="true"/>
+            </properties>
+            <input ref="col_country" name="Columns"/>
+            <input ref="col_company" name="Columns"/>
+        </analyzer>
+	</analysis>
+
+</job>


### PR DESCRIPTION
Fixes #862, but with a few remarks.

 * To make this work I had to do some tricks in the spark module which makes it aware of CreateCsvFileAnalyzer. I would prefer that to have that done in a different manner where the component can do all the work and the spark module just makes available some API for the component to figure out all the details. See #873 for more details. Specifically two things are now managed in Spark which should rather be managed by the component:
  * Creation of part-files instead of a single file.
  * Writing of CSV header line
 * Furthermore I would like to raise the need for a better "is distributable" API than just the ```@Distributable``` annotation. In the case of the "Create CSV file" analyzer the distributable flag is dependent on configuration, specifically whether or not output file sorting is needed. We have some assumptions here at the moment. See #874 for more details.