### PR TITLE
Preview output data stream

### DIFF
--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
@@ -39,7 +39,7 @@ public class CoalesceUnit {
     // transient cached view of columns
     private transient InputColumn<?>[] _inputColumns;
 
-    public CoalesceUnit(List<InputColumn<?>> inputColumns) {
+    public CoalesceUnit(List<? extends InputColumn<?>> inputColumns) {
         this(inputColumns.toArray(new InputColumn[inputColumns.size()]));
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
+++ b/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
@@ -151,9 +151,6 @@ public final class PreviewTransformedDataActionListener implements ActionListene
             return new DefaultTableModel(0, 0);
         }
 
-        // remove all analyzers, except the dummy
-        ajb.removeAllAnalyzers();
-
         // add the result collector (a dummy analyzer)
         final AnalyzerComponentBuilder<PreviewTransformedDataAnalyzer> rowCollector = ajb
                 .addAnalyzer(Descriptors.ofAnalyzer(PreviewTransformedDataAnalyzer.class))

--- a/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/AbstractComponentBuilderPanel.java
@@ -33,6 +33,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 
+import org.datacleaner.api.HiddenProperty;
 import org.datacleaner.descriptors.ComponentDescriptor;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
@@ -91,7 +92,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
 
         final JScrollPane scrolleable = WidgetUtils.scrolleable(_taskPaneContainer);
         add(scrolleable, BorderLayout.CENTER);
-        
+
         _buttonPanel = createTopButtonPanel();
         add(_buttonPanel, BorderLayout.NORTH);
     }
@@ -137,7 +138,6 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
         final ComponentBuilder componentBuilder = getComponentBuilder();
 
         final List<ConfiguredPropertyTaskPane> propertyTaskPanes = createPropertyTaskPanes();
-        
 
         final Set<ConfiguredPropertyDescriptor> unconfiguredPropertyDescriptors = new HashSet<>();
         unconfiguredPropertyDescriptors.addAll(componentBuilder.getDescriptor().getConfiguredProperties());
@@ -150,7 +150,6 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
             unconfiguredPropertyDescriptors.removeAll(propertyTaskPane.getProperties());
         }
 
-
         if (!unconfiguredPropertyDescriptors.isEmpty()) {
             for (ConfiguredPropertyDescriptor property : unconfiguredPropertyDescriptors) {
                 logger.warn("No property widget was found in task panes for property: {}", property);
@@ -160,25 +159,29 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
                 getPropertyWidgetCollection().registerWidget(property, propertyWidget);
             }
         }
