### PR TITLE
Do not use ES's wrapped Guava Strings class

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
@@ -56,7 +56,7 @@ import javax.swing.plaf.metal.MetalButtonUI;
 import org.datacleaner.components.convert.ConvertToNumberTransformer;
 import org.datacleaner.widgets.DCTaskPaneContainer;
 import org.datacleaner.widgets.PopupButton;
-import org.elasticsearch.common.base.Strings;
+import com.google.common.base.Strings;
 import org.jdesktop.swingx.JXCollapsiblePane;
 import org.jdesktop.swingx.JXCollapsiblePane.Direction;
 import org.jdesktop.swingx.JXFormattedTextField;


### PR DESCRIPTION
 We should use the original whenever possible.