### PR TITLE
Bug/1027 unwanted requests on job window closing

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalysisJobBuilder.java
@@ -1192,11 +1192,21 @@ public final class AnalysisJobBuilder implements Closeable {
     }
 
     public void removeAllSourceColumns() {
-        final List<MetaModelInputColumn> sourceColumns = new ArrayList<>(_sourceColumns);
-        for (MetaModelInputColumn inputColumn : sourceColumns) {
-            removeSourceColumn(inputColumn);
+        final Collection<ComponentBuilder> componentBuilders = getComponentBuilders();
+
+        for (ComponentBuilder componentBuilder : componentBuilders) {
+            componentBuilder.clearInputColumns();
         }
-        assert _sourceColumns.isEmpty();
+
+        final List<SourceColumnChangeListener> listeners = new ArrayList<>(_sourceColumnListeners);
+
+        for (SourceColumnChangeListener listener : listeners) {
+            for (MetaModelInputColumn inputColumn : _sourceColumns) {
+                listener.onRemove(inputColumn);
+            }
+        }
+
+        _sourceColumns.clear();
     }
 
     public void removeAllAnalyzers() {

--- a/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
@@ -59,8 +59,8 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
 
     private static final Logger logger = LoggerFactory.getLogger(TransformerComponentBuilder.class);
     private final String _id;
-    private final List<MutableInputColumn<?>> _outputColumns = new ArrayList<MutableInputColumn<?>>();
-    private final List<String> _automaticOutputColumnNames = new ArrayList<String>();
+    private final List<MutableInputColumn<?>> _outputColumns = new ArrayList<>();
+    private final List<String> _automaticOutputColumnNames = new ArrayList<>();
     private final IdGenerator _idGenerator;
     private final List<TransformerChangeListener> _localChangeListeners;
 
@@ -69,14 +69,14 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
         super(analysisJobBuilder, descriptor, TransformerComponentBuilder.class);
         _id = "trans-" + idGenerator.nextId();
         _idGenerator = idGenerator;
-        _localChangeListeners = new ArrayList<TransformerChangeListener>(0);
+        _localChangeListeners = new ArrayList<>(0);
     }
 
     /**
      * Gets the output column of this transformation with it's current
      * configuration.
      * 
-     * @return
+     * @return transformer's output columns
      */
     public List<MutableInputColumn<?>> getOutputColumns() {
         final Component component = getComponentInstanceForQuestioning();
@@ -117,7 +117,7 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
                     final int nextIndex = _outputColumns.size();
                     final String name = getColumnName(outputColumns, nextIndex);
                     final String id = _id + "-" + _idGenerator.nextId();
-                    _outputColumns.add(new TransformedInputColumn<Object>(name, id));
+                    _outputColumns.add(new TransformedInputColumn<>(name, id));
                     _automaticOutputColumnNames.add(name);
                 }
             } else if (colDiff < 0) {
@@ -221,13 +221,13 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
     /**
      * Builds a temporary list of all listeners, both global and local
      * 
-     * @return
+     * @return a list of global and local listeners
      */
     private List<TransformerChangeListener> getAllListeners() {
         @SuppressWarnings("deprecation")
         List<TransformerChangeListener> globalChangeListeners = getAnalysisJobBuilder().getTransformerChangeListeners();
 
-        List<TransformerChangeListener> list = new ArrayList<TransformerChangeListener>(globalChangeListeners.size()
+        List<TransformerChangeListener> list = new ArrayList<>(globalChangeListeners.size()
                 + _localChangeListeners.size());
         list.addAll(globalChangeListeners);
         list.addAll(_localChangeListeners);
@@ -239,8 +239,8 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
      * 
      * @see #getOutputColumns()
      * 
-     * @param name
-     * @return
+     * @param name name of the output column
+     * @return output column
      */
     public MutableInputColumn<?> getOutputColumnByName(String name) {
         if (StringUtils.isNullOrEmpty(name)) {
@@ -306,7 +306,7 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
     /**
      * Adds a change listener to this component
      * 
-     * @param listener
+     * @param listener a new change listener
      */
     public void addChangeListener(TransformerChangeListener listener) {
         _localChangeListeners.add(listener);
@@ -315,7 +315,7 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
     /**
      * Removes a change listener from this component
      * 
-     * @param listener
+     * @param listener the change listener to be removed
      * @return whether or not the listener was found and removed.
      */
     public boolean removeChangeListener(TransformerChangeListener listener) {


### PR DESCRIPTION
Fix for a bug #1027. 

A job with a remote component in it. When trying to close the job window with "discard changes" option there are additional/unwanted HTTP requests to get output columns of the remote component. When the remote server is down, this can freeze the GUI for some time. 

### Question
How to deal with the problem? 

I logged the event and returned empty list of output columns. 

Alternative would be to throw an IllegalStateException. I tried it and it causes another problem. After closing job window there is a dialog with option "discard changes". When this option is clicked, the exception dialog window appears but even after closing this exception dialog the job window is not closed. In this situation I did not find the way how to get rid of the "broken" job window. There already is a "throw new IllegalStateException" in the TransformerComponentBuilder.getOutputColumns method. This causes the same problem (but probably the condition has never occurred or the bug was ignored). 

