### PR TITLE
Feature/914 save job result on hdfs

### DIFF
--- a/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
@@ -20,6 +20,7 @@
 package org.datacleaner.spark;
 
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
@@ -96,14 +97,17 @@ public class Main {
     }
 
     private static String getResultJobFilePath(final JavaSparkContext sparkContext,
-            final SparkJobContext sparkJobContext) {
+            final SparkJobContext sparkJobContext)  {
         String resultPath = sparkJobContext.getResultPath();
         final Configuration hadoopConfiguration = sparkContext.hadoopConfiguration();
         final String fileSystemPrefix = hadoopConfiguration.get("fs.defaultFS");
         if (resultPath == null) {
             resultPath = fileSystemPrefix + DEFAULT_RESULT_PATH;
-        } else {
-            resultPath = fileSystemPrefix + resultPath;
+        } else { 
+            final URI uri = URI.create(resultPath);
+            if (!uri.isAbsolute()){
+                resultPath = fileSystemPrefix + resultPath;
+            }
         }
         final String analysisJobXmlName = sparkJobContext.getAnalysisJobName();
         final Date date = new Date();

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisResultFuture.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisResultFuture.java
@@ -103,8 +103,8 @@ public class SparkAnalysisResultFuture extends AbstractAnalysisResult implements
     public Map<ComponentJob, AnalyzerResult> getResultMap() throws AnalysisJobFailedException {
         final Map<ComponentJob, AnalyzerResult> resultMap = new HashMap<>();
         for (Tuple2<String, AnalyzerResult> tuple : _results) {
-            final AnalyzerResult analyzerResult = tuple._2;
             final ComponentJob component = _sparkJobContext.getComponentByKey(tuple._1);
+            final AnalyzerResult analyzerResult = tuple._2;
             resultMap.put(component, analyzerResult);
         }
         return resultMap;

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisResultFuture.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisResultFuture.java
@@ -22,6 +22,7 @@ package org.datacleaner.spark;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -39,10 +40,12 @@ public class SparkAnalysisResultFuture extends AbstractAnalysisResult implements
 
     private final Date _creationDate;
     private final List<Tuple2<String, AnalyzerResult>> _results;
+    private final SparkJobContext _sparkJobContext;
 
-    public SparkAnalysisResultFuture(List<Tuple2<String, AnalyzerResult>> results) {
+    public SparkAnalysisResultFuture(List<Tuple2<String, AnalyzerResult>> results, SparkJobContext sparkJobContext) {
         _creationDate = new Date();
         _results = results;
+        _sparkJobContext = sparkJobContext;
     }
 
     @Override
@@ -98,8 +101,13 @@ public class SparkAnalysisResultFuture extends AbstractAnalysisResult implements
 
     @Override
     public Map<ComponentJob, AnalyzerResult> getResultMap() throws AnalysisJobFailedException {
-        // TODO: Needs to be implemented, but probably "results" will change anyway
-        throw new UnsupportedOperationException();
+        final Map<ComponentJob, AnalyzerResult> resultMap = new HashMap<>();
+        for (Tuple2<String, AnalyzerResult> tuple : _results) {
+            final AnalyzerResult analyzerResult = tuple._2;
+            final ComponentJob component = _sparkJobContext.getComponentByKey(tuple._1);
+            resultMap.put(component, analyzerResult);
+        }
+        return resultMap;
     }
 
     @Override

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkAnalysisRunner.java
@@ -123,7 +123,7 @@ public class SparkAnalysisRunner implements AnalysisRunner {
             logger.info("AnalyzerResult (" + key + "):\n\n" + result + "\n");
         }
 
-        return new SparkAnalysisResultFuture(results);
+        return new SparkAnalysisResultFuture(results, _sparkJobContext);
     }
 
     private JavaRDD<InputRow> openSourceDatastore(Datastore datastore) {

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -56,6 +56,8 @@ import com.google.common.base.Strings;
  */
 public class SparkJobContext implements Serializable {
 
+    private static String DATA_CLEANER_RESULT_PATH_PROPERTY = "datacleaner.result.hdfs.path";
+    private static String DATA_CLEANER_RESULT_NAME_PROPERTY = "datacleaner.result.hdfs.name";
     public static final String ACCUMULATOR_CONFIGURATION_READS = "DataCleanerConfiguration reads";
     public static final String ACCUMULATOR_JOB_READS = "AnalysisJob reads";
 
@@ -207,5 +209,27 @@ public class SparkJobContext implements Serializable {
         }
 
         return null;
+    }
+
+    public String getResultPath() {
+        if (_customProperties != null) {
+            if (_customProperties.containsKey(DATA_CLEANER_RESULT_PATH_PROPERTY)) {
+                return _customProperties.get(DATA_CLEANER_RESULT_PATH_PROPERTY);
+            }
+        }
+        return null;
+    }
+    
+    public String getResultName() {
+        if (_customProperties != null) {
+            if (_customProperties.containsKey(DATA_CLEANER_RESULT_NAME_PROPERTY)) {
+                return _customProperties.get(DATA_CLEANER_RESULT_NAME_PROPERTY);
+            }
+        }
+        return null;
+    }
+    public String getAnalysisJobXmlName() {
+        final int lastIndexOf = _analysisJobXml.lastIndexOf("/");
+        return  _analysisJobXml.substring(lastIndexOf);
     }
 }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -57,7 +57,6 @@ import com.google.common.base.Strings;
 public class SparkJobContext implements Serializable {
 
     private static String DATA_CLEANER_RESULT_PATH_PROPERTY = "datacleaner.result.hdfs.path";
-    private static String DATA_CLEANER_RESULT_NAME_PROPERTY = "datacleaner.result.hdfs.name";
     public static final String ACCUMULATOR_CONFIGURATION_READS = "DataCleanerConfiguration reads";
     public static final String ACCUMULATOR_JOB_READS = "AnalysisJob reads";
 
@@ -67,6 +66,7 @@ public class SparkJobContext implements Serializable {
 
     private final String _configurationXml;
     private final String _analysisJobXml;
+    private final String _analysisJobXmlPath;
     private final Map<String, String> _customProperties;
 
     // cached/transient state
@@ -83,6 +83,7 @@ public class SparkJobContext implements Serializable {
         _customProperties = readCustomProperties(propertiesPath);
         _configurationXml = readFile(dataCleanerConfigurationPath);
         _analysisJobXml = readFile(analysisJobXmlPath);
+        _analysisJobXmlPath= analysisJobXmlPath;
     }
 
     private String readFile(String path) {
@@ -220,16 +221,10 @@ public class SparkJobContext implements Serializable {
         return null;
     }
     
-    public String getResultName() {
-        if (_customProperties != null) {
-            if (_customProperties.containsKey(DATA_CLEANER_RESULT_NAME_PROPERTY)) {
-                return _customProperties.get(DATA_CLEANER_RESULT_NAME_PROPERTY);
-            }
-        }
-        return null;
-    }
-    public String getAnalysisJobXmlName() {
-        final int lastIndexOf = _analysisJobXml.lastIndexOf("/");
-        return  _analysisJobXml.substring(lastIndexOf);
+    public String getAnalysisJobName() {
+        final int lastIndexOfSlash = _analysisJobXmlPath.lastIndexOf("/");
+        final int lastIndexOfFileExtension = _analysisJobXmlPath.lastIndexOf(".analysis.xml");
+        final String jobName = _analysisJobXmlPath.substring(lastIndexOfSlash+1, lastIndexOfFileExtension);
+        return  jobName;
     }
 }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -67,9 +67,8 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/vanilla-job.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-
+            assertEquals("vanilla-job",sparkJobContext.getAnalysisJobName());
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext);
-
             result = sparkAnalysisRunner.run(job);
             
         } finally {
@@ -94,7 +93,6 @@ public class SparkAnalysisRunnerTest extends TestCase {
         final int upperCaseChars = stringAnalyzerResult.getEntirelyUpperCaseCount(stringAnalyzerResult.getColumns()[0]);
         assertEquals(7, upperCaseChars);
     }
-
     @Test
     public void testWriteDataScenario() throws Exception {
         final String outputPath = "target/write-job.csv";
@@ -113,7 +111,8 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/write-job.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-
+            assertEquals("write-job",sparkJobContext.getAnalysisJobName());
+            
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext,
                     MIN_PARTITIONS_MULTIPLE);
 
@@ -165,6 +164,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/melon-job.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
+            assertEquals("melon-job",sparkJobContext.getAnalysisJobName());
 
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext);
 
@@ -211,6 +211,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/non-dist-melon-job.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
+            assertEquals("non-dist-melon-job",sparkJobContext.getAnalysisJobName());
 
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext,
                     MIN_PARTITIONS_MULTIPLE);
@@ -261,6 +262,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/distributable-value-dist.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
+            assertEquals("distributable-value-dist",sparkJobContext.getAnalysisJobName());
 
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext,
                     MIN_PARTITIONS_MULTIPLE);
@@ -299,6 +301,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/distributable-grouped-value-dist.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
+            assertEquals("distributable-grouped-value-dist",sparkJobContext.getAnalysisJobName());
 
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext,
                     MIN_PARTITIONS_MULTIPLE);
@@ -362,6 +365,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
                     "src/test/resources/conf_local.xml", "src/test/resources/json-job.analysis.xml");
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
+            assertEquals("json-job",sparkJobContext.getAnalysisJobName());
 
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext);
 

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -71,6 +71,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
             final SparkAnalysisRunner sparkAnalysisRunner = new SparkAnalysisRunner(sparkContext, sparkJobContext);
 
             result = sparkAnalysisRunner.run(job);
+            
         } finally {
             sparkContext.close();
         }
@@ -79,6 +80,7 @@ public class SparkAnalysisRunnerTest extends TestCase {
             throw (Exception) result.getErrors().get(0);
         }
 
+        assertEquals(2, result.getResultMap().size());
         final List<AnalyzerResult> results = result.getResults();
         assertEquals(2, results.size());
 


### PR DESCRIPTION
Fixes #914 

- The user has the option to define a path for the result in properties file. The property name is: datacleaner.result.hdfs.path  
- The filename template: jobname-timestamp.analysis.result.dat
- By default the result will be written to hdfs://hostname:port/datacleaner/results/