### PR TITLE
Spark execution properties

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
@@ -116,6 +116,9 @@ public class CliArguments {
     @Option(name = "-job", aliases = { "--job-file" }, metaVar = "PATH", usage = "Path to an analysis job XML file to execute")
     private String jobFile;
 
+    @Option(name = "-properties", aliases = { "--properties-file" }, metaVar = "PATH", usage = "Path to a custom properties file")
+    private String propertiesFile;
+
     @Option(name = "-list", usage = "Used to print a list of various elements available in the configuration")
     private CliListType listType;
 
@@ -182,6 +185,10 @@ public class CliArguments {
 
     public boolean isVersionMode() {
         return versionMode;
+    }
+    
+    public String getPropertiesFile() {
+        return propertiesFile;
     }
 
     public CliOutputType getOutputType() {

--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliRunner.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliRunner.java
@@ -34,7 +34,6 @@ import java.util.Set;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.VFS;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
@@ -337,12 +336,11 @@ public final class CliRunner implements Closeable {
         final JaxbJobReader jobReader = new JaxbJobReader(configuration);
 
         final String jobFilePath = _arguments.getJobFile();
-        final FileObject jobFile = VFS.getManager().resolveFile(jobFilePath);
+        final Resource jobResource = resolveResource(jobFilePath);
         final Map<String, String> variableOverrides = _arguments.getVariableOverrides();
 
-        final InputStream inputStream = jobFile.getContent().getInputStream();
-
         final AnalysisJobBuilder analysisJobBuilder;
+        final InputStream inputStream = jobResource.read();
         try {
             analysisJobBuilder = jobReader.create(inputStream, variableOverrides);
         } finally {

--- a/desktop/ui/src/test/java/org/datacleaner/cli/MainTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/cli/MainTest.java
@@ -82,7 +82,7 @@ public class MainTest extends TestCase {
 
         String[] lines = out1.split("\n");
 
-        assertEquals(11, lines.length);
+        assertEquals(12, lines.length);
 
         assertEquals(
                 "-conf (-configuration, --configuration-file) PATH          : Path to an XML file describing the configuration of",
@@ -105,12 +105,13 @@ public class MainTest extends TestCase {
         assertEquals(
                 "-ot (--output-type) [TEXT | HTML | SERIALIZED]             : How to represent the result of the job",
                 lines[8].trim());
+        assertEquals("-properties (--properties-file) PATH                       : Path to a custom properties file",lines[9].trim());
         assertEquals(
                 "-s (-schema, --schema-name) VAL                            : Name of schema when printing a list of tables or columns",
-                lines[9].trim());
+                lines[10].trim());
         assertEquals(
                 "-t (-table, --table-name) VAL                              : Name of table when printing a list of columns",
-                lines[10].trim());
+                lines[11].trim());
 
         // again without the -usage flag
         _stringWriter = new StringWriter();

--- a/engine/core/src/main/java/org/datacleaner/configuration/DefaultConfigurationReaderInterceptor.java
+++ b/engine/core/src/main/java/org/datacleaner/configuration/DefaultConfigurationReaderInterceptor.java
@@ -20,20 +20,15 @@
 package org.datacleaner.configuration;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
 
 import org.apache.metamodel.util.FileHelper;
-import org.apache.metamodel.util.Func;
 import org.apache.metamodel.util.Resource;
 import org.datacleaner.util.FileResolver;
+import org.datacleaner.util.InputStreamToPropertiesMapFunc;
 import org.datacleaner.util.convert.ClasspathResourceTypeHandler;
 import org.datacleaner.util.convert.FileResourceTypeHandler;
 import org.datacleaner.util.convert.HdfsResourceTypeHandler;
@@ -41,8 +36,6 @@ import org.datacleaner.util.convert.ResourceConverter;
 import org.datacleaner.util.convert.ResourceConverter.ResourceTypeHandler;
 import org.datacleaner.util.convert.UrlResourceTypeHandler;
 import org.datacleaner.util.convert.VfsResourceTypeHandler;
-
-import com.google.common.collect.Maps;
 
 /**
  * Defines a default implementation of the
@@ -69,24 +62,7 @@ public class DefaultConfigurationReaderInterceptor implements ConfigurationReade
         if (propertiesResource == null || !propertiesResource.isExists()) {
             _propertyOverrides = Collections.emptyMap();
         } else {
-            _propertyOverrides = propertiesResource.read(new Func<InputStream, Map<String, String>>() {
-                @Override
-                public Map<String, String> eval(InputStream in) {
-                    final Properties properties = new Properties();
-                    try {
-                        properties.load(in);
-                    } catch (IOException ex) {
-                        throw new RuntimeException(ex);
-                    }
-                    final HashMap<String, String> map = Maps.newHashMapWithExpectedSize(properties.size());
-                    for (Entry<?,?> e : properties.entrySet()) {
-                        final String key = (String) e.getKey();
-                        final String value = (String) e.getValue();
-                        map.put(key, value);
-                    }
-                    return map;
-                }
-            });
+            _propertyOverrides = propertiesResource.read(new InputStreamToPropertiesMapFunc());
         }
     }
 

--- a/engine/core/src/main/java/org/datacleaner/util/InputStreamToPropertiesMapFunc.java
+++ b/engine/core/src/main/java/org/datacleaner/util/InputStreamToPropertiesMapFunc.java
@@ -1,0 +1,56 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Map.Entry;
+
+import org.apache.metamodel.util.Func;
+
+import com.google.common.collect.Maps;
+
+/**
+ * A utility function for reading properties as a {@link Map} of Strings from an
+ * {@link InputStream}.
+ */
+public class InputStreamToPropertiesMapFunc implements Func<InputStream, Map<String, String>> {
+
+    @Override
+    public Map<String, String> eval(InputStream in) {
+        final Properties properties = new Properties();
+        try {
+            properties.load(in);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        final HashMap<String, String> map = Maps.newHashMapWithExpectedSize(properties.size());
+        for (Entry<?, ?> e : properties.entrySet()) {
+            final String key = (String) e.getKey();
+            final String value = (String) e.getValue();
+            map.put(key, value);
+        }
+        return map;
+    }
+
+}

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
@@ -29,17 +29,24 @@ public class Main {
     public static void main(String[] args) {
         if (args.length < 2) {
             throw new IllegalArgumentException("The number of arguments is incorrect. Usage:\n"
-                    + " <path_to_configuration_xml_file> <path_to_analysis_job_xml_file>\n" + "Got: "
+                    + " <configuration file (conf.xml) path> <job file (.analysis.xml) path> [properties file path]\n" + "Got: "
                     + Arrays.toString(args));
         }
 
         final SparkConf conf = new SparkConf().setAppName("DataCleaner-spark");
         final JavaSparkContext sparkContext = new JavaSparkContext(conf);
-        
+
         final String confXmlPath = args[0];
         final String analysisJobXmlPath = args[1];
 
-        final SparkJobContext sparkJobContext = new SparkJobContext(sparkContext, confXmlPath, analysisJobXmlPath);
+        final String propertiesPath; 
+        if (args.length > 2) {
+            propertiesPath = args[2];
+        } else {
+            propertiesPath = null;
+        }
+
+        final SparkJobContext sparkJobContext = new SparkJobContext(sparkContext, confXmlPath, analysisJobXmlPath, propertiesPath);
 
         final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext);
         try {

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/CsvParserFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/CsvParserFunction.java
@@ -34,8 +34,16 @@ public final class CsvParserFunction implements Function<String, Object[]> {
         if (csvConfiguration.isMultilineValues()) {
             throw new IllegalStateException("Multiline CSV files are not supported");
         }
-        if (!csvConfiguration.getEncoding().equalsIgnoreCase("UTF-8")) {
-            throw new IllegalStateException("CSV files must be UTF-8 encoded");
+
+        final String encoding = csvConfiguration.getEncoding();
+        switch (encoding.toUpperCase()) {
+        case "UTF-8":
+        case "UTF8":
+            // supported
+            break;
+        default:
+            throw new IllegalStateException("Unsupported encoding: '" + encoding
+                    + "'. CSV files on Hadoop must be UTF-8 encoded.");
         }
 
         _csvConfiguration = csvConfiguration;

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -190,11 +190,11 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
         this(null);
     }
 
-    public JaxbConfigurationReader(ConfigurationReaderInterceptor configurationReaderCallback) {
-        if (configurationReaderCallback == null) {
-            configurationReaderCallback = new DefaultConfigurationReaderInterceptor();
+    public JaxbConfigurationReader(ConfigurationReaderInterceptor interceptor) {
+        if (interceptor == null) {
+            interceptor = new DefaultConfigurationReaderInterceptor();
         }
-        _interceptor = configurationReaderCallback;
+        _interceptor = interceptor;
         _variablePathBuilder = new ArrayDeque<String>(4);
         try {
             _jaxbContext = JAXBContext.newInstance(ObjectFactory.class.getPackage().getName(),

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -380,9 +380,12 @@ public class JaxbJobReader implements JobReader<InputStream> {
             for (Entry<String, String> entry : entrySet) {
                 final String key = entry.getKey();
                 final String value = entry.getValue();
-                String originalValue = variables.put(key, value);
-                logger.info("Overriding variable: {}={} (original value was {})", new Object[] { key, value,
-                        originalValue });
+                final String originalValue = variables.put(key, value);
+                if (originalValue == null) {
+                    logger.debug("Setting variable: {}={}", key, value);
+                } else {
+                    logger.info("Overriding variable: {}={} (original value was {})", key, value, originalValue);
+                }
             }
         }
 
@@ -450,7 +453,7 @@ public class JaxbJobReader implements JobReader<InputStream> {
                 if (variables.size() > 0) {
                     final MutableAnalysisJobMetadata mutableAnalysisJobMetadata = new MutableAnalysisJobMetadata();
                     mutableAnalysisJobMetadata.getVariables().putAll(variables);
-                    analysisJobBuilder.setAnalysisJobMetadata(mutableAnalysisJobMetadata);    
+                    analysisJobBuilder.setAnalysisJobMetadata(mutableAnalysisJobMetadata);
                 }
             }
 
@@ -860,7 +863,7 @@ public class JaxbJobReader implements JobReader<InputStream> {
             ComponentBuilder componentBuilder) {
         // build a map of inputs first so that we can set the
         // input in one go
-        final ListMultimap<ConfiguredPropertyDescriptor, InputColumn<?>> inputMap = ArrayListMultimap.create(); 
+        final ListMultimap<ConfiguredPropertyDescriptor, InputColumn<?>> inputMap = ArrayListMultimap.create();
 
         for (InputType inputType : input) {
             String name = inputType.getName();
@@ -942,8 +945,9 @@ public class JaxbJobReader implements JobReader<InputStream> {
                     if (stringValue == null) {
                         throw new ComponentConfigurationException("No such variable: " + variableRef);
                     }
-                    
-                    builder.getMetadataProperties().put(DATACLEANER_JAXB_VARIABLE_PREFIX + configuredProperty.getName(), variableRef);
+
+                    builder.getMetadataProperties().put(
+                            DATACLEANER_JAXB_VARIABLE_PREFIX + configuredProperty.getName(), variableRef);
                 }
 
                 final Class<? extends Converter<?>> customConverter = configuredProperty.getCustomConverter();


### PR DESCRIPTION
Added the ability to specify execution properties and system properties for the job and configuration file loading, when running on Spark.

Since the command line length when running Spark jobs is important to keep low (we have seen issues because of long filenames already) I decided to include this using a properties file instead of specifying all properties on the command line directly.