### PR TITLE
Issue #975: Fixed by ensuring that all reordered columns are added

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/properties/AbstractPropertyWidget.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/properties/AbstractPropertyWidget.java
@@ -149,7 +149,11 @@ public abstract class AbstractPropertyWidget<E> extends MinimalPropertyWidget<E>
     }
 
     protected void add(Component component, int index) {
-        _panel.add(component, index);
+        if (_panel.getComponentCount() <= index) {
+            _panel.add(component);
+        } else {
+            _panel.add(component, index);
+        }
     }
 
     protected Component[] getComponents() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
@@ -162,12 +162,12 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
         _buttonPanel.setLayout(new HorizontalLayout(2));
         _buttonPanel.setBorder(WidgetUtils.BORDER_CHECKBOX_LIST_INDENTATION);
 
-        JButton selectAllButton = WidgetFactory.createDefaultButton("Select all");
+        final JButton selectAllButton = WidgetFactory.createDefaultButton("Select all");
         selectAllButton.setFont(WidgetUtils.FONT_SMALL);
         selectAllButton.addActionListener(selectAllActionListener);
         _buttonPanel.add(selectAllButton);
 
-        JButton selectNoneButton = WidgetFactory.createDefaultButton("Select none");
+        final JButton selectNoneButton = WidgetFactory.createDefaultButton("Select none");
         selectNoneButton.setFont(WidgetUtils.FONT_SMALL);
         selectNoneButton.addActionListener(selectNoneActionListener);
         _buttonPanel.add(selectNoneButton);
@@ -375,9 +375,16 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     public void onPanelRemove() {
         super.onPanelRemove();
         final AnalysisJobBuilder analysisJobBuilder = getAnalysisJobBuilder();
-        logger.info("Removing listeners from {}", LabelUtils.getScopeLabel(analysisJobBuilder));
         analysisJobBuilder.removeSourceColumnChangeListener(this);
         analysisJobBuilder.removeTransformerChangeListener(this);
+
+        // remove all listeners on columns too
+        final Set<InputColumn<?>> inputColumns = _checkBoxes.keySet();
+        for (InputColumn<?> inputColumn : inputColumns) {
+            if (inputColumn instanceof MutableInputColumn) {
+                ((MutableInputColumn<?>) inputColumn).removeListener(this);
+            }
+        }
     }
 
     @Override
@@ -510,7 +517,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
     }
 
     private void addAvailableInputColumn(InputColumn<?> col, boolean selected) {
-        JComponent decoration = getOrCreateCheckBoxDecoration(col, selected);
+        final JComponent decoration = getOrCreateCheckBoxDecoration(col, selected);
         add(decoration);
     }
 
@@ -555,9 +562,10 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
 
         // reorder the visual components
         for (int i = 0; i < sortedValue.length; i++) {
-            InputColumn<?> inputColumn = sortedValue[i];
-            JComponent decoration = getOrCreateCheckBoxDecoration(inputColumn, true);
-            add(decoration, i + offset);
+            final InputColumn<?> inputColumn = sortedValue[i];
+            final JComponent decoration = getOrCreateCheckBoxDecoration(inputColumn, true);
+            final int position = offset + i;
+            add(decoration, position);
         }
         updateUI();
 
@@ -588,7 +596,7 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
             _checkBoxDecorations.put(checkBox, decoration);
 
             if (inputColumn instanceof MutableInputColumn) {
-                MutableInputColumn<?> mutableInputColumn = (MutableInputColumn<?>) inputColumn;
+                final MutableInputColumn<?> mutableInputColumn = (MutableInputColumn<?>) inputColumn;
                 mutableInputColumn.addListener(this);
                 if (mutableInputColumn.isHidden()) {
                     decoration.setVisible(false);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleInputColumnsPropertyWidget.java
@@ -240,6 +240,12 @@ public class MultipleInputColumnsPropertyWidget extends AbstractPropertyWidget<I
                 if (col instanceof ExpressionBasedInputColumn) {
                     inputColumnsToBeRemoved.remove(col);
                     availableColumns.add(col);
+                } else {
+                    if (!availableColumns.contains(col)) {
+                        logger.warn(
+                                "The value contains a column which is not found in the 'available' set of input columns: {}",
+                                col);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #975 

This issue was pretty hard to track down. The effective error was that a Swing component was added with an index to the panel in ```AbstractPropertyWidget``` while that panel did not have as many components in it as the index indicated.

But below that is maybe another issue which I honestly couldn't figure out: Why would that happen? The components of the panel are originally added via the ```updateComponents``` method. This method has some logic in it to strip out "non available columns". A column might be unavailable if it's datatype does not match the property's required type. Another reason something might be unavailable is simply if it is referenced as a property value, but it would not be returned when calling ```AnalysisJobBuilder.getAvailableInputColumn```. In this particular case I couldn't figure out what actually caused it. But should it happen, then at least the UI doesn't break anymore.