### PR TITLE
Assemble spark module for mapr compatiblity

### DIFF
--- a/Formatter-Eclipse.xml
+++ b/Formatter-Eclipse.xml
@@ -132,7 +132,7 @@
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
@@ -262,7 +262,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>

--- a/desktop/ui/src/main/java/org/datacleaner/guice/DCModuleImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/guice/DCModuleImpl.java
@@ -394,7 +394,7 @@ public class DCModuleImpl extends AbstractModule implements DCModule {
         handlers.add(new DummyRepositoryResourceFileTypeHandler());
 
         final ResourceConverter resourceConverter = new ResourceConverter(handlers,
-                ResourceConverter.DEFAULT_DEFAULT_SCHEME);
+                ResourceConverter.getConfiguredDefaultScheme());
         return resourceConverter;
     }
 

--- a/engine/core/src/main/java/org/datacleaner/configuration/DefaultConfigurationReaderInterceptor.java
+++ b/engine/core/src/main/java/org/datacleaner/configuration/DefaultConfigurationReaderInterceptor.java
@@ -96,7 +96,7 @@ public class DefaultConfigurationReaderInterceptor implements ConfigurationReade
     @Override
     public Resource createResource(String resourceUrl) {
         final ResourceConverter converter = new ResourceConverter(getResourceTypeHandlers(),
-                ResourceConverter.DEFAULT_DEFAULT_SCHEME);
+                ResourceConverter.getConfiguredDefaultScheme());
         final Resource resource = converter.fromString(Resource.class, resourceUrl);
         return resource;
     }

--- a/engine/core/src/main/java/org/datacleaner/util/HadoopResource.java
+++ b/engine/core/src/main/java/org/datacleaner/util/HadoopResource.java
@@ -32,9 +32,14 @@ public class HadoopResource extends HdfsResource {
         super(url);
         _configuration = configuration;
     }
