### PR TITLE
Bug/910 cancel jobs disregarded

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
@@ -19,6 +19,8 @@
  */
 package org.datacleaner.util;
 
+import java.util.concurrent.ExecutionException;
+
 import javax.swing.SwingWorker;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
@@ -63,11 +65,25 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
         }
     }
 
-    public void cancelIfRunning() {
-        if (_resultFuture != null) {
-            if (!_resultFuture.isDone()) {
-                _resultFuture.cancel();
+    public void cancelIfRunning() throws Exception {
+        final AnalysisResultFuture resultFuture = getResultFuture();
+        if (resultFuture != null) {
+            if (!resultFuture.isDone()) {
+                resultFuture.cancel();
             }
         }
+    }
+    
+    public AnalysisResultFuture getResultFuture() {
+        if (_resultFuture == null){
+           try {
+            _resultFuture = this.get();
+        } catch (InterruptedException e) {
+          logger.error("Unable to fetch result" + e.getStackTrace());
+        } catch (ExecutionException e) {
+            logger.error("Unable to fetch result" + e.getStackTrace());  
+        } 
+        }
+        return _resultFuture;
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
@@ -19,12 +19,11 @@
  */
 package org.datacleaner.util;
 
-import java.util.concurrent.ExecutionException;
-
 import javax.swing.SwingWorker;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.job.AnalysisJob;
+import org.datacleaner.job.runner.AnalysisJobCancellation;
 import org.datacleaner.job.runner.AnalysisListener;
 import org.datacleaner.job.runner.AnalysisResultFuture;
 import org.datacleaner.job.runner.AnalysisRunner;
@@ -65,26 +64,13 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
     }
 
     public void cancelIfRunning(){
-        final AnalysisResultFuture resultFuture = getResultFuture();
-        if (resultFuture != null) {
-            if (!resultFuture.isDone()) {
-                resultFuture.cancel();
+        if (_resultFuture != null) {
+            if (!_resultFuture.isDone()) {
+                _resultFuture.cancel();
             }
+        }else{ 
+            this.cancel(true);
+            _resultWindow.onUnexpectedError(_job, new AnalysisJobCancellation());
         }
-    }
-
-    public AnalysisResultFuture getResultFuture() {
-        if (_resultFuture == null) {
-            try {
-                _resultFuture = this.get();
-            } catch (InterruptedException e) {
-                logger.error("Unable to fetch result" + e.getStackTrace());
-                return null;
-            } catch (ExecutionException e) {
-                logger.error("Unable to fetch result" + e.getStackTrace());
-                return null;
-            }
-        }
-        return _resultFuture;
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
@@ -45,8 +45,7 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
     private final ResultWindow _resultWindow;
     private AnalysisResultFuture _resultFuture;
 
-    public AnalysisRunnerSwingWorker(DataCleanerConfiguration configuration, AnalysisJob job,
-            ResultWindow resultWindow) {
+    public AnalysisRunnerSwingWorker(DataCleanerConfiguration configuration, AnalysisJob job, ResultWindow resultWindow) {
         final AnalysisListener analysisListener = resultWindow.createAnalysisListener();
         _analysisRunner = new AnalysisRunnerImpl(configuration, analysisListener);
         _job = job;
@@ -73,16 +72,18 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
             }
         }
     }
-    
+
     public AnalysisResultFuture getResultFuture() {
-        if (_resultFuture == null){
-           try {
-            _resultFuture = this.get();
-        } catch (InterruptedException e) {
-          logger.error("Unable to fetch result" + e.getStackTrace());
-        } catch (ExecutionException e) {
-            logger.error("Unable to fetch result" + e.getStackTrace());  
-        } 
+        if (_resultFuture == null) {
+            try {
+                _resultFuture = this.get();
+            } catch (InterruptedException e) {
+                logger.error("Unable to fetch result" + e.getStackTrace());
+                return null;
+            } catch (ExecutionException e) {
+                logger.error("Unable to fetch result" + e.getStackTrace());
+                return null;
+            }
         }
         return _resultFuture;
     }

--- a/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
@@ -64,7 +64,7 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
         }
     }
 
-    public void cancelIfRunning() throws Exception {
+    public void cancelIfRunning(){
         final AnalysisResultFuture resultFuture = getResultFuture();
         if (resultFuture != null) {
             if (!resultFuture.isDone()) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -242,12 +242,8 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             _cancelButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    try {
-                        logger.info("Procedding to cancel the job");
-                        _worker.cancelIfRunning();
-                    } catch (Exception exception) {
-                        WidgetUtils.showErrorMessage("Error while cancelling the job", exception);
-                    }
+                    logger.info("Procedding to cancel the job");
+                    _worker.cancelIfRunning();
                 }
             });
         } else {
@@ -381,11 +377,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
         boolean closing = super.onWindowClosing();
         if (closing) {
             if (_worker != null) {
-                try {
-                    _worker.cancelIfRunning();
-                } catch (Exception e) {
-                    WidgetUtils.showErrorMessage("Error while cancelling the job", e);
-                }
+                _worker.cancelIfRunning();
             }
         }
         return closing;

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -242,7 +242,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             _cancelButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    logger.info("Procedding to cancel the job");
+                    _progressInformationPanel.addUserLog("Proceeding to cancel the job.");
                     _worker.cancelIfRunning();
                 }
             });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -177,8 +177,8 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
         _saveResultsPopupButton.getMenu().add(saveAsFileItem);
 
         JMenuItem exportToHtmlItem = WidgetFactory.createMenuItem("Export to HTML", IconUtils.WEBSITE);
-        exportToHtmlItem
-                .addActionListener(new ExportResultToHtmlActionListener(resultRef, _configuration, _userPreferences));
+        exportToHtmlItem.addActionListener(new ExportResultToHtmlActionListener(resultRef, _configuration,
+                _userPreferences));
         exportToHtmlItem.setBorder(buttonBorder);
         _saveResultsPopupButton.getMenu().add(exportToHtmlItem);
 
@@ -246,7 +246,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
                         logger.info("Procedding to cancel the job");
                         _worker.cancelIfRunning();
                     } catch (Exception exception) {
-                       WidgetUtils.showErrorMessage("Error while cancelling the job", exception);
+                        WidgetUtils.showErrorMessage("Error while cancelling the job", exception);
                     }
                 }
             });
