### PR TITLE
Issue #1030: Fixes saving of only 1 component when having only 1 builder

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/builder/ComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/ComponentBuilder.java
@@ -45,7 +45,7 @@ import org.datacleaner.metadata.HasMetadataProperties;
  */
 public interface ComponentBuilder extends HasMetadataProperties, InputColumnSinkJob, OutputDataStreamJobSource,
         HasComponentRequirement, HasName, Renderable {
-
+    
     /**
      * Determines if the underlying component is fully configured or not. This
      * is equivalent to invoking {@link #isConfigured(boolean))} with a 'false'

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-file4.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-file4.xml
@@ -57,23 +57,6 @@
                 <property name="Minus sign" value="-"/>
             </properties>
             <input ref="col_firstname" name="Column"/>
-        </analyzer>
-        <analyzer>
-            <descriptor ref="Pattern finder"/>
-            <properties>
-                <property name="Discriminate text case" value="true"/>
-                <property name="Discriminate negative numbers" value="false"/>
-                <property name="Discriminate decimals" value="true"/>
-                <property name="Enable mixed tokens" value="false"/>
-                <property name="Ignore repeated spaces" value="false"/>
-                <property name="Upper case patterns expand in size" value="false"/>
-                <property name="Lower case patterns expand in size" value="true"/>
-                <property name="Predefined token name" value="&lt;null&gt;"/>
-                <property name="Predefined token regexes" value="&lt;null&gt;"/>
-                <property name="Decimal separator" value="."/>
-                <property name="Thousands separator" value="&amp;#44;"/>
-                <property name="Minus sign" value="-"/>
-            </properties>
             <input ref="col_username" name="Column"/>
         </analyzer>
     </analysis>

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-file5.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-file5.xml
@@ -63,23 +63,6 @@
                 <property name="Minus sign" value="-"/>
             </properties>
             <input ref="col_firstname" name="Column"/>
-        </analyzer>
-        <analyzer>
-            <descriptor ref="Pattern finder"/>
-            <properties>
-                <property name="Discriminate text case" value="true"/>
-                <property name="Discriminate negative numbers" value="false"/>
-                <property name="Discriminate decimals" value="true"/>
-                <property name="Enable mixed tokens" value="false"/>
-                <property name="Ignore repeated spaces" value="false"/>
-                <property name="Upper case patterns expand in size" value="false"/>
-                <property name="Lower case patterns expand in size" value="true"/>
-                <property name="Predefined token name" value="&lt;null&gt;"/>
-                <property name="Predefined token regexes" value="&lt;null&gt;"/>
-                <property name="Decimal separator" value="."/>
-                <property name="Thousands separator" value="&amp;#44;"/>
-                <property name="Minus sign" value="-"/>
-            </properties>
             <input ref="col_username" name="Column"/>
         </analyzer>
         <analyzer requires="outcome_1">

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-file6.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-file6.xml
@@ -63,23 +63,6 @@
                 <property name="Minus sign" value="-"/>
             </properties>
             <input ref="col_firstname" name="Column"/>
-        </analyzer>
-        <analyzer name="pf 1">
-            <descriptor ref="Pattern finder"/>
-            <properties>
-                <property name="Discriminate text case" value="true"/>
-                <property name="Discriminate negative numbers" value="false"/>
-                <property name="Discriminate decimals" value="true"/>
-                <property name="Enable mixed tokens" value="false"/>
-                <property name="Ignore repeated spaces" value="false"/>
-                <property name="Upper case patterns expand in size" value="false"/>
-                <property name="Lower case patterns expand in size" value="true"/>
-                <property name="Predefined token name" value="&lt;null&gt;"/>
-                <property name="Predefined token regexes" value="&lt;null&gt;"/>
-                <property name="Decimal separator" value="."/>
-                <property name="Thousands separator" value="&amp;#44;"/>
-                <property name="Minus sign" value="-"/>
-            </properties>
             <input ref="col_username" name="Column"/>
         </analyzer>
         <analyzer requires="outcome_1" name="pf 2">


### PR DESCRIPTION
Fixes #1030

Finally got around to fix this bug ... The individual components was created because the builder creates many analyzer instances. My approach to solving the bug was to then also instrument each produced analyzer with a "secret" (at least never published) metadata value which the JaxbJobWriter then can use to correlate instances of the same builder and write them under the same ```<analyzer>``` element.

If it passes review, I suggest to also apply this fix to the coming 4.5.4 release.