-        
+
         onOutputDataStreamsChanged();
     }
 
     protected List<ConfiguredPropertyTaskPane> createPropertyTaskPanes() {
-        Set<ConfiguredPropertyDescriptor> configuredProperties = new TreeSet<ConfiguredPropertyDescriptor>(
+        final Set<ConfiguredPropertyDescriptor> configuredProperties = new TreeSet<ConfiguredPropertyDescriptor>(
                 _descriptor.getConfiguredProperties());
 
-        List<ConfiguredPropertyDescriptor> inputProperties = new ArrayList<ConfiguredPropertyDescriptor>();
-        List<ConfiguredPropertyDescriptor> requiredProperties = new ArrayList<ConfiguredPropertyDescriptor>();
-        List<ConfiguredPropertyDescriptor> optionalProperties = new ArrayList<ConfiguredPropertyDescriptor>();
+        final List<ConfiguredPropertyDescriptor> inputProperties = new ArrayList<ConfiguredPropertyDescriptor>();
+        final List<ConfiguredPropertyDescriptor> requiredProperties = new ArrayList<ConfiguredPropertyDescriptor>();
+        final List<ConfiguredPropertyDescriptor> optionalProperties = new ArrayList<ConfiguredPropertyDescriptor>();
+
         for (ConfiguredPropertyDescriptor propertyDescriptor : configuredProperties) {
-            boolean required = propertyDescriptor.isRequired();
-            if (required && propertyDescriptor.isInputColumn()) {
-                inputProperties.add(propertyDescriptor);
-            } else if (required) {
-                requiredProperties.add(propertyDescriptor);
-            } else {
-                optionalProperties.add(propertyDescriptor);
+            final HiddenProperty hiddenProperty = propertyDescriptor.getAnnotation(HiddenProperty.class);
+            if (hiddenProperty == null || !hiddenProperty.hiddenForLocalAccess()) {
+                final boolean required = propertyDescriptor.isRequired();
+                if (required && propertyDescriptor.isInputColumn()) {
+                    inputProperties.add(propertyDescriptor);
+                } else if (required) {
+                    requiredProperties.add(propertyDescriptor);
+                } else {
+                    optionalProperties.add(propertyDescriptor);
+                }
             }
         }
 
@@ -290,7 +293,7 @@ public abstract class AbstractComponentBuilderPanel extends DCPanel implements C
      */
     protected void onConfigurationChanged() {
         getPropertyWidgetCollection().onConfigurationChanged();
-        
+
         onOutputDataStreamsChanged();
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
@@ -56,8 +56,8 @@ import org.datacleaner.widgets.properties.PropertyWidgetFactory;
  * output columns, a "write data" button, a preview button and a context
  * visualization.
  */
-public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPanel implements
-        TransformerComponentBuilderPresenter, TransformerChangeListener {
+public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPanel
+        implements TransformerComponentBuilderPresenter, TransformerChangeListener {
 
     private static final long serialVersionUID = 1L;
 
@@ -99,54 +99,43 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
         _previewAlternativesButton = WidgetFactory.createDefaultButton("\uf0d7");
         _previewAlternativesButton.setBorder(WidgetUtils.BORDER_EMPTY);
         _previewAlternativesButton.setFont(WidgetUtils.FONT_FONTAWESOME.deriveFont(12f));
-        if (isPreviewAvailable()) {
-            final int defaultPreviewRows = getPreviewRows();
-            final PreviewTransformedDataActionListener defaultPreviewTransformedDataActionListener = new PreviewTransformedDataActionListener(
-                    _windowContext, this, _componentBuilder, defaultPreviewRows);
-            final TransformerComponentBuilderPanel transformerComponentBuilderPanel = this;
-            _previewButton.addActionListener(defaultPreviewTransformedDataActionListener);
-            _previewAlternativesButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    final JMenuItem defaultPreviewMenutItem = WidgetFactory.createMenuItem("Preview "
-                            + defaultPreviewRows + " records", IconUtils.ACTION_PREVIEW);
-                    defaultPreviewMenutItem.addActionListener(defaultPreviewTransformedDataActionListener);
+        final int defaultPreviewRows = getPreviewRows();
+        final PreviewTransformedDataActionListener defaultPreviewTransformedDataActionListener = new PreviewTransformedDataActionListener(
+                _windowContext, this, _componentBuilder, defaultPreviewRows);
+        final TransformerComponentBuilderPanel transformerComponentBuilderPanel = this;
+        _previewButton.addActionListener(defaultPreviewTransformedDataActionListener);
+        _previewAlternativesButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                final JMenuItem defaultPreviewMenutItem = WidgetFactory
+                        .createMenuItem("Preview " + defaultPreviewRows + " records", IconUtils.ACTION_PREVIEW);
+                defaultPreviewMenutItem.addActionListener(defaultPreviewTransformedDataActionListener);
 
-                    final JMenuItem maxRowsPreviewMenuItem = WidgetFactory.createMenuItem("Preview N records",
-                            IconUtils.ACTION_PREVIEW);
-                    maxRowsPreviewMenuItem.addActionListener(new ActionListener() {
+                final JMenuItem maxRowsPreviewMenuItem = WidgetFactory.createMenuItem("Preview N records",
+                        IconUtils.ACTION_PREVIEW);
+                maxRowsPreviewMenuItem.addActionListener(new ActionListener() {
 
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            Integer maxRows = WidgetFactory.showMaxRowsDialog(defaultPreviewRows);
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        Integer maxRows = WidgetFactory.showMaxRowsDialog(defaultPreviewRows);
 
-                            if (maxRows != null) {
-                                final PreviewTransformedDataActionListener maxRowsPreviewTransformedDataActionListener = new PreviewTransformedDataActionListener(
-                                        _windowContext, transformerComponentBuilderPanel, _componentBuilder, maxRows);
-                                maxRowsPreviewTransformedDataActionListener.actionPerformed(e);
-                            }
+                        if (maxRows != null) {
+                            final PreviewTransformedDataActionListener maxRowsPreviewTransformedDataActionListener = new PreviewTransformedDataActionListener(
+                                    _windowContext, transformerComponentBuilderPanel, _componentBuilder, maxRows);
+                            maxRowsPreviewTransformedDataActionListener.actionPerformed(e);
                         }
-                    });
+                    }
+                });
 
-                    final JPopupMenu menu = new JPopupMenu();
-                    menu.add(defaultPreviewMenutItem);
-                    menu.add(maxRowsPreviewMenuItem);
+                final JPopupMenu menu = new JPopupMenu();
+                menu.add(defaultPreviewMenutItem);
+                menu.add(maxRowsPreviewMenuItem);
 
-                    final int horizontalPosition = -1 * menu.getPreferredSize().width
-                            + _previewAlternativesButton.getWidth();
-                    menu.show(_previewAlternativesButton, horizontalPosition, _previewAlternativesButton.getHeight());
-                }
-            });
-        } else {
-            // we cannot provide a preview-function for transformers in non-root
-            // AnalysisJobBuilders
-            _previewButton.setVisible(false);
-            _previewAlternativesButton.setVisible(false);
-        }
-    }
-
-    private boolean isPreviewAvailable() {
-        return _componentBuilder.getAnalysisJobBuilder().isRootJobBuilder();
+                final int horizontalPosition = -1 * menu.getPreferredSize().width
+                        + _previewAlternativesButton.getWidth();
+                menu.show(_previewAlternativesButton, horizontalPosition, _previewAlternativesButton.getHeight());
+            }
+        });
     }
 
     @Override
