### PR TITLE
Issue #986: Decreased the amount of sample records to store in Spark

### DIFF
--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
@@ -29,6 +29,8 @@ import org.datacleaner.descriptors.ClasspathScanDescriptorProvider;
 import org.datacleaner.descriptors.DescriptorProvider;
 import org.datacleaner.job.concurrent.SingleThreadedTaskRunner;
 import org.datacleaner.job.concurrent.TaskRunner;
+import org.datacleaner.storage.InMemoryStorageProvider;
+import org.datacleaner.storage.StorageProvider;
 
 /**
  * {@link ConfigurationReaderInterceptor} for conf.xml in a Spark environment
@@ -38,8 +40,11 @@ public class SparkConfigurationReaderInterceptor extends DefaultConfigurationRea
     private static final TaskRunner TASK_RUNNER = new SingleThreadedTaskRunner();
     private static final DescriptorProvider DESCRIPTOR_PROVIDER = new ClasspathScanDescriptorProvider(TASK_RUNNER)
             .scanPackage("org.datacleaner", true).scanPackage("com.hi", true).scanPackage("com.neopost", true);
+    private static final StorageProvider STORAGE_PROVIDER = new InMemoryStorageProvider(500, 20);
+
     private static final DataCleanerEnvironment BASE_ENVIRONMENT = new DataCleanerEnvironmentImpl()
-            .withTaskRunner(TASK_RUNNER).withDescriptorProvider(DESCRIPTOR_PROVIDER);
+            .withTaskRunner(TASK_RUNNER).withDescriptorProvider(DESCRIPTOR_PROVIDER)
+            .withStorageProvider(STORAGE_PROVIDER);
 
     public SparkConfigurationReaderInterceptor(Map<String, String> customProperties) {
         super(customProperties, BASE_ENVIRONMENT);


### PR DESCRIPTION
Fixes #986 
The new setting used here is to keep up to 500 (normal) sample sets of maximum 20 records each (decreased from 500)