### PR TITLE
Bug #865 encoded password with prefix

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
@@ -167,8 +167,7 @@ public class SecurityUtils {
     public static String decodePasswordWithPrefix(String encodedPasswordWithPrefix) {
         if (hasPrefix(encodedPasswordWithPrefix)) {
             return decodePassword(encodedPasswordWithPrefix.substring(PREFIX.length()));
-        }
-        else {
+        } else {
             return encodedPasswordWithPrefix;
         }
     }

--- a/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SecurityUtils.java
@@ -165,11 +165,12 @@ public class SecurityUtils {
      * @return a String containing the decoded password
      */
     public static String decodePasswordWithPrefix(String encodedPasswordWithPrefix) {
-        String encodedPasswordWithoutPrefix = hasPrefix(encodedPasswordWithPrefix) ?
-                encodedPasswordWithPrefix.substring(PREFIX.length()) :
-                encodedPasswordWithPrefix;
-
-        return decodePassword(encodedPasswordWithoutPrefix);
+        if (hasPrefix(encodedPasswordWithPrefix)) {
+            return decodePassword(encodedPasswordWithPrefix.substring(PREFIX.length()));
+        }
+        else {
+            return encodedPasswordWithPrefix;
+        }
     }
 
     public static boolean hasPrefix(String password) {

--- a/engine/core/src/test/java/org/datacleaner/util/SecurityUtilsTest.java
+++ b/engine/core/src/test/java/org/datacleaner/util/SecurityUtilsTest.java
@@ -58,7 +58,7 @@ public class SecurityUtilsTest extends TestCase {
         String decoded = SecurityUtils.decodePasswordWithPrefix(encodedWithPrefix);
         assertEquals(PLAIN_TEXT_VALUE, decoded);
 
-        decoded = SecurityUtils.decodePasswordWithPrefix(ENCODED_VALUE);
+        decoded = SecurityUtils.decodePasswordWithPrefix(PLAIN_TEXT_VALUE);
         assertEquals(PLAIN_TEXT_VALUE, decoded);
     }
 }


### PR DESCRIPTION
Change of a password reading behavior (from conf.xml).  Encoded value with a prefix and a plain text value are loaded correctly. Encoded value without a prefix is incorrect. 