@@ -317,8 +317,8 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             }
 
             final Icon icon = IconUtils.getDescriptorIcon(componentJob.getDescriptor(), IconUtils.ICON_SIZE_TAB);
-            final AnalyzerResultPanel resultPanel = new AnalyzerResultPanel(_rendererFactory, _progressInformationPanel,
-                    componentJob);
+            final AnalyzerResultPanel resultPanel = new AnalyzerResultPanel(_rendererFactory,
+                    _progressInformationPanel, componentJob);
             final Tab<AnalyzerResultPanel> tab = _tabbedPane.addTab(title, icon, resultPanel);
             tab.setTooltip(LabelUtils.getLabel(componentJob, false, true, true));
 
@@ -550,8 +550,8 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
                         final String startingProcessingString = "Starting processing of " + table.getName();
 
                         if (expectedRows != -1) {
-                            _progressInformationPanel
-                                    .addUserLog(startingProcessingString + " (approx. " + expectedRows + " rows)");
+                            _progressInformationPanel.addUserLog(startingProcessingString + " (approx. " + expectedRows
+                                    + " rows)");
                         } else {
                             _progressInformationPanel.addUserLog(startingProcessingString);
                         }
@@ -571,8 +571,8 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             public void rowProcessingSuccess(AnalysisJob job, final RowProcessingMetrics metrics) {
                 logger.info("rowProcessingSuccess: {}", job.getDatastore().getName());
                 _progressInformationPanel.updateProgressFinished(metrics.getTable());
-                _progressInformationPanel.addUserLog(
-                        "Processing of " + metrics.getTable().getName() + " finished. Generating results...");
+                _progressInformationPanel.addUserLog("Processing of " + metrics.getTable().getName()
+                        + " finished. Generating results...");
             }
 
             @Override
@@ -581,8 +581,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             }
 
             @Override
