### PR TITLE
Try to update scope for filters

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainter.java
@@ -48,6 +48,7 @@ import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.util.GraphUtils;
 import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.LabelUtils;
 import org.datacleaner.util.ReflectionUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.slf4j.Logger;
@@ -306,13 +307,9 @@ public class JobGraphLinkPainter {
         if (sourceAnalysisJobBuilder != componentBuilder.getAnalysisJobBuilder()) {
             if (componentBuilder.getInput().length > 0 || componentBuilder.getComponentRequirement() != null) {
                 final String scopeText;
-                if(sourceAnalysisJobBuilder.isRootJobBuilder()){
-                    scopeText = " into the default scope";
-                } else {
-                    scopeText = " into the scope " + sourceAnalysisJobBuilder.getDatastore().getName();
-                }
+                scopeText = LabelUtils.getScopeLabel(sourceAnalysisJobBuilder);
                 final int response = JOptionPane.showConfirmDialog(_graphContext.getVisualizationViewer(),
-                        "This will move " + componentBuilder.getDescriptor().getDisplayName() + scopeText
+                        "This will move " + LabelUtils.getLabel(componentBuilder) + " into the " + scopeText
                                 + ", thereby losing its configured columns and/or requirements", "Change scope?",
                         JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
 

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -427,17 +427,7 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public ComponentBuilder addComponent(ComponentDescriptor<?> descriptor) {
-        final ComponentBuilder builder;
-        if (descriptor instanceof FilterDescriptor) {
-            builder = addFilter((FilterDescriptor<?, ?>) descriptor);
-        } else if (descriptor instanceof TransformerDescriptor) {
-            builder = addTransformer((TransformerDescriptor<?>) descriptor);
-        } else if (descriptor instanceof AnalyzerDescriptor) {
-            builder = addAnalyzer((AnalyzerDescriptor<?>) descriptor);
-        } else {
-            throw new UnsupportedOperationException("Unknown component type: " + descriptor);
-        }
-        return builder;
+        return addComponent(descriptor, null, null, null);
     }
 
     public ComponentBuilder addComponent(ComponentBuilder builder) {
@@ -493,14 +483,17 @@ public final class AnalysisJobBuilder implements Closeable {
      * @return The same builder
      */
     public ComponentBuilder moveComponent(ComponentBuilder builder) {
-        builder.getAnalysisJobBuilder().removeComponent(builder);
+        if(builder.getAnalysisJobBuilder() != this) {
+            builder.getAnalysisJobBuilder().removeComponent(builder);
 
-        // when moving the component to a different scope we need to first reset
-        // the prior input
-        builder.clearInputColumns();
+            // when moving the component to a different scope we need to first reset
+            // the prior input
+            builder.clearInputColumns();
 
-        addComponent(builder);
-        builder.setAnalysisJobBuilder(this);
+            addComponent(builder);
+            builder.setAnalysisJobBuilder(this);
+        }
+
         return builder;
     }
 

--- a/engine/core/src/main/java/org/datacleaner/util/LabelUtils.java
+++ b/engine/core/src/main/java/org/datacleaner/util/LabelUtils.java
@@ -33,6 +33,7 @@ import org.datacleaner.job.AnalyzerJob;
 import org.datacleaner.job.AnyComponentRequirement;
 import org.datacleaner.job.ComponentJob;
 import org.datacleaner.job.ComponentRequirement;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.lifecycle.LifeCycleHelper;
 import org.slf4j.Logger;
@@ -224,5 +225,15 @@ public final class LabelUtils {
         }
 
         return getLabel(value.toString());
+    }
+
+    public static String getScopeLabel(final AnalysisJobBuilder sourceAnalysisJobBuilder) {
+        final String scopeText;
+        if(sourceAnalysisJobBuilder.isRootJobBuilder()){
+            scopeText = "default scope";
+        } else {
+            scopeText = "scope " + sourceAnalysisJobBuilder.getDatastore().getName();
+        }
+        return scopeText;
     }
 }


### PR DESCRIPTION
Filter requirements are now treated like other components, so a component will have its scope changed if a filter from another scope is linked to it.

This also adds a general confirmation for any scope changes that will destroy user configuration, as well as remove a bit of duplication.

Fixes #909