### PR TITLE
Bug/910 error aware cancellation

### DIFF
--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingConsumerSorterTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingConsumerSorterTest.java
@@ -232,7 +232,8 @@ public class RowProcessingConsumerSorterTest extends TestCase {
 
     private List<RowProcessingConsumer> getConsumers(AnalysisJob analysisJob) {
         List<RowProcessingConsumer> consumers = new ArrayList<RowProcessingConsumer>();
-        RowProcessingPublishers publishers = new RowProcessingPublishers(analysisJob, null, null, null);
+        final ErrorAwareAnalysisListener errorListener = new ErrorAwareAnalysisListener();
+        RowProcessingPublishers publishers = new RowProcessingPublishers(analysisJob, null, errorListener, null,null);
         Table table = analysisJob.getSourceColumns().get(0)
                 .getPhysicalColumn().getTable();
         RowProcessingPublisher publisher = publishers.getRowProcessingPublisher(publishers.getStream(table));

--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingMetricsImplTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingMetricsImplTest.java
@@ -115,11 +115,11 @@ public class RowProcessingMetricsImplTest extends TestCase {
     private int getExpectedRowCount() {
         final AnalysisListener analysisListener = new InfoLoggingAnalysisListener();
         final TaskRunner taskRunner = configuration.getEnvironment().getTaskRunner();
-
+        final ErrorAwareAnalysisListener errorListener = new ErrorAwareAnalysisListener();
         final LifeCycleHelper lifeCycleHelper = new LifeCycleHelper(configuration, job, true);
 
-        final RowProcessingPublishers publishers = new RowProcessingPublishers(job, analysisListener, taskRunner,
-                lifeCycleHelper);
+        final RowProcessingPublishers publishers = new RowProcessingPublishers(job, analysisListener, errorListener,
+                taskRunner, lifeCycleHelper);
         final RowProcessingPublisher publisher = publishers.getRowProcessingPublisher(publishers.getStreams()[0]);
         publisher.initializeConsumers(new TaskListener() {
             @Override

--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingQueryOptimizerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingQueryOptimizerTest.java
@@ -109,9 +109,10 @@ public class RowProcessingQueryOptimizerTest extends TestCase {
     private RowProcessingPublisher createPublisher() {
         final AnalysisJob analysisJob = ajb.toAnalysisJob(false);
         final AnalysisListener analysisListener = new InfoLoggingAnalysisListener();
+        final ErrorAwareAnalysisListener errorListener = new ErrorAwareAnalysisListener();
         final TaskRunner taskRunner = new SingleThreadedTaskRunner();
-        final RowProcessingPublishers publishers = new RowProcessingPublishers(analysisJob, analysisListener, taskRunner,
-                lifeCycleHelper);
+        final RowProcessingPublishers publishers = new RowProcessingPublishers(analysisJob, analysisListener,
+                errorListener, taskRunner, lifeCycleHelper);
         final Table table = ajb.getSourceColumns().get(0).getPhysicalColumn().getTable();
         return publishers.getRowProcessingPublisher(publishers.getStream(table));
     }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingPublisher.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingPublisher.java
@@ -64,6 +64,11 @@ public abstract class AbstractRowProcessingPublisher implements RowProcessingPub
         _consumers = new ArrayList<RowProcessingConsumer>();
         _success = new AtomicBoolean(true);
     }
+    
+    @Override
+    public ErrorAware getErrorAware() {
+        return _publishers.getErrorAware();
+    }
 
     /**
      * Gets a {@link RowProcessingQueryOptimizer} instance from the subclass,

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisRunnerJobDelegate.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisRunnerJobDelegate.java
@@ -101,7 +101,7 @@ final class AnalysisRunnerJobDelegate {
                     _includeNonDistributedTasks);
 
             final RowProcessingPublishers publishers = new RowProcessingPublishers(_job, _analysisListener,
-                    _taskRunner, rowProcessingLifeCycleHelper);
+                    _errorAware, _taskRunner, rowProcessingLifeCycleHelper);
 
             final AnalysisJobMetrics analysisJobMetrics = publishers.getAnalysisJobMetrics();
 

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisRunnerJobDelegate.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AnalysisRunnerJobDelegate.java
@@ -168,7 +168,13 @@ final class AnalysisRunnerJobDelegate {
             }
 
             if (!progressThisIteration) {
-                _taskRunner.assistExecution();
+                try {
+                    // Give way for the data processing to happen in other
+                    // threads. Better to sleep() than to yield().
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    // do nothing
+                }
             }
         }
     }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/ConsumeRowHandler.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/ConsumeRowHandler.java
@@ -163,9 +163,12 @@ public class ConsumeRowHandler {
          */
         final SingleThreadedTaskRunner taskRunner = new SingleThreadedTaskRunner();
 
-        final AnalysisListener analysisListener = rowConsumeConfiguration.analysisListener;
+        final ErrorAwareAnalysisListener errorAwareAnalysisListener = new ErrorAwareAnalysisListener();
+        final AnalysisListener analysisListener = new CompositeAnalysisListener(
+                rowConsumeConfiguration.analysisListener, errorAwareAnalysisListener);
+
         final RowProcessingPublishers rowProcessingPublishers = new RowProcessingPublishers(analysisJob,
-                analysisListener, taskRunner, lifeCycleHelper);
+                analysisListener, errorAwareAnalysisListener, taskRunner, lifeCycleHelper);
 
         final RowProcessingPublisher publisher;
         if (rowConsumeConfiguration.table != null) {

--- a/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareAnalysisListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareAnalysisListener.java
@@ -47,11 +47,12 @@ public final class ErrorAwareAnalysisListener extends AnalysisListenerAdaptor im
     private final AtomicBoolean _cancelled = new AtomicBoolean(false);
 
     protected void handleError(AnalysisJob job, Throwable throwable) {
-        if (throwable instanceof AnalysisJobCancellation) {
+        final boolean cancellation = throwable instanceof AnalysisJobCancellation;
+        if (cancellation) {
             _cancelled.set(true);
         }
 
-        if (!(throwable instanceof PreviousErrorsExistException)) {
+        if (!cancellation && !(throwable instanceof PreviousErrorsExistException)) {
             logger.warn("Exception stack trace:", throwable);
         }
 
@@ -109,9 +110,9 @@ public final class ErrorAwareAnalysisListener extends AnalysisListenerAdaptor im
         logger.warn("errorInAnalyzer({},{},{},{})", new Object[] { job, analyzerJob, row, throwable });
         handleError(job, throwable);
     }
-
+    
     @Override
-    public void errorUknown(AnalysisJob job, Throwable throwable) {
+    public void errorUnknown(AnalysisJob job, Throwable throwable) {
         logger.warn("errorUnknown({},{})", new Object[] { job, throwable });
         handleError(job, throwable);
     }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareAnalysisListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareAnalysisListener.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * 
  * 
  */
-final class ErrorAwareAnalysisListener extends AnalysisListenerAdaptor implements ErrorAware {
+public final class ErrorAwareAnalysisListener extends AnalysisListenerAdaptor implements ErrorAware {
 
     private static final Logger logger = LoggerFactory.getLogger(ErrorAwareAnalysisListener.class);
 

--- a/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublisher.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublisher.java
@@ -112,4 +112,6 @@ public interface RowProcessingPublisher {
     public AnalysisListener getAnalysisListener();
 
     public ConsumeRowHandler createConsumeRowHandler();
+
+    public ErrorAware getErrorAware();
 }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublishers.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/RowProcessingPublishers.java
@@ -77,6 +77,7 @@ public final class RowProcessingPublishers {
     private final LifeCycleHelper _lifeCycleHelper;
     private final Map<RowProcessingStream, RowProcessingPublisher> _rowProcessingPublishers;
     private final Map<ComponentJob, RowProcessingConsumer> _consumers;
+    private final ErrorAware _errorAware;
 
     /**
      * Constructs a {@link RowProcessingPublishers}s instance.
@@ -94,7 +95,7 @@ public final class RowProcessingPublishers {
     @Deprecated
     public RowProcessingPublishers(AnalysisJob analysisJob, AnalysisListener analysisListener, TaskRunner taskRunner,
             LifeCycleHelper lifeCycleHelper, SourceColumnFinder sourceColumnFinder) {
-        this(analysisJob, analysisListener, taskRunner, lifeCycleHelper);
+        this(analysisJob, analysisListener, (ErrorAware) analysisListener, taskRunner, lifeCycleHelper);
     }
 
     /**
@@ -102,13 +103,15 @@ public final class RowProcessingPublishers {
      * 
      * @param analysisJob
      * @param analysisListener
+     * @param errorAware
      * @param taskRunner
      * @param lifeCycleHelper
      */
-    public RowProcessingPublishers(AnalysisJob analysisJob, AnalysisListener analysisListener, TaskRunner taskRunner,
-            LifeCycleHelper lifeCycleHelper) {
+    public RowProcessingPublishers(AnalysisJob analysisJob, AnalysisListener analysisListener, ErrorAware errorAware,
+            TaskRunner taskRunner, LifeCycleHelper lifeCycleHelper) {
         _analysisJob = analysisJob;
         _analysisListener = analysisListener;
+        _errorAware = errorAware;
         _taskRunner = taskRunner;
         _lifeCycleHelper = lifeCycleHelper;
 
@@ -306,9 +309,9 @@ public final class RowProcessingPublishers {
 
             _consumers.put(componentJob, consumer);
         }
-        
+
         consumer.registerPublisher(publisher);
-        
+
         return new ConsumerCreation(consumer, create);
     }
 
@@ -421,5 +424,9 @@ public final class RowProcessingPublishers {
 
         final LifeCycleHelper lifeCycleHelper = new LifeCycleHelper(injectionManager, includeNonDistributedTasks);
         return lifeCycleHelper;
+    }
+
+    public ErrorAware getErrorAware() {
+        return _errorAware;
     }
 }

--- a/engine/env/cluster/src/main/java/org/datacleaner/cluster/DistributedAnalysisRunner.java
+++ b/engine/env/cluster/src/main/java/org/datacleaner/cluster/DistributedAnalysisRunner.java
@@ -43,6 +43,7 @@ import org.datacleaner.job.runner.AnalysisListener;
 import org.datacleaner.job.runner.AnalysisResultFuture;
 import org.datacleaner.job.runner.AnalysisRunner;
 import org.datacleaner.job.runner.CompositeAnalysisListener;
+import org.datacleaner.job.runner.ErrorAwareAnalysisListener;
 import org.datacleaner.job.runner.RowProcessingMetrics;
 import org.datacleaner.job.runner.RowProcessingPublisher;
 import org.datacleaner.job.runner.RowProcessingPublishers;
@@ -328,7 +329,9 @@ public final class DistributedAnalysisRunner implements AnalysisRunner {
     private RowProcessingPublishers getRowProcessingPublishers(AnalysisJob job, LifeCycleHelper lifeCycleHelper) {
         final SingleThreadedTaskRunner taskRunner = new SingleThreadedTaskRunner();
 
-        final RowProcessingPublishers publishers = new RowProcessingPublishers(job, null, taskRunner, lifeCycleHelper);
+        final ErrorAwareAnalysisListener errorAwareAnalysisListener = new ErrorAwareAnalysisListener();
+        final RowProcessingPublishers publishers = new RowProcessingPublishers(job, errorAwareAnalysisListener,
+                errorAwareAnalysisListener, taskRunner, lifeCycleHelper);
 
         return publishers;
     }


### PR DESCRIPTION
Fixes #910 

The approach here has a few important aspects to understand what is going on:

 * The way we do cancellation is by updating the ErrorAware implementation (which is the analysis listener).
 * Now the OutputDataStreamRowCollector has access to the ErrorAware and will throw exceptions if the job is errornuous or cancelled. This exception will be used to break any long-running for loop in components that are publishing output data stream records.
 * In AnalysisRunnerJobDelegate we've had to go away from "assisting execution" to sleeping. This was to avoid that the return of AnalysisResultFuture from AnalysisRunner (in the swing worker) was blocked by a long-running task that was assisted by the AnalysisRunnerJobDelegate.