-    
+
     @Override
     public Configuration getHadoopConfiguration() {
         return _configuration;
+    }
+
+    @Override
+    public String toString() {
+        return "HadoopResource[" + getQualifiedPath() + "]";
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/util/HadoopResource.java
+++ b/engine/core/src/main/java/org/datacleaner/util/HadoopResource.java
@@ -19,8 +19,11 @@
  */
 package org.datacleaner.util;
 
+import java.net.URI;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.metamodel.util.HdfsResource;
+import org.apache.metamodel.util.Resource;
 
 public class HadoopResource extends HdfsResource {
 
@@ -28,8 +31,13 @@ public class HadoopResource extends HdfsResource {
 
     private final Configuration _configuration;
 
-    public HadoopResource(String url, Configuration configuration) {
-        super(url);
+    public HadoopResource(URI uri, Configuration configuration) {
+        super(uri.toString());
+        _configuration = configuration;
+    }
+
+    public HadoopResource(Resource resource, Configuration configuration) {
+        super(resource.getQualifiedPath());
         _configuration = configuration;
     }
 

--- a/engine/core/src/main/java/org/datacleaner/util/SystemProperties.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SystemProperties.java
@@ -61,6 +61,12 @@ public class SystemProperties {
     public static final String SANDBOX = "datacleaner.sandbox";
 
     /**
+     * Property used to determine the default scheme, which is normally "file",
+     * but could be set to e.g. "hdfs" for Hadoop environments etc.
+     */
+    public static final String DEFAULT_RESOURCE_SCHEME = "datacleaner.resources.scheme.default";
+
+    /**
      * Property used for keeping the license key for commercial DataCleaner
      * editions.
      */
@@ -203,5 +209,12 @@ public class SystemProperties {
         }
 
         return valueIfNull;
+    }
+
+    public static void setIfNotSpecified(String property, String value) {
+        final String existingValue = System.getProperty(property);
+        if (Strings.isNullOrEmpty(existingValue)) {
+            System.setProperty(property, value);
+        }
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/util/convert/ResourceConverter.java
+++ b/engine/core/src/main/java/org/datacleaner/util/convert/ResourceConverter.java
@@ -172,7 +172,7 @@ public class ResourceConverter implements Converter<Resource> {
     public ResourceConverter(ResourceTypeHandler<?>... handlers) {
         this(Arrays.asList(handlers), getConfiguredDefaultScheme());
     }
-
+    
     @Override
     public Resource fromString(Class<?> type, String serializedForm) {
         final ResourceStructure structure = parseStructure(serializedForm);

--- a/engine/core/src/main/java/org/datacleaner/util/convert/ResourceConverter.java
+++ b/engine/core/src/main/java/org/datacleaner/util/convert/ResourceConverter.java
@@ -36,6 +36,7 @@ import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
 import org.datacleaner.configuration.DataCleanerHomeFolder;
 import org.datacleaner.util.ReflectionUtils;
+import org.datacleaner.util.SystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,16 +52,30 @@ public class ResourceConverter implements Converter<Resource> {
     /**
      * Represents the default "default scheme", for representations that does
      * not have a scheme in the path. This default scheme is "file".
+     * 
+     * @deprecated use {@link #getConfiguredDefaultScheme()} by as a way to
+     *             access this
      */
+    @Deprecated
     public static final String DEFAULT_DEFAULT_SCHEME = FileResourceTypeHandler.DEFAULT_SCHEME;
 
     private static final Pattern RESOURCE_PATTERN = Pattern.compile("\\b([a-zA-Z]+)://(.+)");
+
+    /**
+     * Gets the "default scheme" (see {@link #DEFAULT_DEFAULT_SCHEME}) while
+     * taking into account that this may have been configured via
+     * {@link SystemProperties#DEFAULT_RESOURCE_SCHEME}.
+     * 
+     * @return
+     */
+    public static String getConfiguredDefaultScheme() {
+        return SystemProperties.getString(SystemProperties.DEFAULT_RESOURCE_SCHEME, DEFAULT_DEFAULT_SCHEME);
+    }
 
     public static Collection<? extends ResourceTypeHandler<?>> createDefaultHandlers(
             DataCleanerConfiguration configuration) {
         return createDefaultHandlers(configuration.getHomeFolder());
     }
-    
 
     public static List<ResourceTypeHandler<?>> createDefaultHandlers(DataCleanerHomeFolder homeFolder) {
         final List<ResourceTypeHandler<?>> result = new ArrayList<>();
@@ -128,11 +143,11 @@ public class ResourceConverter implements Converter<Resource> {
     }
 
     public ResourceConverter(DataCleanerConfiguration configuration) {
-        this(configuration, DEFAULT_DEFAULT_SCHEME);
+        this(configuration, getConfiguredDefaultScheme());
     }
 
     public ResourceConverter(Collection<? extends ResourceTypeHandler<?>> handlers) {
-        this(handlers, DEFAULT_DEFAULT_SCHEME);
+        this(handlers, getConfiguredDefaultScheme());
     }
 
     public ResourceConverter(DataCleanerConfiguration configuration, String defaultScheme) {
@@ -155,7 +170,7 @@ public class ResourceConverter implements Converter<Resource> {
     }
 
     public ResourceConverter(ResourceTypeHandler<?>... handlers) {
-        this(Arrays.asList(handlers), DEFAULT_DEFAULT_SCHEME);
+        this(Arrays.asList(handlers), getConfiguredDefaultScheme());
     }
 
     @Override

--- a/engine/core/src/test/java/org/datacleaner/configuration/DataCleanerConfigurationUpdaterTest.java
+++ b/engine/core/src/test/java/org/datacleaner/configuration/DataCleanerConfigurationUpdaterTest.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
-import org.apache.metamodel.util.InMemoryResource;
 import org.apache.metamodel.util.Resource;
 import org.datacleaner.util.SecurityUtils;
 import org.junit.Assert;

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.spark;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -49,12 +50,12 @@ public class Main {
         final SparkConf conf = new SparkConf().setAppName("DataCleaner-spark");
         final JavaSparkContext sparkContext = new JavaSparkContext(conf);
 
-        final String confXmlPath = args[0];
-        final String analysisJobXmlPath = args[1];
+        final URI confXmlPath = URI.create(args[0]);
+        final URI analysisJobXmlPath = URI.create(args[1]);
 
-        final String propertiesPath;
+        final URI propertiesPath;
         if (args.length > 2) {
-            propertiesPath = args[2];
+            propertiesPath = URI.create(args[2]);
         } else {
             propertiesPath = null;
         }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
@@ -45,7 +45,7 @@ public class Main {
                     + " <configuration file (conf.xml) path> <job file (.analysis.xml) path> [properties file path]\n"
                     + "Got: " + Arrays.toString(args));
         }
-
+        
         final SparkConf conf = new SparkConf().setAppName("DataCleaner-spark");
         final JavaSparkContext sparkContext = new JavaSparkContext(conf);
 

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/Main.java
@@ -45,7 +45,7 @@ public class Main {
                     + " <configuration file (conf.xml) path> <job file (.analysis.xml) path> [properties file path]\n"
                     + "Got: " + Arrays.toString(args));
         }
-        
+
         final SparkConf conf = new SparkConf().setAppName("DataCleaner-spark");
         final JavaSparkContext sparkContext = new JavaSparkContext(conf);
 
@@ -81,7 +81,8 @@ public class Main {
     }
 
     private static void saveResult(AnalysisResultFuture result, Resource resultResource) {
-        final AnalysisResultSaveHandler analysisResultSaveHandler = new AnalysisResultSaveHandler(result, resultResource);
+        final AnalysisResultSaveHandler analysisResultSaveHandler = new AnalysisResultSaveHandler(result,
+                resultResource);
         try {
             analysisResultSaveHandler.saveOrThrow();
         } catch (SerializationException e) {
@@ -94,7 +95,8 @@ public class Main {
                         .getUnsafeResultElements();
                 logger.error("Serialization of result failed with the following unsafe elements: {}",
                         unsafeResultElements);
-                logger.warn("Partial AnalysisResult will be persisted to filename '{}'", resultResource.getQualifiedPath());
+                logger.warn("Partial AnalysisResult will be persisted to filename '{}'",
+                        resultResource.getQualifiedPath());
 
                 analysisResultSaveHandler.saveWithoutUnsafeResultElements();
             }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.spark;
 
+import java.net.URI;
 import java.util.Map;
 
 import org.apache.metamodel.util.Resource;
@@ -47,17 +48,18 @@ public class SparkConfigurationReaderInterceptor extends DefaultConfigurationRea
     private static final DataCleanerEnvironment BASE_ENVIRONMENT = new DataCleanerEnvironmentImpl()
             .withTaskRunner(TASK_RUNNER).withDescriptorProvider(DESCRIPTOR_PROVIDER)
             .withStorageProvider(STORAGE_PROVIDER);
-    
+
     private final HdfsHelper _hdfsHelper;
 
     public SparkConfigurationReaderInterceptor(Map<String, String> customProperties) {
         super(customProperties, BASE_ENVIRONMENT);
         _hdfsHelper = HdfsHelper.createHelper();
     }
-    
+
     @Override
     public Resource createResource(String resourceUrl) {
-        return _hdfsHelper.getResourceToUse(resourceUrl);
+        final URI uri = URI.create(resourceUrl);
+        return _hdfsHelper.getResourceToUse(uri);
     }
 
 }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
@@ -21,6 +21,7 @@ package org.datacleaner.spark;
 
 import java.util.Map;
 
+import org.apache.metamodel.util.Resource;
 import org.datacleaner.configuration.ConfigurationReaderInterceptor;
 import org.datacleaner.configuration.DataCleanerEnvironment;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
@@ -29,6 +30,7 @@ import org.datacleaner.descriptors.ClasspathScanDescriptorProvider;
 import org.datacleaner.descriptors.DescriptorProvider;
 import org.datacleaner.job.concurrent.SingleThreadedTaskRunner;
 import org.datacleaner.job.concurrent.TaskRunner;
+import org.datacleaner.spark.utils.HdfsHelper;
 import org.datacleaner.storage.InMemoryStorageProvider;
 import org.datacleaner.storage.StorageProvider;
 
@@ -45,9 +47,17 @@ public class SparkConfigurationReaderInterceptor extends DefaultConfigurationRea
     private static final DataCleanerEnvironment BASE_ENVIRONMENT = new DataCleanerEnvironmentImpl()
             .withTaskRunner(TASK_RUNNER).withDescriptorProvider(DESCRIPTOR_PROVIDER)
             .withStorageProvider(STORAGE_PROVIDER);
+    
+    private final HdfsHelper _hdfsHelper;
 
     public SparkConfigurationReaderInterceptor(Map<String, String> customProperties) {
         super(customProperties, BASE_ENVIRONMENT);
+        _hdfsHelper = HdfsHelper.createHelper();
+    }
+    
+    @Override
+    public Resource createResource(String resourceUrl) {
+        return _hdfsHelper.getResourceToUse(resourceUrl);
     }
 
 }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -80,8 +80,8 @@ public class SparkJobContext implements Serializable {
 
         _configurationXml = hdfsHelper.readFile(dataCleanerConfigurationPath, true);
         if (Strings.isNullOrEmpty(_configurationXml)) {
-            throw new IllegalArgumentException(
-                    "Failed to read content from configuration file: " + dataCleanerConfigurationPath);
+            throw new IllegalArgumentException("Failed to read content from configuration file: "
+                    + dataCleanerConfigurationPath);
         }
 
         _analysisJobXml = hdfsHelper.readFile(analysisJobXmlPath, true);
@@ -95,8 +95,8 @@ public class SparkJobContext implements Serializable {
         } else {
             // this is a pretty ugly way to go back to the bytes to read the
             // properties - but works and is quick
-            _customProperties = new InputStreamToPropertiesMapFunc()
-                    .eval(new ByteArrayInputStream(propertiesString.getBytes()));
+            _customProperties = new InputStreamToPropertiesMapFunc().eval(new ByteArrayInputStream(propertiesString
+                    .getBytes()));
         }
         validateCustomProperties();
     }
@@ -168,8 +168,8 @@ public class SparkJobContext implements Serializable {
             AtomicInteger currentComponentIndex) {
         final Collection<ComponentBuilder> componentBuilders = analysisJobBuilder.getComponentBuilders();
         for (ComponentBuilder componentBuilder : componentBuilders) {
-            componentBuilder.setMetadataProperty(METADATA_PROPERTY_COMPONENT_INDEX,
-                    Integer.toString(currentComponentIndex.getAndIncrement()));
+            componentBuilder.setMetadataProperty(METADATA_PROPERTY_COMPONENT_INDEX, Integer.toString(
+                    currentComponentIndex.getAndIncrement()));
         }
 
         final List<AnalysisJobBuilder> childJobBuilders = analysisJobBuilder.getConsumedOutputDataStreamsJobBuilders();

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -42,6 +42,7 @@ import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.spark.utils.HdfsHelper;
 import org.datacleaner.util.InputStreamToPropertiesMapFunc;
+import org.datacleaner.util.SystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,6 +134,9 @@ public class SparkJobContext implements Serializable {
 
     public AnalysisJobBuilder getAnalysisJobBuilder() {
         if (_analysisJobBuilder == null) {
+            // set HDFS as default scheme to avoid file resources
+            SystemProperties.setIfNotSpecified(SystemProperties.DEFAULT_RESOURCE_SCHEME, "hdfs");
+            
             final DataCleanerConfiguration configuration = getConfiguration();
             final JaxbJobReader jobReader = new JaxbJobReader(configuration);
             _analysisJobBuilder = jobReader.create(createInputStream(_analysisJobXml), _customProperties);

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
@@ -20,6 +20,7 @@
 package org.datacleaner.spark.functions;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -185,7 +186,8 @@ public final class RowProcessingFunction
         final String formattedPartitionNumber = String.format("%05d", partitionNumber);
         if (resource instanceof HdfsResource || resource instanceof HadoopResource) {
             final String path = resource.getQualifiedPath() + "/part-" + formattedPartitionNumber;
-            final Resource replacementResource = HdfsHelper.createHelper().getResourceToUse(path);
+            final URI uri = URI.create(path);
+            final Resource replacementResource = HdfsHelper.createHelper().getResourceToUse(uri);
             return replacementResource;
         }
         if (resource instanceof FileResource) {

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/functions/RowProcessingFunction.java
@@ -72,8 +72,8 @@ import scala.Tuple2;
  * This class implements two interfaces because it has two (quite similar)
  * styles of usages in the {@link SparkAnalysisRunner}.
  */
-public final class RowProcessingFunction
-        implements Function2<Integer, Iterator<InputRow>, Iterator<Tuple2<String, NamedAnalyzerResult>>>,
+public final class RowProcessingFunction implements
+        Function2<Integer, Iterator<InputRow>, Iterator<Tuple2<String, NamedAnalyzerResult>>>,
         PairFlatMapFunction<Iterator<InputRow>, String, NamedAnalyzerResult> {
 
     private static final Logger logger = LoggerFactory.getLogger(RowProcessingFunction.class);
@@ -200,8 +200,8 @@ public final class RowProcessingFunction
             if (!file.exists()) {
                 file.mkdirs();
             }
-            final FileResource fileResource = new FileResource(
-                    resource.getQualifiedPath() + "/part-" + formattedPartitionNumber);
+            final FileResource fileResource = new FileResource(resource.getQualifiedPath() + "/part-"
+                    + formattedPartitionNumber);
             return fileResource;
         }
         return null;
@@ -226,8 +226,8 @@ public final class RowProcessingFunction
             return new JsonDatastore(name, replacementResource, ((JsonDatastore) datastore).getSchemaBuilder());
         }
 
-        logger.warn("Could not replace datastore '{}' because it is of an unsupported type: ", name,
-                datastore.getClass().getSimpleName());
+        logger.warn("Could not replace datastore '{}' because it is of an unsupported type: ", name, datastore
+                .getClass().getSimpleName());
         return datastore;
     }
 
@@ -254,8 +254,8 @@ public final class RowProcessingFunction
         logger.info("Row processing complete - continuing to fetching results");
 
         // collect results
-        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = getAnalyzerResults(
-                consumeRowHandler.getConsumers());
+        final List<Tuple2<String, NamedAnalyzerResult>> analyzerResults = getAnalyzerResults(consumeRowHandler
+                .getConsumers());
 
         // await any future results
         for (ListIterator<Tuple2<String, NamedAnalyzerResult>> it = analyzerResults.listIterator(); it.hasNext();) {

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/utils/HdfsHelper.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/utils/HdfsHelper.java
@@ -19,16 +19,22 @@
  */
 package org.datacleaner.spark.utils;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Func;
 import org.apache.metamodel.util.HdfsResource;
 import org.apache.metamodel.util.Resource;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.deploy.SparkHadoopUtil;
 import org.datacleaner.util.HadoopResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
@@ -37,18 +43,66 @@ import com.google.common.base.Strings;
  */
 public class HdfsHelper {
 
+    private static final Logger logger = LoggerFactory.getLogger(HdfsHelper.class);
+
+    private static Configuration _lastKnownConfiguration;
     private final Configuration _hadoopConfiguration;
 
+    /**
+     * Creates a {@link HdfsHelper} without any configuration or context
+     * available. This is normally not the recommended way to obtain a
+     * {@link HdfsHelper} but may be necessary in executor functions where the
+     * {@link JavaSparkContext} is not in scope and not made available by Spark
+     * (at least spark's end-user API).
+     * 
+     * @return
+     */
+    public static HdfsHelper createHelper() {
+        Configuration configuration = _lastKnownConfiguration;
+        if (configuration == null) {
+            try {
+                final SparkHadoopUtil sparkHadoopUtil = SparkHadoopUtil.get();
+                if (sparkHadoopUtil.isYarnMode()) {
+                    configuration = sparkHadoopUtil.conf();
+                }
+            } catch (Exception e) {
+                // the above is developer API so we don't consider it very
+                // stable.
+            }
+        }
+        return new HdfsHelper(configuration);
+    }
+
     public HdfsHelper(JavaSparkContext sparkContext) {
-        this(sparkContext.hadoopConfiguration());
+        this(getHadoopConfigurationIfYarnMode(sparkContext));
+    }
+
+    private static Configuration getHadoopConfigurationIfYarnMode(JavaSparkContext sparkContext) {
+        final String sparkMaster = sparkContext.getConf().get("spark.master");
+        if (Strings.isNullOrEmpty(sparkMaster) || "local".equals(sparkMaster)) {
+            return null;
+        }
+        return sparkContext.hadoopConfiguration();
     }
 
     public HdfsHelper(Configuration configuration) {
+        if (configuration == null) {
+            logger.warn("Hadoop Configuration is null!", new Throwable());
+        } else {
+            _lastKnownConfiguration = configuration;
+        }
         _hadoopConfiguration = configuration;
     }
 
     public String readFile(String filepath) {
+        return readFile(filepath, false);
+    }
+
+    public String readFile(String filepath, boolean failOnNoData) {
         final Resource resourceInUse = getResourceToUse(filepath);
+        if (failOnNoData && resourceInUse == null) {
+            throw new IllegalArgumentException("Could not resolve resource: " + filepath);
+        }
         return readResource(resourceInUse);
     }
 
@@ -91,6 +145,7 @@ public class HdfsHelper {
         if (Strings.isNullOrEmpty(path)) {
             return null;
         }
+        path = path.trim();
         if (_hadoopConfiguration == null) {
             if (path.toLowerCase().startsWith("hdfs:")) {
                 return new HdfsResource(path);
@@ -98,5 +153,26 @@ public class HdfsHelper {
             return new FileResource(path);
         }
         return new HadoopResource(path, _hadoopConfiguration);
+    }
+
+    public boolean isDirectory(String path) {
+        final Resource resource = getResourceToUse(path);
+        if (!resource.isExists()) {
+            return false;
+        }
+        if (resource instanceof FileResource) {
+            return ((FileResource) resource).getFile().isDirectory();
+        }
+        if (resource instanceof HdfsResource) {
+            final FileSystem fileSystem = ((HdfsResource) resource).getHadoopFileSystem();
+            final Path hadoopPath = ((HdfsResource) resource).getHadoopPath();
+            try {
+                return fileSystem.isDirectory(hadoopPath);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        // actually we don't know, but most likely it's not a directory
+        return false;
     }
 }

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/utils/ResultFilePathUtils.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/utils/ResultFilePathUtils.java
@@ -19,12 +19,12 @@
  */
 package org.datacleaner.spark.utils;
 
+import java.net.URI;
+
 import org.apache.metamodel.util.Resource;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.datacleaner.spark.SparkJobContext;
 import org.datacleaner.util.FileFilters;
-
-import com.google.common.base.Strings;
 
 public class ResultFilePathUtils {
 
@@ -47,15 +47,15 @@ public class ResultFilePathUtils {
             final SparkJobContext sparkJobContext) {
         final HdfsHelper hdfsHelper = new HdfsHelper(sparkContext);
 
-        final String resultPath;
-        if (Strings.isNullOrEmpty(sparkJobContext.getResultPath())) {
-            resultPath = DEFAULT_RESULT_PATH + '/' + generateResultFilename(sparkJobContext);
+        URI resultPath = sparkJobContext.getResultPath();
+        if (resultPath == null) {
+            resultPath = URI.create(DEFAULT_RESULT_PATH + '/' + generateResultFilename(sparkJobContext));
         } else {
-            if (hdfsHelper.isDirectory(sparkJobContext.getResultPath())) {
-                if (sparkJobContext.getResultPath().endsWith("/")) {
-                    resultPath = sparkJobContext.getResultPath() + generateResultFilename(sparkJobContext);
+            if (hdfsHelper.isDirectory(resultPath)) {
+                if (resultPath.toString().endsWith("/")) {
+                    resultPath = URI.create(resultPath.toString() + generateResultFilename(sparkJobContext));
                 } else {
-                    resultPath = sparkJobContext.getResultPath() + '/' + generateResultFilename(sparkJobContext);
+                    resultPath = URI.create(resultPath.toString() + '/' + generateResultFilename(sparkJobContext));
                 }
             } else {
                 resultPath = sparkJobContext.getResultPath();

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/utils/ResultFilePathUtils.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/utils/ResultFilePathUtils.java
@@ -19,86 +19,54 @@
  */
 package org.datacleaner.spark.utils;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Date;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.log4j.Logger;
+import org.apache.metamodel.util.Resource;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.datacleaner.spark.SparkJobContext;
 import org.datacleaner.util.FileFilters;
 
-public class ResultFilePathUtils {
+import com.google.common.base.Strings;
 
-    private static final Logger logger = Logger.getLogger(ResultFilePathUtils.class);
+public class ResultFilePathUtils {
 
     private static final String DEFAULT_RESULT_PATH = "/datacleaner/results";
     private static final String RESULT_FILE_EXTENSION = FileFilters.ANALYSIS_RESULT_SER.getExtension();
 
     /**
-     * Gets the hdfs path of job's result. The path can be configured in the job
-     * properties file with property 'datacleaner.result.hdfs.path'. The path
-     * can be absolute(
+     * Gets the Resource to use for the job's result. The path can be configured
+     * in the job properties file with property 'datacleaner.result.hdfs.path'.
+     * The path can be absolute(
      * 'hdfs://[hostname]:[port]/myresults/myjob.analysis.result.dat') or
      * relative('/myresults/myjob.analysis.result.dat'). If no path is set in
      * the properties file and the system is configured to save the results, the
      * default path will be saved to
      * '/datacleaner/results/[jobname]-[timestamp].analysis.result.dat
      * 
-     * @throws URISyntaxException
-     * 
-     * @retur
+     * @return a Resource to use
      */
-    public static String getResultFilePath(final JavaSparkContext sparkContext, final SparkJobContext sparkJobContext)
-            throws URISyntaxException {
-        String resultPath = sparkJobContext.getResultPath();
-        final Configuration hadoopConfiguration = sparkContext.hadoopConfiguration();
-        /**
-         * The default value would be read from hadoop configuration at runtime
-         * from core-site.xml. It represents the machine's hostname and port.
-         * Example: hdfs://bigdatavm:9000
-         **/
-        final String fileSystemPrefix = hadoopConfiguration.get("fs.defaultFS");
-        if (resultPath == null || resultPath.isEmpty()) {
-            resultPath = createPath(fileSystemPrefix, DEFAULT_RESULT_PATH);
+    public static Resource getResultResource(final JavaSparkContext sparkContext,
+            final SparkJobContext sparkJobContext) {
+        final HdfsHelper hdfsHelper = new HdfsHelper(sparkContext);
+
+        final String resultPath;
+        if (Strings.isNullOrEmpty(sparkJobContext.getResultPath())) {
+            resultPath = DEFAULT_RESULT_PATH + '/' + generateResultFilename(sparkJobContext);
         } else {
-            final URI uri = URI.create(resultPath);
-            if (!uri.isAbsolute()) {
-                resultPath = createPath(fileSystemPrefix, resultPath);
+            if (hdfsHelper.isDirectory(sparkJobContext.getResultPath())) {
+                if (sparkJobContext.getResultPath().endsWith("/")) {
+                    resultPath = sparkJobContext.getResultPath() + generateResultFilename(sparkJobContext);
+                } else {
+                    resultPath = sparkJobContext.getResultPath() + '/' + generateResultFilename(sparkJobContext);
+                }
+            } else {
+                resultPath = sparkJobContext.getResultPath();
             }
         }
-        resultPath = attachResultJobFilename(sparkJobContext, resultPath);
-        return resultPath;
+
+        return hdfsHelper.getResourceToUse(resultPath);
     }
 
-    private static String attachResultJobFilename(final SparkJobContext sparkJobContext, String resultPath)
-            throws URISyntaxException {
-
-        if (resultPath != null && !resultPath.endsWith(RESULT_FILE_EXTENSION)) {
-            final String analysisJobXmlName = sparkJobContext.getJobName();
-            final Date date = new Date();
-            final String filename = analysisJobXmlName + "-" + date.getTime() + RESULT_FILE_EXTENSION;
-            resultPath = createPath(resultPath, filename);
-        }
-        return resultPath;
-    }
-
-    public static String createPath(final String fileSystemPrefix, String resultPath) throws URISyntaxException {
-
-        final URI uri;
-        try {
-            URI systemPrefix = new URI(fileSystemPrefix);
-            if (!resultPath.startsWith("/")) {
-                resultPath = "/" + resultPath;
-            }
-            uri = new URI("hdfs", null, systemPrefix.getHost(), systemPrefix.getPort(), systemPrefix.getPath()
-                    + resultPath, null, null);
-            return uri.toString();
-        } catch (URISyntaxException e) {
-            logger.error("Error while trying to create url for saving the job", e);
-            throw e;
-        }
+    private static String generateResultFilename(SparkJobContext sparkJobContext) {
+        return sparkJobContext.getJobName() + "-" + System.currentTimeMillis() + RESULT_FILE_EXTENSION;
     }
 
 }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
@@ -51,14 +51,15 @@ public class JobResultPathTest {
         try {
 
             final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
-                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
-                    URI.create("src/test/resources/jobProperties/jobAbsolutePath.properties"), sparkContext);
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"), URI.create(
+                            "src/test/resources/jobProperties/jobAbsolutePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath().toString());
+            assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath()
+                    .toString());
             assertEquals("vanilla-job", sparkJobContext.getJobName());
-            assertTrue(ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext).getQualifiedPath()
-                    .endsWith("results/myresult.analysis.result.dat"));
+            assertTrue(ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext).getQualifiedPath().endsWith(
+                    "results/myresult.analysis.result.dat"));
         } finally {
             sparkContext.close();
         }
@@ -71,8 +72,8 @@ public class JobResultPathTest {
         try {
 
             final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
-                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
-                    URI.create("src/test/resources/jobProperties/jobEmptyPath.properties"), sparkContext);
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"), URI.create(
+                            "src/test/resources/jobProperties/jobEmptyPath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals(null, sparkJobContext.getResultPath());
@@ -94,8 +95,8 @@ public class JobResultPathTest {
         try {
 
             final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
-                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
-                    URI.create("src/test/resources/jobProperties/jobRelativePath.properties"), sparkContext);
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"), URI.create(
+                            "src/test/resources/jobProperties/jobRelativePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals("target", sparkJobContext.getResultPath().toString());
@@ -125,8 +126,8 @@ public class JobResultPathTest {
             final Resource resultResource = ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext);
             final int lastIndexOfDash = resultResource.getQualifiedPath().lastIndexOf("-");
             assertTrue(resultResource.getQualifiedPath().contains(analysisJobName));
-            assertEquals("/datacleaner/results/vanilla-job",
-                    resultResource.getQualifiedPath().substring(0, lastIndexOfDash));
+            assertEquals("/datacleaner/results/vanilla-job", resultResource.getQualifiedPath().substring(0,
+                    lastIndexOfDash));
 
         } finally {
             sparkContext.close();

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
+
 import org.apache.metamodel.util.Resource;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -48,9 +50,9 @@ public class JobResultPathTest {
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobAbsolutePath.properties", sparkContext);
+            final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
+                    URI.create("src/test/resources/jobProperties/jobAbsolutePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath());
@@ -68,9 +70,9 @@ public class JobResultPathTest {
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobEmptyPath.properties", sparkContext);
+            final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
+                    URI.create("src/test/resources/jobProperties/jobEmptyPath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals("", sparkJobContext.getResultPath());
@@ -91,9 +93,9 @@ public class JobResultPathTest {
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobRelativePath.properties", sparkContext);
+            final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"),
+                    URI.create("src/test/resources/jobProperties/jobRelativePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals("target", sparkJobContext.getResultPath());
@@ -113,8 +115,8 @@ public class JobResultPathTest {
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml", null, sparkContext);
+            final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                    URI.create("src/test/resources/vanilla-job.analysis.xml"), null, sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertNull(sparkJobContext.getResultPath());

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
@@ -55,7 +55,7 @@ public class JobResultPathTest {
                     URI.create("src/test/resources/jobProperties/jobAbsolutePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath());
+            assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath().toString());
             assertEquals("vanilla-job", sparkJobContext.getJobName());
             assertTrue(ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext).getQualifiedPath()
                     .endsWith("results/myresult.analysis.result.dat"));
@@ -75,7 +75,7 @@ public class JobResultPathTest {
                     URI.create("src/test/resources/jobProperties/jobEmptyPath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("", sparkJobContext.getResultPath());
+            assertEquals(null, sparkJobContext.getResultPath());
             final String analysisJobName = sparkJobContext.getJobName();
             assertEquals("vanilla-job", analysisJobName);
 
@@ -98,7 +98,7 @@ public class JobResultPathTest {
                     URI.create("src/test/resources/jobProperties/jobRelativePath.properties"), sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("target", sparkJobContext.getResultPath());
+            assertEquals("target", sparkJobContext.getResultPath().toString());
             final String analysisJobName = sparkJobContext.getJobName();
             assertEquals("vanilla-job", analysisJobName);
 

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
@@ -1,23 +1,50 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.spark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.metamodel.util.Resource;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.spark.utils.ResultFilePathUtils;
+import org.junit.Rule;
 import org.junit.Test;
-
-import junit.framework.TestCase;
+import org.junit.rules.TestName;
 
 /**
  * This class tests the path of the result specified in the job properties file
  * or otherwise.
  */
-public class JobResultPathTest extends TestCase {
+public class JobResultPathTest {
+
+    @Rule
+    public TestName name = new TestName();
 
     @Test
     public void testResultPathAbolutePathSpecified() throws Exception {
-        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + getName());
+        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + name.getMethodName());
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
@@ -37,7 +64,7 @@ public class JobResultPathTest extends TestCase {
 
     @Test
     public void testResultPathSpecifiedEmptyPath() throws Exception {
-        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + getName());
+        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + name.getMethodName());
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
@@ -60,7 +87,7 @@ public class JobResultPathTest extends TestCase {
 
     @Test
     public void testResultPathNameJustFolderSpecified() throws Exception {
-        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + getName());
+        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + name.getMethodName());
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 
@@ -82,7 +109,7 @@ public class JobResultPathTest extends TestCase {
 
     @Test
     public void testResultPathNameNoVariableSpecified() throws Exception {
-        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + getName());
+        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + name.getMethodName());
         final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
         try {
 

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/JobResultPathTest.java
@@ -1,33 +1,13 @@
 package org.datacleaner.spark;
 
-/**
- * DataCleaner (community edition)
- * Copyright (C) 2014 Neopost - Customer Information Management
- *
- * This copyrighted material is made available to anyone wishing to use, modify,
- * copy, or redistribute it subject to the terms and conditions of the GNU
- * Lesser General Public License, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this distribution; if not, write to:
- * Free Software Foundation, Inc.
- * 51 Franklin Street, Fifth Floor
- * Boston, MA  02110-1301  USA
- */
-import java.net.URISyntaxException;
-
-import junit.framework.TestCase;
-
+import org.apache.metamodel.util.Resource;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.spark.utils.ResultFilePathUtils;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /**
  * This class tests the path of the result specified in the job properties file
@@ -43,14 +23,13 @@ public class JobResultPathTest extends TestCase {
 
             final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
                     "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobAbsolutePath.properties", sparkContext.hadoopConfiguration());
+                    "src/test/resources/jobProperties/jobAbsolutePath.properties", sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("hdfs://bigdatavm:9000/target/results/myresult.analysis.result.dat",
-                    sparkJobContext.getResultPath());
+            assertEquals("file:///target/results/myresult.analysis.result.dat", sparkJobContext.getResultPath());
             assertEquals("vanilla-job", sparkJobContext.getJobName());
-            assertEquals("hdfs://bigdatavm:9000/target/results/myresult.analysis.result.dat",
-                    ResultFilePathUtils.getResultFilePath(sparkContext, sparkJobContext));
+            assertTrue(ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext).getQualifiedPath()
+                    .endsWith("results/myresult.analysis.result.dat"));
         } finally {
             sparkContext.close();
         }
@@ -64,15 +43,15 @@ public class JobResultPathTest extends TestCase {
 
             final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
                     "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobEmptyPath.properties", sparkContext.hadoopConfiguration());
+                    "src/test/resources/jobProperties/jobEmptyPath.properties", sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertEquals("", sparkJobContext.getResultPath());
             final String analysisJobName = sparkJobContext.getJobName();
             assertEquals("vanilla-job", analysisJobName);
 
-            final String resultJobFilePath = ResultFilePathUtils.getResultFilePath(sparkContext, sparkJobContext);
-            assertTrue(resultJobFilePath.contains(analysisJobName));
+            final Resource resultResource = ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext);
+            assertTrue(resultResource.getQualifiedPath().contains(analysisJobName));
 
         } finally {
             sparkContext.close();
@@ -87,43 +66,15 @@ public class JobResultPathTest extends TestCase {
 
             final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
                     "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobRelativePath.properties", sparkContext.hadoopConfiguration());
+                    "src/test/resources/jobProperties/jobRelativePath.properties", sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
-            assertEquals("/target/results", sparkJobContext.getResultPath());
+            assertEquals("target", sparkJobContext.getResultPath());
             final String analysisJobName = sparkJobContext.getJobName();
             assertEquals("vanilla-job", analysisJobName);
 
-            final String resultJobFilePath = ResultFilePathUtils.getResultFilePath(sparkContext, sparkJobContext);
-            final int lastIndexOfDash = resultJobFilePath.lastIndexOf("-");
-            assertTrue(resultJobFilePath.contains(analysisJobName));
-            assertEquals("hdfs://target/results/vanilla-job", resultJobFilePath.substring(0, lastIndexOfDash));
-
-        } finally {
-            sparkContext.close();
-        }
-    }
-
-    @Test
-    public void testResultPathNameJustANameSpecified() throws Exception {
-        final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("DCTest - " + getName());
-        final JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
-        try {
-
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml",
-                    "src/test/resources/jobProperties/jobSimpleNamePath.properties", sparkContext.hadoopConfiguration());
-            final AnalysisJob job = sparkJobContext.getAnalysisJob();
-            assertNotNull(job);
-            assertEquals("myresult", sparkJobContext.getResultPath());
-            final String analysisJobName = sparkJobContext.getJobName();
-            assertEquals("vanilla-job", analysisJobName);
-
-            final String resultJobFilePath = ResultFilePathUtils.getResultFilePath(sparkContext, sparkJobContext);
-            final int lastIndexOfDash = resultJobFilePath.lastIndexOf("-");
-            assertTrue(resultJobFilePath.contains(analysisJobName));
-            assertEquals("hdfs://myresult/vanilla-job", resultJobFilePath.substring(0, lastIndexOfDash));
-
+            final Resource resultResource = ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext);
+            assertTrue(resultResource.getQualifiedPath().contains(analysisJobName));
         } finally {
             sparkContext.close();
         }
@@ -136,31 +87,20 @@ public class JobResultPathTest extends TestCase {
         try {
 
             final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    "src/test/resources/vanilla-job.analysis.xml", null, sparkContext.hadoopConfiguration());
+                    "src/test/resources/vanilla-job.analysis.xml", null, sparkContext);
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
             assertNull(sparkJobContext.getResultPath());
             final String analysisJobName = sparkJobContext.getJobName();
             assertEquals("vanilla-job", analysisJobName);
-            final String resultJobFilePath = ResultFilePathUtils.getResultFilePath(sparkContext, sparkJobContext);
-            final int lastIndexOfDash = resultJobFilePath.lastIndexOf("-");
-            assertTrue(resultJobFilePath.contains(analysisJobName));
-            assertEquals("hdfs://datacleaner/results/vanilla-job", resultJobFilePath.substring(0, lastIndexOfDash));
+            final Resource resultResource = ResultFilePathUtils.getResultResource(sparkContext, sparkJobContext);
+            final int lastIndexOfDash = resultResource.getQualifiedPath().lastIndexOf("-");
+            assertTrue(resultResource.getQualifiedPath().contains(analysisJobName));
+            assertEquals("/datacleaner/results/vanilla-job",
+                    resultResource.getQualifiedPath().substring(0, lastIndexOfDash));
 
         } finally {
             sparkContext.close();
         }
     }
-
-    @Test
-    public void testCreatePath() throws URISyntaxException {
-        final String newPath1 = ResultFilePathUtils.createPath("hdfs://bigdatavm:9000",
-                "mypath/myfile.analysis.result.dat");
-        assertEquals("hdfs://bigdatavm:9000/mypath/myfile.analysis.result.dat", newPath1);
-
-        final String newPath2 = ResultFilePathUtils.createPath("hdfs://bigdatavm:9000",
-                "/mypath/myfile.analysis.result.dat");
-        assertEquals("hdfs://bigdatavm:9000/mypath/myfile.analysis.result.dat", newPath2);
-    }
-
 }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -100,8 +100,8 @@ public class SparkAnalysisRunnerTest {
 
     @Test
     public void testVanillaScenario() throws Exception {
-        final AnalysisResultFuture result = runAnalysisJob("DCTest - " + getName(),
-                URI.create("src/test/resources/vanilla-job.analysis.xml"), "vanilla-job", false);
+        final AnalysisResultFuture result = runAnalysisJob("DCTest - " + getName(), URI.create(
+                "src/test/resources/vanilla-job.analysis.xml"), "vanilla-job", false);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -112,8 +112,8 @@ public class SparkAnalysisRunnerTest {
         assertEquals(2, results.size());
 
         final StringAnalyzerResult stringAnalyzerResult = result.getResults(StringAnalyzerResult.class).get(0);
-        assertEquals("[MetaModelInputColumn[resources.person_names.txt.company]]",
-                Arrays.toString(stringAnalyzerResult.getColumns()));
+        assertEquals("[MetaModelInputColumn[resources.person_names.txt.company]]", Arrays.toString(stringAnalyzerResult
+                .getColumns()));
 
         final int rowCount = stringAnalyzerResult.getRowCount(stringAnalyzerResult.getColumns()[0]);
         assertEquals(7, rowCount);
@@ -155,12 +155,12 @@ public class SparkAnalysisRunnerTest {
 
             final SparkJobContext sparkJobContext;
             if (saveResult) {
-                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
-                        URI.create("src/test/resources/write-job.analysis.xml"), null, sparkContext);
+                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"), URI.create(
+                        "src/test/resources/write-job.analysis.xml"), null, sparkContext);
             } else {
-                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
-                        URI.create("src/test/resources/write-job.analysis.xml"),
-                        URI.create("src/test/resources/jobProperties/noResult.properties"), sparkContext);
+                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"), URI.create(
+                        "src/test/resources/write-job.analysis.xml"), URI.create(
+                                "src/test/resources/jobProperties/noResult.properties"), sparkContext);
             }
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
@@ -200,25 +200,25 @@ public class SparkAnalysisRunnerTest {
 
     @Test
     public void testOutputDataStreamsScenario() throws Exception {
-        final AnalysisResultFuture result = runAnalysisJob("DCTest - testOutputDataStreamsScenario",
-                URI.create("src/test/resources/melon-job.analysis.xml"), "melon-job", false);
+        final AnalysisResultFuture result = runAnalysisJob("DCTest - testOutputDataStreamsScenario", URI.create(
+                "src/test/resources/melon-job.analysis.xml"), "melon-job", false);
 
         final List<AnalyzerResult> results = result.getResults();
         assertEquals(3, results.size());
 
-        final CompletenessAnalyzerResult completenessAnalyzerResult = result
-                .getResults(CompletenessAnalyzerResult.class).get(0);
+        final CompletenessAnalyzerResult completenessAnalyzerResult = result.getResults(
+                CompletenessAnalyzerResult.class).get(0);
         assertEquals(7, completenessAnalyzerResult.getTotalRowCount());
         assertEquals(7, completenessAnalyzerResult.getValidRowCount());
         assertEquals(0, completenessAnalyzerResult.getInvalidRowCount());
 
-        final ValueMatchAnalyzerResult incompleteValueMatcherAnalyzerResult = result
-                .getResults(ValueMatchAnalyzerResult.class).get(0);
+        final ValueMatchAnalyzerResult incompleteValueMatcherAnalyzerResult = result.getResults(
+                ValueMatchAnalyzerResult.class).get(0);
         assertEquals(0, incompleteValueMatcherAnalyzerResult.getTotalCount());
         assertEquals(Integer.valueOf(0), incompleteValueMatcherAnalyzerResult.getCount("Kasper"));
 
-        final ValueMatchAnalyzerResult completeValueMatcherAnalyzerResult = result
-                .getResults(ValueMatchAnalyzerResult.class).get(1);
+        final ValueMatchAnalyzerResult completeValueMatcherAnalyzerResult = result.getResults(
+                ValueMatchAnalyzerResult.class).get(1);
         assertEquals(7, completeValueMatcherAnalyzerResult.getTotalCount());
         assertEquals(Integer.valueOf(1), completeValueMatcherAnalyzerResult.getCount("Tomasz"));
         assertEquals(Integer.valueOf(6), completeValueMatcherAnalyzerResult.getUnexpectedValueCount());
@@ -228,8 +228,8 @@ public class SparkAnalysisRunnerTest {
     public void testOutputDataStreamsNonDistributableScenario() throws Exception {
         final AnalysisResultFuture result;
 
-        result = runAnalysisJob("DCTest - testOutputDataStreamsNonDistributableScenario",
-                URI.create("src/test/resources/non-dist-melon-job.analysis.xml"), "non-dist-melon-job", true);
+        result = runAnalysisJob("DCTest - testOutputDataStreamsNonDistributableScenario", URI.create(
+                "src/test/resources/non-dist-melon-job.analysis.xml"), "non-dist-melon-job", true);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -238,19 +238,19 @@ public class SparkAnalysisRunnerTest {
         final List<AnalyzerResult> results = result.getResults();
         assertEquals(3, results.size());
 
-        final CompletenessAnalyzerResult completenessAnalyzerResult = result
-                .getResults(CompletenessAnalyzerResult.class).get(0);
+        final CompletenessAnalyzerResult completenessAnalyzerResult = result.getResults(
+                CompletenessAnalyzerResult.class).get(0);
         assertEquals(7, completenessAnalyzerResult.getTotalRowCount());
         assertEquals(7, completenessAnalyzerResult.getValidRowCount());
         assertEquals(0, completenessAnalyzerResult.getInvalidRowCount());
 
-        final ValueMatchAnalyzerResult incompleteValueMatcherAnalyzerResult = result
-                .getResults(ValueMatchAnalyzerResult.class).get(0);
+        final ValueMatchAnalyzerResult incompleteValueMatcherAnalyzerResult = result.getResults(
+                ValueMatchAnalyzerResult.class).get(0);
         assertEquals(0, incompleteValueMatcherAnalyzerResult.getTotalCount());
         assertEquals(Integer.valueOf(0), incompleteValueMatcherAnalyzerResult.getCount("Kasper"));
 
-        final UniqueKeyCheckAnalyzerResult uniqueKeyCheckAnalyzerResult = result
-                .getResults(UniqueKeyCheckAnalyzerResult.class).get(0);
+        final UniqueKeyCheckAnalyzerResult uniqueKeyCheckAnalyzerResult = result.getResults(
+                UniqueKeyCheckAnalyzerResult.class).get(0);
         assertEquals(7, uniqueKeyCheckAnalyzerResult.getRowCount());
         assertEquals(7, uniqueKeyCheckAnalyzerResult.getUniqueCount());
         assertEquals(0, uniqueKeyCheckAnalyzerResult.getNonUniqueCount());
@@ -261,8 +261,28 @@ public class SparkAnalysisRunnerTest {
 
     @Test
     public void testValueDistributionReducer() throws Exception {
-        final AnalysisResultFuture result = runAnalysisJob("DCTest - testValueDistributionReducer",
-                URI.create("src/test/resources/distributable-value-dist.analysis.xml"), "distributable-value-dist",
+        final AnalysisResultFuture result = runAnalysisJob("DCTest - testValueDistributionReducer", URI.create(
+                "src/test/resources/distributable-value-dist.analysis.xml"), "distributable-value-dist", true);
+
+        if (result.isErrornous()) {
+            throw (Exception) result.getErrors().get(0);
+        }
+
+        final List<AnalyzerResult> results = result.getResults();
+        assertEquals(1, results.size());
+
+        final ValueDistributionAnalyzerResult completeValueDistributionAnalyzerResult = result.getResults(
+                ValueDistributionAnalyzerResult.class).get(0);
+        assertEquals(7, completeValueDistributionAnalyzerResult.getTotalCount());
+        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getUniqueCount());
+        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getDistinctCount());
+        assertEquals(0, completeValueDistributionAnalyzerResult.getNullCount());
+    }
+
+    @Test
+    public void testGroupedValueDistributionReducer() throws Exception {
+        final AnalysisResultFuture result = runAnalysisJob("DCTest - testGroupedValueDistributionReducer", URI.create(
+                "src/test/resources/distributable-grouped-value-dist.analysis.xml"), "distributable-grouped-value-dist",
                 true);
 
         if (result.isErrornous()) {
@@ -272,29 +292,8 @@ public class SparkAnalysisRunnerTest {
         final List<AnalyzerResult> results = result.getResults();
         assertEquals(1, results.size());
 
-        final ValueDistributionAnalyzerResult completeValueDistributionAnalyzerResult = result
-                .getResults(ValueDistributionAnalyzerResult.class).get(0);
-        assertEquals(7, completeValueDistributionAnalyzerResult.getTotalCount());
-        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getUniqueCount());
-        assertEquals(Integer.valueOf(7), completeValueDistributionAnalyzerResult.getDistinctCount());
-        assertEquals(0, completeValueDistributionAnalyzerResult.getNullCount());
-    }
-
-    @Test
-    public void testGroupedValueDistributionReducer() throws Exception {
-        final AnalysisResultFuture result = runAnalysisJob("DCTest - testGroupedValueDistributionReducer",
-                URI.create("src/test/resources/distributable-grouped-value-dist.analysis.xml"),
-                "distributable-grouped-value-dist", true);
-
-        if (result.isErrornous()) {
-            throw (Exception) result.getErrors().get(0);
-        }
-
-        final List<AnalyzerResult> results = result.getResults();
-        assertEquals(1, results.size());
-
-        final ValueDistributionAnalyzerResult completeValueDistributionAnalyzerResult = result
-                .getResults(ValueDistributionAnalyzerResult.class).get(0);
+        final ValueDistributionAnalyzerResult completeValueDistributionAnalyzerResult = result.getResults(
+                ValueDistributionAnalyzerResult.class).get(0);
         assertEquals(GroupedValueDistributionResult.class, completeValueDistributionAnalyzerResult.getClass());
         GroupedValueDistributionResult completeGroupedResult = (GroupedValueDistributionResult) completeValueDistributionAnalyzerResult;
         Iterator<? extends ValueCountingAnalyzerResult> iterator = completeGroupedResult.getGroupResults().iterator();
@@ -313,17 +312,17 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testJsonDatastore() throws Exception {
         final String appName = "DCTest - " + getName();
-        final AnalysisResultFuture result = runAnalysisJob(appName,
-                URI.create("src/test/resources/json-job.analysis.xml"), "json-job", false);
+        final AnalysisResultFuture result = runAnalysisJob(appName, URI.create(
+                "src/test/resources/json-job.analysis.xml"), "json-job", false);
 
         final List<AnalyzerResult> results = result.getResults();
         assertNotNull(results);
         assertEquals(1, results.size());
 
-        final ValueDistributionAnalyzerResult valueDistributionAnalyzerResult = result
-                .getResults(ValueDistributionAnalyzerResult.class).get(0);
-        assertEquals("[[blue->3], [green->2], [<unique>->1]]",
-                valueDistributionAnalyzerResult.getValueCounts().toString());
+        final ValueDistributionAnalyzerResult valueDistributionAnalyzerResult = result.getResults(
+                ValueDistributionAnalyzerResult.class).get(0);
+        assertEquals("[[blue->3], [green->2], [<unique>->1]]", valueDistributionAnalyzerResult.getValueCounts()
+                .toString());
 
         assertEquals(1, valueDistributionAnalyzerResult.getUniqueCount().intValue());
         assertEquals("[brown]", valueDistributionAnalyzerResult.getUniqueValues().toString());

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -144,11 +144,11 @@ public class SparkAnalysisRunnerTest {
             final SparkJobContext sparkJobContext;
             if (saveResult) {
                 sparkJobContext = new SparkJobContext(
-                        "src/test/resources/conf_local.xml", "src/test/resources/write-job.analysis.xml", null, sparkContext.hadoopConfiguration());
+                        "src/test/resources/conf_local.xml", "src/test/resources/write-job.analysis.xml", null, sparkContext);
             } else {
                 sparkJobContext = new SparkJobContext(
                         "src/test/resources/conf_local.xml", "src/test/resources/write-job.analysis.xml",
-                        "src/test/resources/jobProperties/noResult.properties", sparkContext.hadoopConfiguration());
+                        "src/test/resources/jobProperties/noResult.properties", sparkContext);
             }
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
@@ -359,7 +359,7 @@ public class SparkAnalysisRunnerTest {
                 appName);
         try (JavaSparkContext sparkContext = new JavaSparkContext(sparkConf)) {
             final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                    analysisJobXmlPath, null, sparkContext.hadoopConfiguration());
+                    analysisJobXmlPath, null, sparkContext);
             if (sparkJobLifeCycleListener != null) {
                 sparkJobContext.addSparkJobLifeCycleListener(sparkJobLifeCycleListener);
             }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -21,6 +21,7 @@ package org.datacleaner.spark;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -100,7 +101,7 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testVanillaScenario() throws Exception {
         final AnalysisResultFuture result = runAnalysisJob("DCTest - " + getName(),
-                "src/test/resources/vanilla-job.analysis.xml", "vanilla-job", false);
+                URI.create("src/test/resources/vanilla-job.analysis.xml"), "vanilla-job", false);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -154,12 +155,12 @@ public class SparkAnalysisRunnerTest {
 
             final SparkJobContext sparkJobContext;
             if (saveResult) {
-                sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                        "src/test/resources/write-job.analysis.xml", null, sparkContext);
+                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                        URI.create("src/test/resources/write-job.analysis.xml"), null, sparkContext);
             } else {
-                sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
-                        "src/test/resources/write-job.analysis.xml",
-                        "src/test/resources/jobProperties/noResult.properties", sparkContext);
+                sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
+                        URI.create("src/test/resources/write-job.analysis.xml"),
+                        URI.create("src/test/resources/jobProperties/noResult.properties"), sparkContext);
             }
             final AnalysisJob job = sparkJobContext.getAnalysisJob();
             assertNotNull(job);
@@ -200,7 +201,7 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testOutputDataStreamsScenario() throws Exception {
         final AnalysisResultFuture result = runAnalysisJob("DCTest - testOutputDataStreamsScenario",
-                "src/test/resources/melon-job.analysis.xml", "melon-job", false);
+                URI.create("src/test/resources/melon-job.analysis.xml"), "melon-job", false);
 
         final List<AnalyzerResult> results = result.getResults();
         assertEquals(3, results.size());
@@ -228,7 +229,7 @@ public class SparkAnalysisRunnerTest {
         final AnalysisResultFuture result;
 
         result = runAnalysisJob("DCTest - testOutputDataStreamsNonDistributableScenario",
-                "src/test/resources/non-dist-melon-job.analysis.xml", "non-dist-melon-job", true);
+                URI.create("src/test/resources/non-dist-melon-job.analysis.xml"), "non-dist-melon-job", true);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -261,7 +262,8 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testValueDistributionReducer() throws Exception {
         final AnalysisResultFuture result = runAnalysisJob("DCTest - testValueDistributionReducer",
-                "src/test/resources/distributable-value-dist.analysis.xml", "distributable-value-dist", true);
+                URI.create("src/test/resources/distributable-value-dist.analysis.xml"), "distributable-value-dist",
+                true);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -281,8 +283,8 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testGroupedValueDistributionReducer() throws Exception {
         final AnalysisResultFuture result = runAnalysisJob("DCTest - testGroupedValueDistributionReducer",
-                "src/test/resources/distributable-grouped-value-dist.analysis.xml", "distributable-grouped-value-dist",
-                true);
+                URI.create("src/test/resources/distributable-grouped-value-dist.analysis.xml"),
+                "distributable-grouped-value-dist", true);
 
         if (result.isErrornous()) {
             throw (Exception) result.getErrors().get(0);
@@ -311,8 +313,8 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testJsonDatastore() throws Exception {
         final String appName = "DCTest - " + getName();
-        final AnalysisResultFuture result = runAnalysisJob(appName, "src/test/resources/json-job.analysis.xml",
-                "json-job", false);
+        final AnalysisResultFuture result = runAnalysisJob(appName,
+                URI.create("src/test/resources/json-job.analysis.xml"), "json-job", false);
 
         final List<AnalyzerResult> results = result.getResults();
         assertNotNull(results);
@@ -330,7 +332,7 @@ public class SparkAnalysisRunnerTest {
     @Test
     public void testLifeCycleListener() throws Exception {
         final String appName = "DCTest - " + getName();
-        final String analysisJobXmlPath = "src/test/resources/json-job.analysis.xml";
+        final URI analysisJobXmlPath = URI.create("src/test/resources/json-job.analysis.xml");
         final String expectedAnalysisJobName = "json-job";
         final TestSparkJobLifeCycleListener sparkJobLifeCycleListener = new TestSparkJobLifeCycleListener();
 
@@ -353,18 +355,18 @@ public class SparkAnalysisRunnerTest {
         return testName.getMethodName();
     }
 
-    private AnalysisResultFuture runAnalysisJob(final String appName, final String analysisJobXmlPath,
+    private AnalysisResultFuture runAnalysisJob(final String appName, final URI analysisJobXmlPath,
             final String expectedAnalysisJobName, boolean useMinPartitions) throws Exception {
         return runAnalysisJob(appName, analysisJobXmlPath, expectedAnalysisJobName, useMinPartitions, null);
     }
 
-    private AnalysisResultFuture runAnalysisJob(final String appName, final String analysisJobXmlPath,
+    private AnalysisResultFuture runAnalysisJob(final String appName, final URI analysisJobXmlPath,
             final String expectedAnalysisJobName, boolean useMinPartitions,
             final SparkJobLifeCycleListener sparkJobLifeCycleListener) throws Exception {
         final AnalysisResultFuture result;
         final SparkConf sparkConf = new SparkConf().setMaster("local").setAppName(appName);
         try (JavaSparkContext sparkContext = new JavaSparkContext(sparkConf)) {
-            final SparkJobContext sparkJobContext = new SparkJobContext("src/test/resources/conf_local.xml",
+            final SparkJobContext sparkJobContext = new SparkJobContext(URI.create("src/test/resources/conf_local.xml"),
                     analysisJobXmlPath, null, sparkContext);
             if (sparkJobLifeCycleListener != null) {
                 sparkJobContext.addSparkJobLifeCycleListener(sparkJobLifeCycleListener);

--- a/engine/env/spark/src/test/resources/jobProperties/jobAbsolutePath.properties
+++ b/engine/env/spark/src/test/resources/jobProperties/jobAbsolutePath.properties
@@ -1,1 +1,1 @@
-datacleaner.result.hdfs.path=hdfs://bigdatavm:9000/target/results/myresult.analysis.result.dat
+datacleaner.result.hdfs.path=file:///target/results/myresult.analysis.result.dat

--- a/engine/env/spark/src/test/resources/jobProperties/jobRelativePath.properties
+++ b/engine/env/spark/src/test/resources/jobProperties/jobRelativePath.properties
@@ -1,1 +1,1 @@
-datacleaner.result.hdfs.path=/target/results
+datacleaner.result.hdfs.path=target


### PR DESCRIPTION
I've been spending most of my day making sure we are compatible with Spark running on MapR (using the MapR 5.0.0 sandbox).

This PR unlocks that capability. It ensures that the new ```HdfsHelper``` is in control at all the important stages where resources/paths are loaded. It also makes HDFS the default scheme to use in the Spark module when parsing resource paths without any scheme defined.