@@ -178,14 +167,12 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
         bottomButtonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT, 4, 0));
         bottomButtonPanel.add(_writeDataButton);
 
-        if (isPreviewAvailable()) {
-            final ComboButton previewButtonPanel = new ComboButton();
-            previewButtonPanel.addButton(_previewButton);
-            previewButtonPanel.add(new JLabel("|"));
-            previewButtonPanel.addButton(_previewAlternativesButton);
-            
-            bottomButtonPanel.add(previewButtonPanel);
-        }
+        final ComboButton previewButtonPanel = new ComboButton();
+        previewButtonPanel.addButton(_previewButton);
+        previewButtonPanel.add(new JLabel("|"));
+        previewButtonPanel.addButton(_previewAlternativesButton);
+
+        bottomButtonPanel.add(previewButtonPanel);
 
         if (!_componentBuilder.getDescriptor().isMultiStreamComponent()) {
             final DCPanel outputColumnsPanel = new DCPanel();

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphMouseListener.java
@@ -84,8 +84,8 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
 
     private Point _pressedPoint;
 
-    public JobGraphMouseListener(JobGraphContext graphContext, JobGraphLinkPainter linkPainter,
-            JobGraphActions actions, WindowContext windowContext, UsageLogger usageLogger) {
+    public JobGraphMouseListener(JobGraphContext graphContext, JobGraphLinkPainter linkPainter, JobGraphActions actions,
+            WindowContext windowContext, UsageLogger usageLogger) {
         _graphContext = graphContext;
         _linkPainter = linkPainter;
         _actions = actions;
@@ -124,8 +124,8 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
 
         popup.add(createLinkMenuItem(table));
 
-        final JMenuItem previewMenuItem = new JMenuItem("Preview data", ImageManager.get().getImageIcon(
-                IconUtils.ACTION_PREVIEW, IconUtils.ICON_SIZE_SMALL));
+        final JMenuItem previewMenuItem = new JMenuItem("Preview data",
+                ImageManager.get().getImageIcon(IconUtils.ACTION_PREVIEW, IconUtils.ICON_SIZE_SMALL));
         final AnalysisJobBuilder analysisJobBuilder = _graphContext.getAnalysisJobBuilder(table);
         final Datastore datastore = analysisJobBuilder.getDatastore();
         final List<MetaModelInputColumn> inputColumns = analysisJobBuilder.getSourceColumnsOfTable(table);
@@ -147,8 +147,8 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
 
         final JPopupMenu popup = new JPopupMenu();
 
-        final JMenuItem configureComponentMenuItem = new JMenuItem("Configure ...", ImageManager.get().getImageIcon(
-                IconUtils.MENU_OPTIONS, IconUtils.ICON_SIZE_SMALL));
+        final JMenuItem configureComponentMenuItem = new JMenuItem("Configure ...",
+                ImageManager.get().getImageIcon(IconUtils.MENU_OPTIONS, IconUtils.ICON_SIZE_SMALL));
         configureComponentMenuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -179,16 +179,13 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
         });
         popup.add(renameMenuItem);
 
-        if (componentBuilder instanceof TransformerComponentBuilder) {
+        if (!isMultiStream && componentBuilder instanceof TransformerComponentBuilder) {
             final TransformerComponentBuilder<?> tjb = (TransformerComponentBuilder<?>) componentBuilder;
-
-            if (!isMultiStream && tjb.getAnalysisJobBuilder().isRootJobBuilder()) {
-                final JMenuItem previewMenuItem = new JMenuItem("Preview data", ImageManager.get().getImageIcon(
-                        IconUtils.ACTION_PREVIEW, IconUtils.ICON_SIZE_SMALL));
-                previewMenuItem.addActionListener(new PreviewTransformedDataActionListener(_windowContext, tjb));
-                previewMenuItem.setEnabled(componentBuilder.isConfigured());
-                popup.add(previewMenuItem);
-            }
+            final JMenuItem previewMenuItem = new JMenuItem("Preview data",
+                    ImageManager.get().getImageIcon(IconUtils.ACTION_PREVIEW, IconUtils.ICON_SIZE_SMALL));
+            previewMenuItem.addActionListener(new PreviewTransformedDataActionListener(_windowContext, tjb));
+            previewMenuItem.setEnabled(componentBuilder.isConfigured());
+            popup.add(previewMenuItem);
         }
 
         if (ChangeRequirementMenu.isRelevant(componentBuilder)) {
@@ -200,8 +197,8 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
     }
 
     private JMenuItem createLinkMenuItem(final Object from) {
-        return createLinkMenuItem(new JobGraphLinkPainter.VertexContext(from,
-                _graphContext.getAnalysisJobBuilder(from), null));
+        return createLinkMenuItem(
+                new JobGraphLinkPainter.VertexContext(from, _graphContext.getAnalysisJobBuilder(from), null));
     }
 
     private JMenuItem createLinkMenuItem(final JobGraphLinkPainter.VertexContext from) {
@@ -213,8 +210,8 @@ public class JobGraphMouseListener extends MouseAdapter implements GraphMouseLis
             menuItemText = "Link \"" + from.getOutputDataStream().getName() + "\" to ...";
         }
 
-        final JMenuItem menuItem = new JMenuItem(menuItemText, imageManager.getImageIcon(IconUtils.ACTION_ADD,
-                IconUtils.ICON_SIZE_SMALL));
+        final JMenuItem menuItem = new JMenuItem(menuItemText,
+                imageManager.getImageIcon(IconUtils.ACTION_ADD, IconUtils.ICON_SIZE_SMALL));
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/engine/core/src/main/java/org/datacleaner/components/maxrows/MaxRowsFilter.java
+++ b/engine/core/src/main/java/org/datacleaner/components/maxrows/MaxRowsFilter.java
@@ -30,6 +30,7 @@ import org.datacleaner.api.Configured;
 import org.datacleaner.api.Description;
 import org.datacleaner.api.Distributed;
 import org.datacleaner.api.HasLabelAdvice;
+import org.datacleaner.api.HiddenProperty;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.api.NumberProperty;
@@ -42,6 +43,8 @@ import org.datacleaner.components.categories.FilterCategory;
 @Categorized(value = FilterCategory.class)
 @Distributed(false)
 public class MaxRowsFilter implements QueryOptimizedFilter<MaxRowsFilter.Category>, HasLabelAdvice {
+
+    public static final String PROPERTY_APPLY_ORDERING = "Apply ordering";
 
     public static enum Category {
         VALID, INVALID
@@ -57,7 +60,13 @@ public class MaxRowsFilter implements QueryOptimizedFilter<MaxRowsFilter.Categor
     @Description("The first row (aka 'offset') to process.")
     int firstRow = 1;
 
-    @Configured(required = false)
+    // this property is hidden because normally it is driven by the selection of
+    // "orderColumn" below
+    @Configured(value = PROPERTY_APPLY_ORDERING, order = 1000, required = false)
+    @HiddenProperty
+    boolean applyOrdering = true;
+
+    @Configured(order = 1001, required = false)
     @Description("Optional column to use for specifying dataset ordering. Use if consistent pagination is needed.")
     InputColumn<?> orderColumn;
 
@@ -99,6 +108,14 @@ public class MaxRowsFilter implements QueryOptimizedFilter<MaxRowsFilter.Categor
 
     public void setOrderColumn(InputColumn<?> orderColumn) {
         this.orderColumn = orderColumn;
+    }
+    
+    public void setApplyOrdering(boolean applyOrdering) {
+        this.applyOrdering = applyOrdering;
+    }
+    
+    public boolean isApplyOrdering() {
+        return applyOrdering;
     }
 
     @Validate
@@ -158,7 +175,7 @@ public class MaxRowsFilter implements QueryOptimizedFilter<MaxRowsFilter.Categor
                 q.setMaxRows(newMaxRows);
             }
 
-            if (orderColumn != null) {
+            if (applyOrdering && orderColumn != null) {
                 final Column physicalColumn = orderColumn.getPhysicalColumn();
                 q.orderBy(physicalColumn);
             }

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
@@ -215,8 +215,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
     }
 
     @Override
-    public final boolean isConfigured(boolean throwException)
-            throws ComponentValidationException, UnconfiguredConfiguredPropertyException {
+    public final boolean isConfigured(boolean throwException) throws ComponentValidationException,
+            UnconfiguredConfiguredPropertyException {
         for (ConfiguredPropertyDescriptor configuredProperty : _descriptor.getConfiguredProperties()) {
             if (!isConfigured(configuredProperty, throwException)) {
                 if (throwException) {
@@ -341,8 +341,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
                     for (int i = 0; i < length; i++) {
                         Object valuePart = Array.get(value, i);
                         if (valuePart == null) {
-                            logger.warn("Element no. {} in array (size {}) is null! Value passed to {}",
-                                    new Object[] { i, length, configuredProperty });
+                            logger.warn("Element no. {} in array (size {}) is null! Value passed to {}", new Object[] {
+                                    i, length, configuredProperty });
                         } else {
                             if (!ReflectionUtils.is(valuePart.getClass(), configuredProperty.getBaseType())) {
                                 correctType = false;
@@ -431,8 +431,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
 
     @Override
     public ConfiguredPropertyDescriptor getDefaultConfiguredPropertyForInput() throws UnsupportedOperationException {
-        Collection<ConfiguredPropertyDescriptor> inputProperties = getDescriptor()
-                .getConfiguredPropertiesForInput(false);
+        Collection<ConfiguredPropertyDescriptor> inputProperties = getDescriptor().getConfiguredPropertiesForInput(
+                false);
 
         if (inputProperties.isEmpty()) {
             // if there are no required input columns, try optional input
@@ -444,8 +444,9 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
             ConfiguredPropertyDescriptor propertyDescriptor = inputProperties.iterator().next();
             return propertyDescriptor;
         } else {
-            throw new UnsupportedOperationException("There are " + inputProperties.size() + " named input columns in \""
-                    + getDescriptor().getDisplayName() + "\", please specify which one to configure");
+            throw new UnsupportedOperationException("There are " + inputProperties.size()
+                    + " named input columns in \"" + getDescriptor().getDisplayName()
+                    + "\", please specify which one to configure");
         }
     }
 
@@ -463,8 +464,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
             // check input column type parameter compatibility
             final Class<?> actualDataType = inputColumn.getDataType();
             if (!ReflectionUtils.is(actualDataType, expectedDataType, false)) {
-                throw new IllegalArgumentException(
-                        "Unsupported InputColumn type: " + actualDataType + ", expected: " + expectedDataType);
+                throw new IllegalArgumentException("Unsupported InputColumn type: " + actualDataType + ", expected: "
+                        + expectedDataType);
             }
         }
 
@@ -497,8 +498,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
             for (InputColumn<?> inputColumn : inputColumns) {
                 final Class<?> actualDataType = inputColumn.getDataType();
                 if (!ReflectionUtils.is(actualDataType, expectedDataType, false)) {
-                    throw new IllegalArgumentException(
-                            "Unsupported InputColumn type: " + actualDataType + ", expected: " + expectedDataType);
+                    throw new IllegalArgumentException("Unsupported InputColumn type: " + actualDataType
+                            + ", expected: " + expectedDataType);
                 }
             }
         }
@@ -571,6 +572,9 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
     }
 
     public void setRequirement(FilterComponentBuilder<?, ?> filterComponentBuilder, String category) {
+        if (filterComponentBuilder == this) {
+            throw new IllegalArgumentException("Requirement source and sink cannot be the same");
+        }
         final FilterOutcome filterOutcome = filterComponentBuilder.getFilterOutcome(category);
         if (filterOutcome == null) {
             throw new IllegalArgumentException("No such category found in available outcomes: " + category);
@@ -578,12 +582,15 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
         setRequirement(filterOutcome);
     }
 
-    public void setRequirement(FilterComponentBuilder<?, ?> filterJobBuilder, Enum<?> category) {
-        EnumSet<?> categories = filterJobBuilder.getDescriptor().getOutcomeCategories();
+    public void setRequirement(FilterComponentBuilder<?, ?> filterComponentBuilder, Enum<?> category) {
+        if (filterComponentBuilder == this) {
+            throw new IllegalArgumentException("Requirement source and sink cannot be the same");
+        }
+        final EnumSet<?> categories = filterComponentBuilder.getDescriptor().getOutcomeCategories();
         if (!categories.contains(category)) {
             throw new IllegalArgumentException("No such category found in available outcomes: " + category);
         }
-        setRequirement(filterJobBuilder.getFilterOutcome(category));
+        setRequirement(filterComponentBuilder.getFilterOutcome(category));
     }
 
     public void setRequirement(FilterOutcome outcome) throws IllegalArgumentException {
@@ -596,8 +603,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
         } else if (outcome instanceof FilterOutcome) {
             setComponentRequirement(new SimpleComponentRequirement((FilterOutcome) outcome));
         } else {
-            throw new IllegalArgumentException(
-                    "Unsupported outcome type (use ComponentRequirement instead): " + outcome);
+            throw new IllegalArgumentException("Unsupported outcome type (use ComponentRequirement instead): "
+                    + outcome);
         }
     }
 
@@ -668,8 +675,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
                     for (int i = 0; i < length; i++) {
                         InputColumn<?> column = (InputColumn<?>) Array.get(inputColumns, i);
                         if (column == null) {
-                            logger.warn("Element no. {} in array (size {}) is null! Value read from {}",
-                                    new Object[] { i, length, configuredProperty });
+                            logger.warn("Element no. {} in array (size {}) is null! Value read from {}", new Object[] {
+                                    i, length, configuredProperty });
                         } else {
                             result.add(column);
                         }
@@ -826,8 +833,7 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
                         if (table instanceof MutableTable) {
                             final MutableTable mutableTable = (MutableTable) table;
                             if (isOutputDataStreamConsumed(existingStream)) {
-                                final AnalysisJobBuilder existingJobBuilder = getOutputDataStreamJobBuilder(
-                                        existingStream);
+                                final AnalysisJobBuilder existingJobBuilder = getOutputDataStreamJobBuilder(existingStream);
                                 // update the table
                                 updateStream(mutableTable, existingJobBuilder, newStream);
                             } else {
@@ -913,8 +919,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
         final List<OutputDataStreamJob> result = new ArrayList<>();
         for (OutputDataStream outputDataStream : outputDataStreams) {
             if (isOutputDataStreamConsumed(outputDataStream)) {
-                result.add(
-                        new LazyOutputDataStreamJob(outputDataStream, getOutputDataStreamJobBuilder(outputDataStream)));
+                result.add(new LazyOutputDataStreamJob(outputDataStream,
+                        getOutputDataStreamJobBuilder(outputDataStream)));
             }
         }
         return result.toArray(new OutputDataStreamJob[result.size()]);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1216,6 +1216,12 @@ public final class AnalysisJobBuilder implements Closeable {
         }
         assert _transformerComponentBuilders.isEmpty();
     }
+    
+    public void removeAllComponents() {
+        removeAllAnalyzers();
+        removeAllFilters();
+        removeAllTransformers();
+    }
 
     public void removeAllFilters() {
         final List<FilterComponentBuilder<?, ?>> filters = new ArrayList<>(_filterComponentBuilders);

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -614,31 +614,17 @@ public final class AnalysisJobBuilder implements Closeable {
                     setDefaultRequirement((ComponentRequirement) null);
                 }
 
-                for (final AnalyzerComponentBuilder<?> ajb : _analyzerComponentBuilders) {
-                    final ComponentRequirement requirement = ajb.getComponentRequirement();
+                for (final ComponentBuilder cb : getComponentBuilders()) {
+                    final ComponentRequirement requirement = cb.getComponentRequirement();
                     if (requirement != null && requirement.getProcessingDependencies().contains(outcome)) {
-                        ajb.setComponentRequirement(previousRequirement);
-                    }
-                }
-
-                for (final TransformerComponentBuilder<?> tjb : _transformerComponentBuilders) {
-                    final ComponentRequirement requirement = tjb.getComponentRequirement();
-                    if (requirement != null && requirement.getProcessingDependencies().contains(outcome)) {
-                        tjb.setComponentRequirement(previousRequirement);
-                    }
-                }
-
-                for (final FilterComponentBuilder<?, ?> fjb : _filterComponentBuilders) {
-                    final ComponentRequirement requirement = fjb.getComponentRequirement();
-                    if (requirement != null && requirement.getProcessingDependencies().contains(outcome)) {
-                        fjb.setComponentRequirement(previousRequirement);
+                        cb.setComponentRequirement(previousRequirement);
                     }
                 }
             }
 
             filterJobBuilder.onRemoved();
 
-            // Ajb removal last, so listeners gets triggered
+            // removal last, so listeners gets triggered
             onComponentRemoved();
         }
         return this;

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -483,10 +483,11 @@ public final class AnalysisJobBuilder implements Closeable {
      * @return The same builder
      */
     public ComponentBuilder moveComponent(ComponentBuilder builder) {
-        if(builder.getAnalysisJobBuilder() != this) {
+        if (builder.getAnalysisJobBuilder() != this) {
             builder.getAnalysisJobBuilder().removeComponent(builder);
 
-            // when moving the component to a different scope we need to first reset
+            // when moving the component to a different scope we need to first
+            // reset
             // the prior input
             builder.clearInputColumns();
 
@@ -498,16 +499,16 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     /**
-     * Creates a filter job builder like the incoming filter job. Note that
-     * input (columns and requirements) will not be mapped since these depend on
-     * the context of the {@link FilterJob} and may not be matched in the
-     * {@link AnalysisJobBuilder}.
+     * Creates a component builder similar to the incoming {@link ComponentJob}.
+     * Note that input (columns and requirements) will not be mapped since these
+     * depend on the context of the {@link FilterJob} and may not be matched in
+     * the {@link AnalysisJobBuilder}.
      *
      * @param componentJob
      *
      * @return the builder object for the specific component
      */
-    protected Object addComponent(ComponentJob componentJob) {
+    protected ComponentBuilder addComponent(ComponentJob componentJob) {
         final ComponentDescriptor<?> descriptor = componentJob.getDescriptor();
         final ComponentBuilder builder = addComponent(descriptor);
 

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilderImportHelper.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilderImportHelper.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.metamodel.schema.Column;
 import org.datacleaner.api.ExpressionBasedInputColumn;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.data.MetaModelInputColumn;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.AnalysisJob;
@@ -41,6 +42,7 @@ import org.datacleaner.job.CompoundComponentRequirement;
 import org.datacleaner.job.FilterOutcome;
 import org.datacleaner.job.HasFilterOutcomes;
 import org.datacleaner.job.InputColumnSourceJob;
+import org.datacleaner.job.OutputDataStreamJob;
 import org.datacleaner.job.SimpleComponentRequirement;
 import org.datacleaner.util.SourceColumnFinder;
 
@@ -59,6 +61,8 @@ final class AnalysisJobBuilderImportHelper {
     public void importJob(AnalysisJob job) {
         _builder.setDatastore(job.getDatastore());
 
+        _builder.setAnalysisJobMetadata(job.getMetadata());
+
         final Collection<InputColumn<?>> sourceColumns = job.getSourceColumns();
         for (InputColumn<?> inputColumn : sourceColumns) {
             _builder.addSourceColumn((MetaModelInputColumn) inputColumn);
@@ -68,41 +72,57 @@ final class AnalysisJobBuilderImportHelper {
         sourceColumnFinder.addSources(job);
 
         // map that translates original component jobs to their builder objects
-        final Map<ComponentJob, Object> componentBuilders = new IdentityHashMap<ComponentJob, Object>();
+        final Map<ComponentJob, ComponentBuilder> componentBuilders = new IdentityHashMap<ComponentJob, ComponentBuilder>();
         addComponentBuilders(job.getFilterJobs(), componentBuilders);
         addComponentBuilders(job.getTransformerJobs(), componentBuilders);
         addComponentBuilders(job.getAnalyzerJobs(), componentBuilders);
 
         // re-build filter requirements
-        for (Entry<ComponentJob, Object> entry : componentBuilders.entrySet()) {
+        for (Entry<ComponentJob, ComponentBuilder> entry : componentBuilders.entrySet()) {
             final ComponentJob componentJob = entry.getKey();
+            final ComponentBuilder builder = entry.getValue();
             final ComponentRequirement originalRequirement = componentJob.getComponentRequirement();
             final ComponentRequirement componentRequirement = findImportedRequirement(originalRequirement,
                     componentBuilders);
-            final AbstractComponentBuilder<?, ?, ?> builder = (AbstractComponentBuilder<?, ?, ?>) entry.getValue();
             builder.setComponentRequirement(componentRequirement);
         }
 
         // re-build input column dependencies
-        for (Entry<ComponentJob, Object> entry : componentBuilders.entrySet()) {
+        for (Entry<ComponentJob, ComponentBuilder> entry : componentBuilders.entrySet()) {
             final ComponentJob componentJob = entry.getKey();
+            final ComponentBuilder builder = entry.getValue();
             final Set<ConfiguredPropertyDescriptor> inputColumnProperties = componentJob.getDescriptor()
                     .getConfiguredPropertiesForInput(true);
-
-            final AbstractComponentBuilder<?, ?, ?> builder = (AbstractComponentBuilder<?, ?, ?>) entry.getValue();
 
             for (ConfiguredPropertyDescriptor inputColumnProperty : inputColumnProperties) {
                 final Object originalInputColumnValue = componentJob.getConfiguration()
                         .getProperty(inputColumnProperty);
-                final Object newInputColumnValue = findImportedInputColumns(originalInputColumnValue,
-                        componentBuilders, sourceColumnFinder);
+                final Object newInputColumnValue = findImportedInputColumns(originalInputColumnValue, componentBuilders,
+                        sourceColumnFinder);
                 builder.setConfiguredProperty(inputColumnProperty, newInputColumnValue);
+            }
+        }
+
+        // re-build output data streams
+        for (Entry<ComponentJob, ComponentBuilder> entry : componentBuilders.entrySet()) {
+            final ComponentJob componentJob = entry.getKey();
+            final ComponentBuilder builder = entry.getValue();
+            final OutputDataStreamJob[] outputDataStreamJobs = componentJob.getOutputDataStreamJobs();
+            for (OutputDataStreamJob outputDataStreamJob : outputDataStreamJobs) {
+                final OutputDataStream outputDataStream = outputDataStreamJob.getOutputDataStream();
+                final AnalysisJobBuilder outputDataStreamJobBuilder = builder
+                        .getOutputDataStreamJobBuilder(outputDataStream.getName());
+
+                // delegate to a new helper to handle the output data stream
+                final AnalysisJobBuilderImportHelper helper = new AnalysisJobBuilderImportHelper(
+                        outputDataStreamJobBuilder);
+                helper.importJob(outputDataStreamJob.getJob());
             }
         }
     }
 
     private Object findImportedInputColumns(Object originalInputColumnValue,
-            Map<ComponentJob, Object> componentBuilders, SourceColumnFinder sourceColumnFinder) {
+            Map<ComponentJob, ComponentBuilder> componentBuilders, SourceColumnFinder sourceColumnFinder) {
         if (originalInputColumnValue == null) {
             return null;
         }
@@ -126,7 +146,7 @@ final class AnalysisJobBuilderImportHelper {
     }
 
     private InputColumn<?> findImportedInputColumn(InputColumn<?> originalInputColumn,
-            Map<ComponentJob, Object> componentBuilders, SourceColumnFinder sourceColumnFinder) {
+            Map<ComponentJob, ComponentBuilder> componentBuilders, SourceColumnFinder sourceColumnFinder) {
         if (originalInputColumn.isPhysicalColumn()) {
             Column physicalColumn = originalInputColumn.getPhysicalColumn();
             return _builder.getSourceColumnByName(physicalColumn.getQualifiedLabel());
@@ -158,7 +178,7 @@ final class AnalysisJobBuilderImportHelper {
     }
 
     private ComponentRequirement findImportedRequirement(ComponentRequirement originalRequirement,
-            Map<ComponentJob, Object> componentBuilders) {
+            Map<ComponentJob, ComponentBuilder> componentBuilders) {
         if (originalRequirement == null) {
             return null;
         }
@@ -189,12 +209,12 @@ final class AnalysisJobBuilderImportHelper {
     }
 
     private FilterOutcome findFilterOutcome(FilterOutcome originalFilterOutcome,
-            Map<ComponentJob, Object> componentBuilders) {
+            Map<ComponentJob, ComponentBuilder> componentBuilders) {
         final HasFilterOutcomes source = originalFilterOutcome.getSource();
-        final Object builder = componentBuilders.get(source);
+        final ComponentBuilder builder = componentBuilders.get(source);
         if (builder == null) {
-            throw new IllegalStateException("Could not find builder corresponding to " + source + " in builder map: "
-                    + componentBuilders);
+            throw new IllegalStateException(
+                    "Could not find builder corresponding to " + source + " in builder map: " + componentBuilders);
         }
         final Enum<?> category = originalFilterOutcome.getCategory();
 
@@ -204,9 +224,9 @@ final class AnalysisJobBuilderImportHelper {
     }
 
     private void addComponentBuilders(Collection<? extends ComponentJob> componentJobs,
-            Map<ComponentJob, Object> componentBuilders) {
+            Map<ComponentJob, ComponentBuilder> componentBuilders) {
         for (ComponentJob componentJob : componentJobs) {
-            Object builder = _builder.addComponent(componentJob);
+            ComponentBuilder builder = _builder.addComponent(componentJob);
             componentBuilders.put(componentJob, builder);
         }
     }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingConsumerSorter.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingConsumerSorter.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.datacleaner.api.ExpressionBasedInputColumn;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.MultiStreamComponent;
 import org.datacleaner.job.ComponentJob;
 import org.datacleaner.job.FilterOutcome;
 import org.datacleaner.job.FilterOutcomes;
@@ -111,6 +112,18 @@ class RowProcessingConsumerSorter {
 						}
 					}
 				}
+			}
+			
+			if (!changed) {
+			    // handle special case where a multistream component has a requirement from another stream
+			    for (final Iterator<RowProcessingConsumer> it = remainingConsumers.iterator(); it.hasNext();) {
+	                final RowProcessingConsumer consumer = it.next();
+	                if  (consumer.getComponent() instanceof MultiStreamComponent) {
+	                    orderedConsumers.add(consumer);
+	                    it.remove();
+	                    changed = true;
+	                }
+			    }
 			}
 
 			if (!changed) {


### PR DESCRIPTION
Implements a preview function for transformers in output data streams.

Despite the claimed prerequisite described in #931 - that we should take caution into account with this - I decided to go ahead for now. Upon further thought I guess the caution-taking part can be also added later if it is deemed important. But for now I see that preview of output data streams is becoming more and more natural, especially if we add also the Grouper component (another open PR) then this should "just work".

Fixes #931 

![screen shot 2015-11-22 at 23 00 44](https://cloud.githubusercontent.com/assets/291450/11326555/e35cb2fa-916c-11e5-84fd-2531800961ca.png)
