### PR TITLE
Spark CSV write speed fixed by buffering and not needlessly checking isExists()

### DIFF
--- a/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
+++ b/components/writers/src/main/java/org/datacleaner/extension/output/CreateCsvFileAnalyzer.java
@@ -142,7 +142,7 @@ public class CreateCsvFileAnalyzer extends AbstractOutputWriterAnalyzer implemen
 
     @Validate
     public void validate() {
-        if (file.isExists() && !overwriteFileIfExists) {
+        if (!overwriteFileIfExists && file.isExists()) {
             throw new IllegalStateException(
                     "The file already exists. Please configure the job to overwrite the existing file.");
         }

--- a/engine/core/src/main/java/org/datacleaner/output/csv/CsvOutputWriter.java
+++ b/engine/core/src/main/java/org/datacleaner/output/csv/CsvOutputWriter.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.output.csv;
 
+import java.io.BufferedOutputStream;
 import java.io.OutputStream;
 
 import org.apache.metamodel.csv.CsvConfiguration;
@@ -49,8 +50,11 @@ final class CsvOutputWriter implements OutputWriter {
                     final String headerLine = csvWriter.buildLine(columnNames);
                     final byte[] bytes = headerLine.getBytes(csvConfiguration.getEncoding());
                     outputStream.write(bytes);
+                    outputStream.flush();
                 }
-                return outputStream;
+                // 512 kb buffer
+                final int bufferSize = 1024 * 512;
+                return new BufferedOutputStream(outputStream, bufferSize);
             }
         };
     }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
@@ -20,12 +20,9 @@
 package org.datacleaner.spark;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.util.Resource;
-import org.apache.spark.Accumulator;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -121,15 +118,7 @@ public class SparkAnalysisRunner implements AnalysisRunner {
         for (Tuple2<String, AnalyzerResult> analyzerResultTuple : results) {
             final String key = analyzerResultTuple._1;
             final AnalyzerResult result = analyzerResultTuple._2;
-            logger.info("AnalyzerResult: " + key + "->" + result);
-        }
-
-        // log accumulators
-        final Map<String, Accumulator<Integer>> accumulators = _sparkJobContext.getAccumulators();
-        for (Entry<String, Accumulator<Integer>> entry : accumulators.entrySet()) {
-            final String name = entry.getKey();
-            final Accumulator<Integer> accumulator = entry.getValue();
-            logger.info("Accumulator: {} -> {}", name, accumulator.value());
+            logger.info("AnalyzerResult (" + key + "):\n\n" + result + "\n");
         }
 
         return new SparkAnalysisResultFuture(results);


### PR DESCRIPTION
Fixes #902

A few optimizations

 * Added buffering to the output stream (this did the trick)
 * Avoiding needless call to HdfsResource.isExists() - this might save some time because it happens again and again.
 * Avoiding re-reading the files on HDFS again and again by saving them as Strings in SparkJobContext instead. This means only the driver program needs to read them.