### PR TITLE
Making sure to close the Client object made for ElasticSearch connection

### DIFF
--- a/components/writers/src/main/java/org/datacleaner/extension/output/AbstractOutputWriterAnalyzer.java
+++ b/components/writers/src/main/java/org/datacleaner/extension/output/AbstractOutputWriterAnalyzer.java
@@ -53,14 +53,16 @@ public abstract class AbstractOutputWriterAnalyzer implements Analyzer<WriteData
 	
 	@Validate
 	public final void validateFieldNames() {
-	    final Set<String> uniqueFieldNames = new HashSet<>();
-	    for (String fieldName : fields) {
-	        final String normalizedFieldName = fieldName.trim().toLowerCase();
-            final boolean added = uniqueFieldNames.add(normalizedFieldName);
-            if (!added) {
-                throw new IllegalStateException("Field names must be unique. Field name '" + normalizedFieldName + "' occurs multiple times.");
-            }
-        }
+	    if (fields != null) {
+	        final Set<String> uniqueFieldNames = new HashSet<>();
+	        for (String fieldName : fields) {
+	            final String normalizedFieldName = fieldName.trim().toLowerCase();
+	            final boolean added = uniqueFieldNames.add(normalizedFieldName);
+	            if (!added) {
+	                throw new IllegalStateException("Field names must be unique. Field name '" + normalizedFieldName + "' occurs multiple times.");
+	            }
+	        }
+	    }
 	}
 
 	@Initialize

--- a/engine/core/src/main/java/org/datacleaner/connection/DatastoreConnectionImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/DatastoreConnectionImpl.java
@@ -19,12 +19,9 @@
  */
 package org.datacleaner.connection;
 
-import java.io.Closeable;
-import java.io.IOException;
-
+import org.apache.metamodel.DataContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.metamodel.DataContext;
 
 public class DatastoreConnectionImpl<E extends DataContext> extends UsageAwareDatastoreConnection<E> {
 
@@ -32,9 +29,9 @@ public class DatastoreConnectionImpl<E extends DataContext> extends UsageAwareDa
 
 	private final E _dataContext;
 	private final SchemaNavigator _schemaNavigator;
-	private final Closeable[] _closeables;
+	private final AutoCloseable[] _closeables;
 
-	public DatastoreConnectionImpl(E dataContext, Datastore datastore, Closeable... closeables) {
+	public DatastoreConnectionImpl(E dataContext, Datastore datastore, AutoCloseable... closeables) {
 		super(datastore);
 		_dataContext = dataContext;
 		_schemaNavigator = new SchemaNavigator(dataContext);
@@ -54,10 +51,10 @@ public class DatastoreConnectionImpl<E extends DataContext> extends UsageAwareDa
 	@Override
 	protected final void closeInternal() {
 		for (int i = 0; i < _closeables.length; i++) {
-            final Closeable closeable = _closeables[i];
+            final AutoCloseable closeable = _closeables[i];
 			try {
 				closeable.close();
-			} catch (IOException e) {
+			} catch (Exception e) {
 				logger.error("Could not close _closeables[" + i + "]", e);
 			}
 		}

--- a/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/ElasticSearchDatastore.java
@@ -22,6 +22,7 @@ package org.datacleaner.connection;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
 import java.util.List;
+
 import org.apache.metamodel.elasticsearch.ElasticSearchDataContext;
 import org.apache.metamodel.util.SimpleTableDef;
 import org.datacleaner.util.StringUtils;
@@ -78,8 +79,10 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
     }
 
     public ElasticSearchDatastore(String name, ClientType clientType, String hostname, Integer port,
-            String clusterName, String indexName, String username, String password, boolean ssl, String keystorePath, String keystorePassword) {
-        this(name, clientType, hostname, port, clusterName, indexName, null, username, password, ssl, keystorePath, keystorePassword);
+            String clusterName, String indexName, String username, String password, boolean ssl, String keystorePath,
+            String keystorePassword) {
+        this(name, clientType, hostname, port, clusterName, indexName, null, username, password, ssl, keystorePath,
+                keystorePassword);
     }
 
     public ElasticSearchDatastore(String name, ClientType clientType, String hostname, Integer port,
@@ -107,7 +110,7 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
     @Override
     protected UsageAwareDatastoreConnection<ElasticSearchDataContext> createDatastoreConnection() {
 
-        Client client;
+        final Client client;
         if (ClientType.TRANSPORT.equals(_clientType)) {
             final Builder settingsBuilder = ImmutableSettings.builder();
             settingsBuilder.put("name", "DataCleaner");
@@ -115,7 +118,7 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
             if (!StringUtils.isNullOrEmpty(_username) && !StringUtils.isNullOrEmpty(_password)) {
                 settingsBuilder.put("shield.user", _username + ":" + _password);
                 if (_ssl) {
-                    if(!Strings.isNullOrEmpty(_keystorePath)) {
+                    if (!Strings.isNullOrEmpty(_keystorePath)) {
                         settingsBuilder.put("shield.ssl.keystore.path", _keystorePath);
                         settingsBuilder.put("shield.ssl.keystore.password", _keystorePassword);
                     }
@@ -143,7 +146,8 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
         } else {
             dataContext = new ElasticSearchDataContext(client, _indexName, _tableDefs);
         }
-        return new UpdateableDatastoreConnectionImpl<ElasticSearchDataContext>(dataContext, this);
+
+        return new UpdateableDatastoreConnectionImpl<ElasticSearchDataContext>(dataContext, this, client);
     }
 
     @Override
@@ -187,11 +191,11 @@ public class ElasticSearchDatastore extends UsageAwareDatastore<ElasticSearchDat
     public boolean getSsl() {
         return _ssl;
     }
-    
+
     public String getKeystorePath() {
         return _keystorePath;
     }
-    
+
     public String getKeystorePassword() {
         return _keystorePassword;
     }

--- a/engine/core/src/main/java/org/datacleaner/connection/UpdateableDatastoreConnectionImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/UpdateableDatastoreConnectionImpl.java
@@ -19,14 +19,12 @@
  */
 package org.datacleaner.connection;
 
-import java.io.Closeable;
-
 import org.apache.metamodel.UpdateableDataContext;
 
 public class UpdateableDatastoreConnectionImpl<E extends UpdateableDataContext> extends DatastoreConnectionImpl<E> implements
 		UpdateableDatastoreConnection {
 
-	public UpdateableDatastoreConnectionImpl(E dataContext, Datastore datastore, Closeable... closeables) {
+	public UpdateableDatastoreConnectionImpl(E dataContext, Datastore datastore, AutoCloseable... closeables) {
 		super(dataContext, datastore, closeables);
 	}
 


### PR DESCRIPTION
This should ensure that we keep the client objects created for ElasticSearch under control - that we don't let them linger but close them once the datastore connection is closed.

__PLEASE AWAIT CONFIRMATION BEFORE MERGING__