### PR TITLE
Issue #967: Fixed HDFS port text field

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/NumberDocument.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/NumberDocument.java
@@ -50,7 +50,7 @@ public class NumberDocument extends PlainDocument {
         _allowDecimal = allowDecimal;
         _allowNegative = allowNegative;
     }
-
+    
     @Override
     public void insertString(int offs, String str, AttributeSet a) throws BadLocationException {
         boolean valid = true;

--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
@@ -350,7 +350,8 @@ public final class WidgetFactory {
 
                         @Override
                         public Object stringToValue(final String text) throws ParseException {
-                            return format.parseObject(text);
+                            final Object value = format.parseObject(text);
+                            return value;
                         }
 
                         @Override
@@ -359,7 +360,8 @@ public final class WidgetFactory {
                                 return "";
                             }
 
-                            return format.format(value);
+                            final String string = format.format(value);
+                            return string;
                         }
                     };
                 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/HdfsServerAddressDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/HdfsServerAddressDialog.java
@@ -51,7 +51,9 @@ import org.jdesktop.swingx.VerticalLayout;
 public class HdfsServerAddressDialog extends JComponent {
 
     private static final long serialVersionUID = 1L;
-    
+
+    private static final int DEFAULT_PORT = 8020;
+
     private final JXTextField _hostnameField;
     private final JXFormattedTextField _portField;
     private final JButton _okButton;
@@ -70,11 +72,12 @@ public class HdfsServerAddressDialog extends JComponent {
         final NumberFormat integerFormat = NumberFormat.getIntegerInstance();
         integerFormat.setMaximumIntegerDigits(5);
         integerFormat.setMinimumIntegerDigits(1);
+        integerFormat.setGroupingUsed(false);
         _portField = WidgetFactory.createFormattedTextField("port", 4, integerFormat);
         _portField.setDocument(new NumberDocument(false, false));
-        _portField.setText("9000");
+        _portField.setText("" + DEFAULT_PORT);
         if (port == -1) {
-            _portField.setText("9000");
+            _portField.setText("" + DEFAULT_PORT);
         } else {
             _portField.setText(Integer.toString(port));
         }
@@ -86,13 +89,16 @@ public class HdfsServerAddressDialog extends JComponent {
         DCPanel propertiesPanel = new DCPanel();
         propertiesPanel.setLayout(new GridBagLayout());
         WidgetUtils.addToGridBag(DCLabel.dark("Hostname: "), propertiesPanel, 0, 0);
-        WidgetUtils.addToGridBag(_hostnameField, propertiesPanel, 1, 0, 1, 1, GridBagConstraints.WEST, WidgetUtils.DEFAULT_PADDING, 1, 1, GridBagConstraints.HORIZONTAL);
+        WidgetUtils.addToGridBag(_hostnameField, propertiesPanel, 1, 0, 1, 1, GridBagConstraints.WEST,
+                WidgetUtils.DEFAULT_PADDING, 1, 1, GridBagConstraints.HORIZONTAL);
         WidgetUtils.addToGridBag(DCLabel.dark("Port: "), propertiesPanel, 0, 1);
-        WidgetUtils.addToGridBag(_portField, propertiesPanel, 1, 1, 1, 1, GridBagConstraints.WEST, WidgetUtils.DEFAULT_PADDING, 1, 1, GridBagConstraints.HORIZONTAL);
+        WidgetUtils.addToGridBag(_portField, propertiesPanel, 1, 1, 1, 1, GridBagConstraints.WEST,
+                WidgetUtils.DEFAULT_PADDING, 1, 1, GridBagConstraints.HORIZONTAL);
 
         add(propertiesPanel);
         add(DCPanel.flow(Alignment.RIGHT, _okButton, _cancelButton));
-        setBorder(new EmptyBorder(WidgetUtils.DEFAULT_PADDING, WidgetUtils.DEFAULT_PADDING, WidgetUtils.DEFAULT_PADDING, WidgetUtils.DEFAULT_PADDING));
+        setBorder(new EmptyBorder(WidgetUtils.DEFAULT_PADDING, WidgetUtils.DEFAULT_PADDING, WidgetUtils.DEFAULT_PADDING,
+                WidgetUtils.DEFAULT_PADDING));
     }
 
     public static URI showHdfsNameNodeDialog(JComponent parent, URI oldUri) {
@@ -105,15 +111,15 @@ public class HdfsServerAddressDialog extends JComponent {
         }
 
         final HdfsServerAddressDialog serverChoiceDialog = new HdfsServerAddressDialog(host, port);
-        final JDialog dialog = WidgetFactory.createModalDialog(serverChoiceDialog, parent, "Enter HDFS namenode details", false);
+        final JDialog dialog = WidgetFactory.createModalDialog(serverChoiceDialog, parent,
+                "Enter HDFS namenode details", false);
         serverChoiceDialog._okButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(final ActionEvent aE) {
                 try {
-                    final URI uri =
-                            new URIBuilder().setScheme(HdfsUrlChooser.HDFS_SCHEME).setHost(serverChoiceDialog.
-                                    _hostnameField.getText()).setPort(Integer.parseInt(serverChoiceDialog.
-                                    _portField.getText())).setPath("/").build();
+                    final URI uri = new URIBuilder().setScheme(HdfsUrlChooser.HDFS_SCHEME)
+                            .setHost(serverChoiceDialog._hostnameField.getText())
+                            .setPort(Integer.parseInt(serverChoiceDialog._portField.getText())).setPath("/").build();
 
                     FileSystem tempFS = HdfsUtils.getFileSystemFromUri(uri);
                     tempFS.listStatus(new Path(uri));
@@ -123,10 +129,13 @@ public class HdfsServerAddressDialog extends JComponent {
                     dialog.setVisible(false);
 
                 } catch (URISyntaxException | NumberFormatException e) {
-                    JOptionPane.showMessageDialog(serverChoiceDialog, "This server address is wrong", "Wrong server address", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(serverChoiceDialog, "This server address is wrong",
+                            "Wrong server address", JOptionPane.ERROR_MESSAGE);
                 } catch (IOException e) {
-                    // _fileSystem.makeQualified will throw illegal argument is it cannot connect.
-                    JOptionPane.showMessageDialog(serverChoiceDialog, "This server address is not available", "Server unavailable", JOptionPane.ERROR_MESSAGE);
+                    // _fileSystem.makeQualified will throw illegal argument is
+                    // it cannot connect.
+                    JOptionPane.showMessageDialog(serverChoiceDialog, "This server address is not available",
+                            "Server unavailable", JOptionPane.ERROR_MESSAGE);
                 }
             }
         });


### PR DESCRIPTION
The issue was caused by the NumberFormat applying grouping (thousand
separator) which then made the FormattedTextField try to submit the
value as e.g. "8,020" instead of "8020". This then caused the
NumberDocument to reject the value and return empty string instead.

Also did a small change to update the default port from 9000 to 8020.