### PR TITLE
Improved ability to track (log) and release early DatastoreConnections

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/SchemaTreePanel.java
@@ -86,6 +86,20 @@ public class SchemaTreePanel extends DCPanel {
         setFocusable(true);
     }
 
+    /**
+     * Method invoked when this panel is not longer shown to the user (typically
+     * because there is no longer any open datastore / job).
+     * 
+     * Note: This method is here because the {@link #removeNotify()} method is
+     * not invoked by the layout manager of the parent window.
+     */
+    public void onPanelHiding() {
+        resetSearch();
+        // remove children to notify them
+        removeAll();
+        updateParentPanel();
+    }
+
     public void setDatastore(final Datastore datastore, final boolean expandTree) {
         removeAll();
         if (datastore == null) {
@@ -197,7 +211,7 @@ public class SchemaTreePanel extends DCPanel {
             return;
         }
         _searchTextField.setText("");
-        _schemaTree.filter("");        
+        _schemaTree.filter("");
     }
 
     protected JXTextField createSearchTextField() {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -447,7 +447,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     public void changePanel(AnalysisWindowPanelType panel) {
         if (_datastore == null) {
             _currentPanelType = panel;
-            _schemaTreePanel.resetSearch();
+            _schemaTreePanel.onPanelHiding();
         } else {
             _currentPanelType = AnalysisWindowPanelType.EDITING_CONTEXT;
         }

--- a/engine/core/src/main/java/org/datacleaner/connection/UsageAwareDatastoreConnection.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/UsageAwareDatastoreConnection.java
@@ -20,6 +20,8 @@
 package org.datacleaner.connection;
 
 import org.datacleaner.util.UsageAwareCloseable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.metamodel.DataContext;
 
 /**
@@ -30,9 +32,11 @@ import org.apache.metamodel.DataContext;
  */
 public abstract class UsageAwareDatastoreConnection<E extends DataContext> extends UsageAwareCloseable implements DatastoreConnection {
 
+    private static final Logger logger = LoggerFactory.getLogger(UsageAwareDatastoreConnection.class);
     private final Datastore _datastore;
 
     public UsageAwareDatastoreConnection(Datastore datastore) {
+        super(logger);
         _datastore = datastore;
     }
 

--- a/engine/core/src/main/java/org/datacleaner/util/UsageAwareCloseable.java
+++ b/engine/core/src/main/java/org/datacleaner/util/UsageAwareCloseable.java
@@ -46,7 +46,7 @@ public abstract class UsageAwareCloseable implements Closeable {
         }
     }
 
-    private static final int STACK_TRACE_ELEMENTS_TO_LOG = 7;
+    private static final int STACK_TRACE_ELEMENTS_TO_LOG = 20;
 
     private final Logger _logger;
 
@@ -74,7 +74,7 @@ public abstract class UsageAwareCloseable implements Closeable {
 
     private void logNearestStack() {
         StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-        for (int i = 1; i < stackTrace.length && i < 7; i++) {
+        for (int i = 1; i < stackTrace.length && i < STACK_TRACE_ELEMENTS_TO_LOG; i++) {
             StackTraceElement ste = stackTrace[i];
             _logger.debug(" - {} @ line {}", ste.getClassName(), ste.getLineNumber());
         }


### PR DESCRIPTION
I found that the UI was holding a DatastoreConnection even after closing a job. It turned out that this was because the schema tree holds on to it, even after being hidden.

To find out all this I had to use the UsageAwareCloseable logging mechanisms.