### PR TITLE
Added ignore rule for common JUNG error

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/util/DCUncaughtExceptionHandler.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/DCUncaughtExceptionHandler.java
@@ -26,18 +26,53 @@ import org.slf4j.LoggerFactory;
 
 public final class DCUncaughtExceptionHandler implements UncaughtExceptionHandler {
 
-	private static final Logger logger = LoggerFactory.getLogger(DCUncaughtExceptionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(DCUncaughtExceptionHandler.class);
 
-	@Override
-	public void uncaughtException(Thread t, final Throwable e) {
-		logger.error("Thread " + t.getName() + " threw uncaught exception", e);
+    @Override
+    public void uncaughtException(Thread t, final Throwable e) {
+        if (isIgnoreIssue(e)) {
+            logger.debug("Ignoring uncaught exception", e);
+            return;
+        }
 
-		WidgetUtils.invokeSwingAction(new Runnable() {
-			@Override
-			public void run() {
-				WidgetUtils.showErrorMessage("Unexpected error!", e);
-			}
-		});
-	}
+        logger.error("Thread " + t.getName() + " threw uncaught exception", e);
+
+        WidgetUtils.invokeSwingAction(new Runnable() {
+            @Override
+            public void run() {
+                WidgetUtils.showErrorMessage("Unexpected error!", e);
+            }
+        });
+    }
+
+    /**
+     * Intentionally dirty (because it's hard to make this sorta stuff pretty)
+     * method used to identify known issues that we cannot do anything about
+     * 
+     * @param e
+     * @return
+     */
+    private boolean isIgnoreIssue(Throwable e) {
+        final StackTraceElement[] stackTrace = e.getStackTrace();
+        /**
+         * <pre>
+         * java.lang.NullPointerException
+         *   at java.awt.geom.RectangularShape.setFrameFromDiagonal(RectangularShape.java:271)
+         *   at edu.uci.ics.jung.visualization.control.PickingGraphMousePlugin.mouseDragged(PickingGraphMousePlugin.java:295)
+         * </pre>
+         */
+        if (e instanceof NullPointerException && stackTrace != null && stackTrace.length > 1) {
+            final StackTraceElement stack1 = stackTrace[0];
+            if ("java.awt.geom.RectangularShape".equals(stack1.getClassName())
+                    && "setFrameFromDiagonal".equals(stack1.getMethodName())) {
+                final StackTraceElement stack2 = stackTrace[1];
+                if ("edu.uci.ics.jung.visualization.control.PickingGraphMousePlugin".equals(stack2.getClassName())
+                        && "mouseDragged".equals(stack2.getMethodName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
 }


### PR DESCRIPTION
I've run into this issue a number of times and don't see any way we can "fix" it since it must be burried deep in the JUNG framework.

So instead here's a suggestion to make our "uncaught exception handler" simply ignore it.