-            public void componentSuccess(AnalysisJob job, final ComponentJob componentJob,
-                    final AnalyzerResult result) {
+            public void componentSuccess(AnalysisJob job, final ComponentJob componentJob, final AnalyzerResult result) {
                 final StringBuilder sb = new StringBuilder();
                 sb.append("Component ");
                 sb.append(LabelUtils.getLabel(componentJob));
@@ -603,8 +602,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             }
 
             @Override
-            public void errorInComponent(AnalysisJob job, ComponentJob componentJob, InputRow row,
-                    Throwable throwable) {
+            public void errorInComponent(AnalysisJob job, ComponentJob componentJob, InputRow row, Throwable throwable) {
                 _progressInformationPanel.addUserLog(
                         "An error occurred in the component: " + LabelUtils.getLabel(componentJob), throwable, true);
             }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -242,7 +242,12 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
             _cancelButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    _worker.cancelIfRunning();
+                    try {
+                        logger.info("Procedding to cancel the job");
+                        _worker.cancelIfRunning();
+                    } catch (Exception exception) {
+                       WidgetUtils.showErrorMessage("Error while cancelling the job", exception);
+                    }
                 }
             });
         } else {
@@ -376,7 +381,11 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
         boolean closing = super.onWindowClosing();
         if (closing) {
             if (_worker != null) {
-                _worker.cancelIfRunning();
+                try {
+                    _worker.cancelIfRunning();
+                } catch (Exception e) {
+                    WidgetUtils.showErrorMessage("Error while cancelling the job", e);
+                }
             }
         }
         return closing;

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
@@ -36,142 +36,143 @@ import org.slf4j.LoggerFactory;
 
 public final class AnalysisResultFutureImpl extends AbstractAnalysisResult implements AnalysisResultFuture {
 
-    private static final Logger logger = LoggerFactory.getLogger(AnalysisResultFutureImpl.class);
+	private static final Logger logger = LoggerFactory.getLogger(AnalysisResultFutureImpl.class);
 
-    private final Queue<JobAndResult> _resultQueue;
-    private final ErrorAware _errorAware;
-    private final StatusAwareTaskListener _jobTaskListener;
-    private volatile boolean _done;
+	private final Queue<JobAndResult> _resultQueue;
+	private final ErrorAware _errorAware;
+	private final StatusAwareTaskListener _jobTaskListener;
+	private volatile boolean _done;
 
-    public AnalysisResultFutureImpl(Queue<JobAndResult> resultQueue, StatusAwareTaskListener jobCompletionListener,
-            ErrorAware errorAware) {
-        _resultQueue = resultQueue;
-        _jobTaskListener = jobCompletionListener;
-        _errorAware = errorAware;
-        _done = false;
-    }
+	public AnalysisResultFutureImpl(Queue<JobAndResult> resultQueue, StatusAwareTaskListener jobCompletionListener,
+			ErrorAware errorAware) {
+		_resultQueue = resultQueue;
+		_jobTaskListener = jobCompletionListener;
+		_errorAware = errorAware;
+		_done = false;
+	}
 
-    @Override
-    public boolean isDone() {
-        if (!_done) {
-            _done = _jobTaskListener.isDone();
-        }
-        return _done;
-    }
+	@Override
+	public boolean isDone() {
+		if (!_done) {
+			_done = _jobTaskListener.isDone();
+		}
+		return _done;
+	}
+	
+	@Override
+	public Date getCreationDate() {
+		return _jobTaskListener.getCompletionTime();
+	}
 
-    @Override
-    public Date getCreationDate() {
-        return _jobTaskListener.getCompletionTime();
-    }
+	@Override
+	public void cancel() {
+		if (!isDone()) {
+		    logger.info("The job is not finished. cancelling"); 
+			_jobTaskListener.onError(null, new AnalysisJobCancellation());
+		}
+	}
 
-    @Override
-    public void cancel() {
-        if (!isDone()) {
-            _jobTaskListener.onError(null, new AnalysisJobCancellation());
-        }
-    }
+	@Override
+	public void await(long timeout, TimeUnit timeUnit) {
+		if (!isDone()) {
+			try {
+				logger.debug("_closeCompletionListener.await({},{})", timeout, timeUnit);
+				_jobTaskListener.await(timeout, timeUnit);
+			} catch (InterruptedException e) {
+				logger.error("Unexpected error while retreiving results", e);
+			}
+		}
+	}
 
-    @Override
-    public void await(long timeout, TimeUnit timeUnit) {
-        if (!isDone()) {
-            try {
-                logger.debug("_closeCompletionListener.await({},{})", timeout, timeUnit);
-                _jobTaskListener.await(timeout, timeUnit);
-            } catch (InterruptedException e) {
-                logger.error("Unexpected error while retreiving results", e);
-            }
-        }
-    }
+	@Override
+	public void await() {
+		while (!isDone()) {
+			try {
+				logger.debug("_closeCompletionListener.await()");
+				_jobTaskListener.await();
+			} catch (Exception e) {
+				logger.error("Unexpected error while retreiving results", e);
+			}
+		}
+	}
 
-    @Override
-    public void await() {
-        while (!isDone()) {
-            try {
-                logger.debug("_closeCompletionListener.await()");
-                _jobTaskListener.await();
-            } catch (Exception e) {
-                logger.error("Unexpected error while retreiving results", e);
-            }
-        }
-    }
+	@Override
+	public List<AnalyzerResult> getResults() throws IllegalStateException {
+		await();
+		if (isErrornous()) {
+		    throw new AnalysisJobFailedException(getErrors());
+		}
+		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+		ArrayList<AnalyzerResult> result = new ArrayList<AnalyzerResult>(resultQueueCopy.size());
+		for (JobAndResult jobResult : resultQueueCopy) {
+			result.add(jobResult.getResult());
+		}
+		return result;
+	}
 
-    @Override
-    public List<AnalyzerResult> getResults() throws IllegalStateException {
-        await();
-        if (isErrornous()) {
-            throw new AnalysisJobFailedException(getErrors());
-        }
-        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-        ArrayList<AnalyzerResult> result = new ArrayList<AnalyzerResult>(resultQueueCopy.size());
-        for (JobAndResult jobResult : resultQueueCopy) {
-            result.add(jobResult.getResult());
-        }
-        return result;
-    }
+	@Override
+	public AnalyzerResult getResult(ComponentJob componentJob) throws AnalysisJobFailedException {
+		await();
+		if (isErrornous()) {
+			throw new AnalysisJobFailedException(getErrors());
+		}
+		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+		for (JobAndResult jobResult : resultQueueCopy) {
+			if (jobResult.getJob().equals(componentJob)) {
+				return jobResult.getResult();
+			}
+		}
+		return null;
+	}
 
-    @Override
-    public AnalyzerResult getResult(ComponentJob componentJob) throws AnalysisJobFailedException {
-        await();
-        if (isErrornous()) {
-            throw new AnalysisJobFailedException(getErrors());
-        }
-        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-        for (JobAndResult jobResult : resultQueueCopy) {
-            if (jobResult.getJob().equals(componentJob)) {
-                return jobResult.getResult();
-            }
-        }
-        return null;
-    }
+	@Override
+	public Map<ComponentJob, AnalyzerResult> getResultMap() throws IllegalStateException {
+		await();
+		if (isErrornous()) {
+		    throw new AnalysisJobFailedException(getErrors());
+		}
+		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+		Map<ComponentJob, AnalyzerResult> result = new HashMap<ComponentJob, AnalyzerResult>();
+		for (JobAndResult jobResult : resultQueueCopy) {
+			ComponentJob job = jobResult.getJob();
+			AnalyzerResult analyzerResult = jobResult.getResult();
+			result.put(job, analyzerResult);
+		}
+		return result;
+	}
 
-    @Override
-    public Map<ComponentJob, AnalyzerResult> getResultMap() throws IllegalStateException {
-        await();
-        if (isErrornous()) {
-            throw new AnalysisJobFailedException(getErrors());
-        }
-        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-        Map<ComponentJob, AnalyzerResult> result = new HashMap<ComponentJob, AnalyzerResult>();
-        for (JobAndResult jobResult : resultQueueCopy) {
-            ComponentJob job = jobResult.getJob();
-            AnalyzerResult analyzerResult = jobResult.getResult();
-            result.put(job, analyzerResult);
-        }
-        return result;
-    }
+	@Override
+	public boolean isSuccessful() {
+		await();
+		return !_errorAware.isErrornous();
+	}
 
-    @Override
-    public boolean isSuccessful() {
-        await();
-        return !_errorAware.isErrornous();
-    }
+	@Override
+	public List<Throwable> getErrors() {
+		return _errorAware.getErrors();
+	}
 
-    @Override
-    public List<Throwable> getErrors() {
-        return _errorAware.getErrors();
-    }
+	@Override
+	public boolean isErrornous() {
+		return !isSuccessful();
+	}
 
-    @Override
-    public boolean isErrornous() {
-        return !isSuccessful();
-    }
+	@Override
+	public JobStatus getStatus() {
+		if (isDone()) {
+			if (isSuccessful()) {
+				return JobStatus.SUCCESSFUL;
+			}
+			return JobStatus.ERRORNOUS;
+		}
+		if (!_errorAware.isErrornous()) {
+			return JobStatus.NOT_FINISHED;
+		}
+		return JobStatus.ERRORNOUS;
+	}
 
-    @Override
-    public JobStatus getStatus() {
-        if (isDone()) {
-            if (isSuccessful()) {
-                return JobStatus.SUCCESSFUL;
-            }
-            return JobStatus.ERRORNOUS;
-        }
-        if (!_errorAware.isErrornous()) {
-            return JobStatus.NOT_FINISHED;
-        }
-        return JobStatus.ERRORNOUS;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return _errorAware.isCancelled();
-    }
+	@Override
+	public boolean isCancelled() {
+		return _errorAware.isCancelled();
+	}
 }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
@@ -66,7 +66,7 @@ public final class AnalysisResultFutureImpl extends AbstractAnalysisResult imple
 
 	@Override
 	public void cancel() {
-		if (!_done) {
+		if (!isDone()) {
 			_jobTaskListener.onError(null, new AnalysisJobCancellation());
 		}
 	}

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisResultFutureImpl.java
@@ -36,142 +36,142 @@ import org.slf4j.LoggerFactory;
 
 public final class AnalysisResultFutureImpl extends AbstractAnalysisResult implements AnalysisResultFuture {
 
-	private static final Logger logger = LoggerFactory.getLogger(AnalysisResultFutureImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(AnalysisResultFutureImpl.class);
 
-	private final Queue<JobAndResult> _resultQueue;
-	private final ErrorAware _errorAware;
-	private final StatusAwareTaskListener _jobTaskListener;
-	private volatile boolean _done;
+    private final Queue<JobAndResult> _resultQueue;
+    private final ErrorAware _errorAware;
+    private final StatusAwareTaskListener _jobTaskListener;
+    private volatile boolean _done;
 
-	public AnalysisResultFutureImpl(Queue<JobAndResult> resultQueue, StatusAwareTaskListener jobCompletionListener,
-			ErrorAware errorAware) {
-		_resultQueue = resultQueue;
-		_jobTaskListener = jobCompletionListener;
-		_errorAware = errorAware;
-		_done = false;
-	}
+    public AnalysisResultFutureImpl(Queue<JobAndResult> resultQueue, StatusAwareTaskListener jobCompletionListener,
+            ErrorAware errorAware) {
+        _resultQueue = resultQueue;
+        _jobTaskListener = jobCompletionListener;
+        _errorAware = errorAware;
+        _done = false;
+    }
 
-	@Override
-	public boolean isDone() {
-		if (!_done) {
-			_done = _jobTaskListener.isDone();
-		}
-		return _done;
-	}
-	
-	@Override
-	public Date getCreationDate() {
-		return _jobTaskListener.getCompletionTime();
-	}
+    @Override
+    public boolean isDone() {
+        if (!_done) {
+            _done = _jobTaskListener.isDone();
+        }
+        return _done;
+    }
 
-	@Override
-	public void cancel() {
-		if (!isDone()) {
-			_jobTaskListener.onError(null, new AnalysisJobCancellation());
-		}
-	}
+    @Override
+    public Date getCreationDate() {
+        return _jobTaskListener.getCompletionTime();
+    }
 
-	@Override
-	public void await(long timeout, TimeUnit timeUnit) {
-		if (!isDone()) {
-			try {
-				logger.debug("_closeCompletionListener.await({},{})", timeout, timeUnit);
-				_jobTaskListener.await(timeout, timeUnit);
-			} catch (InterruptedException e) {
-				logger.error("Unexpected error while retreiving results", e);
-			}
-		}
-	}
+    @Override
+    public void cancel() {
+        if (!isDone()) {
+            _jobTaskListener.onError(null, new AnalysisJobCancellation());
+        }
+    }
 
-	@Override
-	public void await() {
-		while (!isDone()) {
-			try {
-				logger.debug("_closeCompletionListener.await()");
-				_jobTaskListener.await();
-			} catch (Exception e) {
-				logger.error("Unexpected error while retreiving results", e);
-			}
-		}
-	}
+    @Override
+    public void await(long timeout, TimeUnit timeUnit) {
+        if (!isDone()) {
+            try {
+                logger.debug("_closeCompletionListener.await({},{})", timeout, timeUnit);
+                _jobTaskListener.await(timeout, timeUnit);
+            } catch (InterruptedException e) {
+                logger.error("Unexpected error while retreiving results", e);
+            }
+        }
+    }
 
-	@Override
-	public List<AnalyzerResult> getResults() throws IllegalStateException {
-		await();
-		if (isErrornous()) {
-		    throw new AnalysisJobFailedException(getErrors());
-		}
-		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-		ArrayList<AnalyzerResult> result = new ArrayList<AnalyzerResult>(resultQueueCopy.size());
-		for (JobAndResult jobResult : resultQueueCopy) {
-			result.add(jobResult.getResult());
-		}
-		return result;
-	}
+    @Override
+    public void await() {
+        while (!isDone()) {
+            try {
+                logger.debug("_closeCompletionListener.await()");
+                _jobTaskListener.await();
+            } catch (Exception e) {
+                logger.error("Unexpected error while retreiving results", e);
+            }
+        }
+    }
 
-	@Override
-	public AnalyzerResult getResult(ComponentJob componentJob) throws AnalysisJobFailedException {
-		await();
-		if (isErrornous()) {
-			throw new AnalysisJobFailedException(getErrors());
-		}
-		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-		for (JobAndResult jobResult : resultQueueCopy) {
-			if (jobResult.getJob().equals(componentJob)) {
-				return jobResult.getResult();
-			}
-		}
-		return null;
-	}
+    @Override
+    public List<AnalyzerResult> getResults() throws IllegalStateException {
+        await();
+        if (isErrornous()) {
+            throw new AnalysisJobFailedException(getErrors());
+        }
+        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+        ArrayList<AnalyzerResult> result = new ArrayList<AnalyzerResult>(resultQueueCopy.size());
+        for (JobAndResult jobResult : resultQueueCopy) {
+            result.add(jobResult.getResult());
+        }
+        return result;
+    }
 
-	@Override
-	public Map<ComponentJob, AnalyzerResult> getResultMap() throws IllegalStateException {
-		await();
-		if (isErrornous()) {
-		    throw new AnalysisJobFailedException(getErrors());
-		}
-		ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
-		Map<ComponentJob, AnalyzerResult> result = new HashMap<ComponentJob, AnalyzerResult>();
-		for (JobAndResult jobResult : resultQueueCopy) {
-			ComponentJob job = jobResult.getJob();
-			AnalyzerResult analyzerResult = jobResult.getResult();
-			result.put(job, analyzerResult);
-		}
-		return result;
-	}
+    @Override
+    public AnalyzerResult getResult(ComponentJob componentJob) throws AnalysisJobFailedException {
+        await();
+        if (isErrornous()) {
+            throw new AnalysisJobFailedException(getErrors());
+        }
+        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+        for (JobAndResult jobResult : resultQueueCopy) {
+            if (jobResult.getJob().equals(componentJob)) {
+                return jobResult.getResult();
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public boolean isSuccessful() {
-		await();
-		return !_errorAware.isErrornous();
-	}
+    @Override
+    public Map<ComponentJob, AnalyzerResult> getResultMap() throws IllegalStateException {
+        await();
+        if (isErrornous()) {
+            throw new AnalysisJobFailedException(getErrors());
+        }
+        ArrayList<JobAndResult> resultQueueCopy = new ArrayList<JobAndResult>(_resultQueue);
+        Map<ComponentJob, AnalyzerResult> result = new HashMap<ComponentJob, AnalyzerResult>();
+        for (JobAndResult jobResult : resultQueueCopy) {
+            ComponentJob job = jobResult.getJob();
+            AnalyzerResult analyzerResult = jobResult.getResult();
+            result.put(job, analyzerResult);
+        }
+        return result;
+    }
 
-	@Override
-	public List<Throwable> getErrors() {
-		return _errorAware.getErrors();
-	}
+    @Override
+    public boolean isSuccessful() {
+        await();
+        return !_errorAware.isErrornous();
+    }
 
-	@Override
-	public boolean isErrornous() {
-		return !isSuccessful();
-	}
+    @Override
+    public List<Throwable> getErrors() {
+        return _errorAware.getErrors();
+    }
 
-	@Override
-	public JobStatus getStatus() {
-		if (isDone()) {
-			if (isSuccessful()) {
-				return JobStatus.SUCCESSFUL;
-			}
-			return JobStatus.ERRORNOUS;
-		}
-		if (!_errorAware.isErrornous()) {
-			return JobStatus.NOT_FINISHED;
-		}
-		return JobStatus.ERRORNOUS;
-	}
+    @Override
+    public boolean isErrornous() {
+        return !isSuccessful();
+    }
 
-	@Override
-	public boolean isCancelled() {
-		return _errorAware.isCancelled();
-	}
+    @Override
+    public JobStatus getStatus() {
+        if (isDone()) {
+            if (isSuccessful()) {
+                return JobStatus.SUCCESSFUL;
+            }
+            return JobStatus.ERRORNOUS;
+        }
+        if (!_errorAware.isErrornous()) {
+            return JobStatus.NOT_FINISHED;
+        }
+        return JobStatus.ERRORNOUS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return _errorAware.isCancelled();
+    }
 }

--- a/engine/core/src/test/java/org/datacleaner/job/runner/AnalysisResultFutureImplTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/runner/AnalysisResultFutureImplTest.java
@@ -94,7 +94,7 @@ public class AnalysisResultFutureImplTest extends TestCase {
 
 		jobCompletionListener.onError(null, new AnalysisJobCancellation());
 		EasyMock.expect(errorAware.isCancelled()).andReturn(true);
-
+        EasyMock.expect(jobCompletionListener.isDone()).andReturn(false);
 		EasyMock.replay(jobCompletionListener, errorAware);
 
 		AnalysisResultFutureImpl resultFuture = new AnalysisResultFutureImpl(resultQueue, jobCompletionListener, errorAware);
@@ -104,4 +104,20 @@ public class AnalysisResultFutureImplTest extends TestCase {
 
 		EasyMock.verify(jobCompletionListener, errorAware);
 	}
+	public void testCancelJobfinished() throws Exception {
+        Queue<JobAndResult> resultQueue = new LinkedList<JobAndResult>();
+        StatusAwareTaskListener jobCompletionListener = EasyMock.createMock(StatusAwareTaskListener.class);
+        ErrorAware errorAware = EasyMock.createMock(ErrorAware.class);
+
+        EasyMock.expect(errorAware.isCancelled()).andReturn(false);
+        EasyMock.expect(jobCompletionListener.isDone()).andReturn(true);
+        EasyMock.replay(jobCompletionListener, errorAware);
+
+        AnalysisResultFutureImpl resultFuture = new AnalysisResultFutureImpl(resultQueue, jobCompletionListener, errorAware);
+        resultFuture.cancel();
+
+        assertFalse(resultFuture.isCancelled());
+
+        EasyMock.verify(jobCompletionListener, errorAware);
+    }
 }


### PR DESCRIPTION
Fixes #910 

A job could never be cancelled because _resultFuture in AnalysisRunnerSwingWorker class would always be null. The reason was that the job is started in ResultWindow using the method execute from super class SwingWorker, and not doInBackground() from AnalysisRunnerSwingWorker class. I hope it makes sense what I am trying to say. 

Fixed by fetching the result first in cancelIfRunning(). 