### PR TITLE
Fixed javadoc linter errors (not warnings - but enough to make it pass)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
   - oraclejdk8
 
 after_success:
-  - mvn test
+  - mvn test javadoc:javadoc

--- a/api/src/main/java/org/datacleaner/api/OutputDataStream.java
+++ b/api/src/main/java/org/datacleaner/api/OutputDataStream.java
@@ -43,7 +43,7 @@ public interface OutputDataStream extends HasName, Serializable {
 
     /**
      * Gets the logical (or physical) {@link Table} objects that represent the
-     * format of the data that will be made available by the {@link DataStream}
+     * format of the data that will be made available by the data stream.
      * 
      * @return
      */

--- a/desktop/api/src/main/java/org/datacleaner/util/WindowSizePreferences.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WindowSizePreferences.java
@@ -36,8 +36,8 @@ public class WindowSizePreferences {
      * @param userPreferences
      *            represents the settings provided by the user at runtime @{link
      *            UserPreferences}
-     * @param identifier
-     *            represents the name of the class that calls this class
+     * @param windowClass
+     *            the window class that calls this class
      * @param defaultWidth
      *            represents the default width
      * @param defaultHeight


### PR DESCRIPTION
This should hopefully make it possible to release DC when a JDK 8 is installed. Currently that fails due to the javadoc linter errors.