### PR TITLE
Always show link target component dialog

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
@@ -281,6 +281,9 @@ public class JobGraphLinkPainter {
                 logger.debug("createLink(...) returning false - popup with choices presented to user");
                 return false;
             }
+
+            // When we can't do anything, at least show the dialog.
+            _actions.showConfigurationDialog(componentBuilder);
         }
         logger.debug("createLink(...) returning false - no applicable action");
         return false;


### PR DESCRIPTION
 A user should always see the component dialog when trying to link dialogs, even if there are no columns to map.

Fixes #908 