### PR TITLE
Issue #954: Fixed

### DIFF
--- a/api/src/main/java/org/datacleaner/api/InputRow.java
+++ b/api/src/main/java/org/datacleaner/api/InputRow.java
@@ -49,7 +49,7 @@ public interface InputRow extends Serializable {
      * 
      * @return an identifier for this row
      */
-    public int getId();
+    public long getId();
 
     /**
      * @return the input columns represented in this row

--- a/components/basic-transformers/src/main/java/org/datacleaner/beans/numbers/GenerateIdTransformer.java
+++ b/components/basic-transformers/src/main/java/org/datacleaner/beans/numbers/GenerateIdTransformer.java
@@ -19,7 +19,7 @@
  */
 package org.datacleaner.beans.numbers;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Named;
 
@@ -65,12 +65,12 @@ public class GenerateIdTransformer implements Transformer {
     InputColumn<?> columnInScope;
 
     @Configured
-    int offset = 0;
+    long offset = 0;
 
-    private final AtomicInteger _counter;
+    private final AtomicLong _counter;
 
     public GenerateIdTransformer() {
-        _counter = new AtomicInteger();
+        _counter = new AtomicLong();
     }
 
     @Initialize
@@ -80,18 +80,18 @@ public class GenerateIdTransformer implements Transformer {
 
     @Override
     public OutputColumns getOutputColumns() {
-        return new OutputColumns(Integer.class, "Generated ID");
+        return new OutputColumns(Number.class, "Generated ID");
     }
 
     @Override
-    public Integer[] transform(InputRow inputRow) {
-        final int id;
+    public Number[] transform(InputRow inputRow) {
+        final long id;
         if (IdType.ROW_NUMBER == idType) {
             id = inputRow.getId();
         } else {
             id = _counter.incrementAndGet();
         }
-        return new Integer[] { id };
+        return new Number[] { id };
     }
 
 }

--- a/components/basic-transformers/src/test/java/org/datacleaner/beans/numbers/GenerateIdTransformerTest.java
+++ b/components/basic-transformers/src/test/java/org/datacleaner/beans/numbers/GenerateIdTransformerTest.java
@@ -60,15 +60,15 @@ public class GenerateIdTransformerTest extends TestCase {
     public void testRowId() throws Exception {
         transformer.idType = IdType.ROW_NUMBER;
         
-        final Integer[] result1 = transformer.transform(new MockInputRow().put(col, null));
-        final Integer[] result2 = transformer.transform(new MockInputRow().put(col, null));
-        final Integer[] result3 = transformer.transform(new MockInputRow().put(col, null));
-        final Integer[] result4 = transformer.transform(new MockInputRow().put(col, null));
+        final Number[] result1 = transformer.transform(new MockInputRow().put(col, null));
+        final Number[] result2 = transformer.transform(new MockInputRow().put(col, null));
+        final Number[] result3 = transformer.transform(new MockInputRow().put(col, null));
+        final Number[] result4 = transformer.transform(new MockInputRow().put(col, null));
         
-        final int id1 = result1[0];
-        final int id2 = result2[0];
-        final int id3 = result3[0];
-        final int id4 = result4[0];
+        final int id1 = result1[0].intValue();
+        final int id2 = result2[0].intValue();
+        final int id3 = result3[0].intValue();
+        final int id4 = result4[0].intValue();
         
         assertTrue(id1 < id2);
         assertTrue(id2 < id3);

--- a/components/grouper/src/main/java/org/datacleaner/components/group/AbstractRowNumberAwareAggregateBuilder.java
+++ b/components/grouper/src/main/java/org/datacleaner/components/group/AbstractRowNumberAwareAggregateBuilder.java
@@ -49,7 +49,7 @@ abstract class AbstractRowNumberAwareAggregateBuilder<T> implements AggregateBui
             _values = new TreeSet<>(Collections.reverseOrder(ObjectComparator.getComparator()));
             break;
         case RECORD_ORDER:
-            _values = new TreeMap<Integer, Object>();
+            _values = new TreeMap<Long, Object>();
             break;
         default:
             throw new UnsupportedOperationException();
@@ -61,7 +61,7 @@ abstract class AbstractRowNumberAwareAggregateBuilder<T> implements AggregateBui
         throw new UnsupportedOperationException();
     }
 
-    public final void add(Object o, int rowNumber) {
+    public final void add(Object o, long rowNumber) {
         if (_skipNulls && o == null) {
             return;
         }
@@ -78,7 +78,7 @@ abstract class AbstractRowNumberAwareAggregateBuilder<T> implements AggregateBui
             break;
         case RECORD_ORDER:
             @SuppressWarnings("unchecked")
-            final Map<Integer, Object> map = (Map<Integer, Object>) _values;
+            final Map<Long, Object> map = (Map<Long, Object>) _values;
             map.put(rowNumber, o);
             break;
         }

--- a/components/grouper/src/main/java/org/datacleaner/components/group/GrouperTransformer.java
+++ b/components/grouper/src/main/java/org/datacleaner/components/group/GrouperTransformer.java
@@ -195,7 +195,7 @@ public class GrouperTransformer extends MultiStreamComponent {
 
 
         final List<AggregateBuilder<?>> aggregateBuilders = getAggregateBuilders(key);
-        final int rowId = row.getId();
+        final long rowId = row.getId();
         
         // send rowId to COUNT function
         aggregateBuilders.get(0).add(rowId);

--- a/engine/core/src/main/java/org/datacleaner/data/AbstractLegacyAwareInputRow.java
+++ b/engine/core/src/main/java/org/datacleaner/data/AbstractLegacyAwareInputRow.java
@@ -1,0 +1,88 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.data;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectInputStream.GetField;
+import java.io.ObjectStreamField;
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+import org.datacleaner.api.InputRow;
+
+/**
+ * Abstract super-class for {@link InputRow} implementations that are aware of
+ * (and impacted by) the change of {@link InputRow#getId()} which was changed
+ * from type int to long.
+ * 
+ * To enable deserialization of old objects where the value is stored as an int,
+ * but should be deserialized into a long, this class provides a mechanism for
+ * converting the values.
+ */
+abstract class AbstractLegacyAwareInputRow extends AbstractInputRow {
+
+    private static final long serialVersionUID = 1L;
+
+    protected abstract String getFieldNameForOldId();
+
+    protected abstract String getFieldNameForNewId();
+
+    protected abstract Collection<String> getFieldNamesInAdditionToId();
+
+    /**
+     * Subclasses should call this method within their
+     * readObject(ObjectInputStream) invocations
+     * 
+     * @param stream
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    protected void doReadObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        final GetField readFields = stream.readFields();
+
+        for (String fieldName : getFieldNamesInAdditionToId()) {
+            final Object value = readFields.get(fieldName, null);
+            setField(fieldName, value);
+        }
+
+        // fix issue of deserializing _rowNumber in it's previous int form
+        final long rowNumber;
+        final ObjectStreamField legacyRowNumberField = readFields.getObjectStreamClass().getField(
+                getFieldNameForOldId());
+        if (legacyRowNumberField != null) {
+            rowNumber = readFields.get(getFieldNameForOldId(), -1);
+        } else {
+            rowNumber = readFields.get(getFieldNameForNewId(), -1l);
+        }
+
+        setField(getFieldNameForNewId(), rowNumber);
+    }
+
+    private void setField(String fieldName, Object value) {
+        try {
+            final Field field = getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(this, value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set field '" + fieldName + "' to value: " + value, e);
+        }
+    }
+}

--- a/engine/core/src/main/java/org/datacleaner/data/MetaModelInputRow.java
+++ b/engine/core/src/main/java/org/datacleaner/data/MetaModelInputRow.java
@@ -19,12 +19,16 @@
  */
 package org.datacleaner.data;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.metamodel.data.Row;
@@ -39,23 +43,42 @@ import org.slf4j.LoggerFactory;
 /**
  * A physical {@link InputRow} originating from a MetaModel {@link Row} object.
  */
-public final class MetaModelInputRow extends AbstractInputRow {
+public final class MetaModelInputRow extends AbstractLegacyAwareInputRow {
 
     private static final long serialVersionUID = 1L;
 
     private static final Logger logger = LoggerFactory.getLogger(MetaModelInputRow.class);
 
     private final Row _row;
-    private final int _rowNumber;
+    private final long _id;
 
-    public MetaModelInputRow(int rowNumber, Row row) {
-        _rowNumber = rowNumber;
+    public MetaModelInputRow(long rowNumber, Row row) {
+        _id = rowNumber;
         _row = row;
+    }
+    
+    @Override
+    protected String getFieldNameForNewId() {
+        return "_id";
+    }
+    
+    @Override
+    protected String getFieldNameForOldId() {
+        return "_rowNumber";
+    }
+    
+    @Override
+    protected Collection<String> getFieldNamesInAdditionToId() {
+        return Arrays.asList("_row");
+    }
+    
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        doReadObject(stream);
     }
 
     @Override
-    public int getId() {
-        return _rowNumber;
+    public long getId() {
+        return _id;
     }
 
     public Row getRow() {

--- a/engine/core/src/main/java/org/datacleaner/data/MockInputRow.java
+++ b/engine/core/src/main/java/org/datacleaner/data/MockInputRow.java
@@ -19,10 +19,15 @@
  */
 package org.datacleaner.data;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.datacleaner.api.InputColumn;
@@ -31,29 +36,29 @@ import org.datacleaner.api.InputColumn;
  * A mock implementation of the InputRow interface. Allows for adhoc generation
  * of a row using the put(...) method.
  */
-public class MockInputRow extends AbstractInputRow {
+public class MockInputRow extends AbstractLegacyAwareInputRow {
 
     private static final long serialVersionUID = 1L;
 
     private static final AtomicInteger _idGenerator = new AtomicInteger(Integer.MIN_VALUE);
 
     private final Map<InputColumn<?>, Object> _values;
-    private final int _id;
+    private final long _rowId;
 
     public MockInputRow() {
         this(_idGenerator.getAndIncrement());
     }
 
-    public MockInputRow(int id, Map<InputColumn<?>, Object> values) {
+    public MockInputRow(long id, Map<InputColumn<?>, Object> values) {
         _values = values;
-        _id = id;
+        _rowId = id;
     }
 
     public MockInputRow(Map<InputColumn<?>, Object> values) {
         this(_idGenerator.getAndIncrement(), values);
     }
 
-    public MockInputRow(int id) {
+    public MockInputRow(long id) {
         this(id, new LinkedHashMap<InputColumn<?>, Object>());
     }
 
@@ -69,8 +74,27 @@ public class MockInputRow extends AbstractInputRow {
     }
 
     @Override
-    public int getId() {
-        return _id;
+    protected String getFieldNameForNewId() {
+        return "_rowId";
+    }
+
+    @Override
+    protected String getFieldNameForOldId() {
+        return "_id";
+    }
+
+    @Override
+    protected Collection<String> getFieldNamesInAdditionToId() {
+        return Arrays.asList("_values");
+    }
+
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        doReadObject(stream);
+    }
+
+    @Override
+    public long getId() {
+        return _rowId;
     }
 
     @Override
@@ -114,11 +138,7 @@ public class MockInputRow extends AbstractInputRow {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + _id;
-        result = prime * result + ((_values == null) ? 0 : _values.hashCode());
-        return result;
+        return Objects.hash(_rowId, _values);
     }
 
     @Override
@@ -130,7 +150,7 @@ public class MockInputRow extends AbstractInputRow {
         if (getClass() != obj.getClass())
             return false;
         MockInputRow other = (MockInputRow) obj;
-        if (_id != other._id)
+        if (_rowId != other._rowId)
             return false;
         if (_values == null) {
             if (other._values != null)
@@ -142,6 +162,6 @@ public class MockInputRow extends AbstractInputRow {
 
     @Override
     public String toString() {
-        return "MockInputRow[id=" + _id + "]";
+        return "MockInputRow[id=" + _rowId + "]";
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/runner/TransformerConsumer.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/TransformerConsumer.java
@@ -164,14 +164,14 @@ final class TransformerConsumer extends AbstractRowProcessingConsumer implements
         }
     }
 
-    private int getNextVirtualRowId(InputRow row, int recordNo) {
+    private long getNextVirtualRowId(InputRow row, int recordNo) {
         if (_idGenerator == null) {
             // this can more or less never happen, except in test cases or in
             // cases where the consumers are programmatically being used outside
             // of an AnalysisRunner. There's a risk then here that we get the
             // same row ID twice, but that's life :-P
-            int offset = Integer.MAX_VALUE;
-            int hiLoIntervalOffset = row.getId() * 1000;
+            long offset = Long.MAX_VALUE;
+            long hiLoIntervalOffset = row.getId() * 10000;
             return offset - hiLoIntervalOffset + recordNo;
         }
         return _idGenerator.nextVirtualRowId();

--- a/engine/core/src/main/java/org/datacleaner/storage/AbstractRowAnnotationFactory.java
+++ b/engine/core/src/main/java/org/datacleaner/storage/AbstractRowAnnotationFactory.java
@@ -70,7 +70,7 @@ public abstract class AbstractRowAnnotationFactory implements RowAnnotationFacto
         if (storeRow) {
             // TODO: In clustered scenarios, there's a chance of row ID
             // collision
-            final int rowId = row.getId();
+            final int rowId = (int) row.getId();
             if (_cachedRows != null) {
                 Boolean previously = _cachedRows.asMap().putIfAbsent(rowId, true);
                 if (previously == null) {

--- a/engine/core/src/test/java/org/datacleaner/job/runner/ConsumeRowHandlerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/runner/ConsumeRowHandlerTest.java
@@ -151,7 +151,7 @@ public class ConsumeRowHandlerTest extends TestCase {
                 + "TransformedInputColumn[id=trans-0001-0003,name=Mock multi row transformer (2)]=42, "
                 + "TransformedInputColumn[id=trans-0004-0005,name=mock output]=mocked: 2}," + "delegate=" + inputRow
                 + "]", outputRow.toString());
-        assertEquals(2147383649, outputRow.getId());
+        assertEquals(9223372036853775809l, outputRow.getId());
 
         outputRow = result.get(2);
         assertEquals("TransformedInputRow[values={"
@@ -159,7 +159,7 @@ public class ConsumeRowHandlerTest extends TestCase {
                 + "TransformedInputColumn[id=trans-0001-0003,name=Mock multi row transformer (2)]=42, "
                 + "TransformedInputColumn[id=trans-0004-0005,name=mock output]=mocked: 3}," + "delegate=" + inputRow
                 + "]", outputRow.toString());
-        assertEquals(2147383650, outputRow.getId());
+        assertEquals(9223372036853775810l, outputRow.getId());
 
         List<InputColumn<?>> outputColumns = outputRow.getInputColumns();
         assertEquals(6, outputColumns.size());

--- a/engine/core/src/test/java/org/datacleaner/job/tasks/ConsumeRowTaskTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/tasks/ConsumeRowTaskTest.java
@@ -110,9 +110,9 @@ public class ConsumeRowTaskTest extends TestCase {
         assertEquals(10, list.get(12).getValue(countingColumn));
 
         // assert that all generated rows have unique ids
-        Set<Integer> ids = new HashSet<Integer>();
+        final Set<Long> ids = new HashSet<>();
         for (InputRow row : list) {
-            int id = row.getId();
+            final long id = row.getId();
             if (ids.contains(id)) {
                 fail("Multiple rows with id " + id);
             }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/components/ComponentHandler.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/components/ComponentHandler.java
@@ -271,7 +271,7 @@ public class ComponentHandler {
         // Results will be collected in a tree map, sorted by row ID, to return the rows
         // in the same order. It is needed because we do the transformation in threads and
         // results could be computed in different order.
-        final Map<Integer, List<Object[]>> results = new TreeMap<>();
+        final Map<Long, List<Object[]>> results = new TreeMap<>();
 
         final SecurityContext securityContext = SecurityContextHolder.getContext();
 
@@ -332,7 +332,7 @@ public class ComponentHandler {
      * Thread-safe transformation method that runs transformer for an 'inputRow'
      * and puts a list of output rows to the 'results' map (key is the row ID).
      */
-    private void transform(InputRow inputRow, Map<Integer, List<Object[]>> results) {
+    private void transform(InputRow inputRow, Map<Long, List<Object[]>> results) {
         ThreadLocalOutputListener outputListener = new ThreadLocalOutputListener();
 
         final Set<ProvidedPropertyDescriptor> outputRowCollectorProperties = descriptor

--- a/testware/src/main/java/org/datacleaner/test/MockOutputDataStreamAnalyzer.java
+++ b/testware/src/main/java/org/datacleaner/test/MockOutputDataStreamAnalyzer.java
@@ -43,7 +43,7 @@ import org.datacleaner.result.ListResult;
 import org.junit.Assert;
 
 @Named("Mock output data stream analyzer")
-public class MockOutputDataStreamAnalyzer implements Analyzer<ListResult<Integer>>, HasOutputDataStreams {
+public class MockOutputDataStreamAnalyzer implements Analyzer<ListResult<Number>>, HasOutputDataStreams {
 
     public static final String PROPERTY_IDENTIFIER = "Identifier";
     public static final String STREAM_NAME1 = "foo bar records";
@@ -58,7 +58,7 @@ public class MockOutputDataStreamAnalyzer implements Analyzer<ListResult<Integer
     private OutputRowCollector collector1;
     private OutputRowCollector collector2;
     private AtomicInteger counter;
-    private List<Integer> list;
+    private List<Number> list;
     private boolean _hasBeenValidated = false;
 
     @Configured
@@ -112,7 +112,7 @@ public class MockOutputDataStreamAnalyzer implements Analyzer<ListResult<Integer
                     + identifier);
         }
 
-        final int id = row.getId();
+        final long id = row.getId();
         if (id % 3 == 0) {
             // one third of the times we will write to our result list
             list.add(id);
@@ -130,7 +130,7 @@ public class MockOutputDataStreamAnalyzer implements Analyzer<ListResult<Integer
     }
 
     @Override
-    public ListResult<Integer> getResult() {
+    public ListResult<Number> getResult() {
         if (collector1 != null) {
             collector1.putValues("baz", null);
         }


### PR DESCRIPTION
Fixes #954

I should add a few notes to this:

 * I first tried something quite ambitious - implementing ```long``` instead of ```int``` more or less everywhere. The important places I identified this was:
  * InputRow.getId() (which is what #954 tells about)
  * RowAnnotation.getRowCount() (not described in #954)
  * RowProcessingMetrics.getExpectedRow() (not described in #954)
 * But the above quickly became a nightmare to solve in one go. Especially the RowAnnotation change will have a huge impact. It literally is used in hundreds of places. And it's used a lot in result reducer code where it becomes hard to fix unless you really consider line-by-line or even class-by-class what makes sense to do.
 * So I reverted to "just" fixing #954. And here's the result.
 * Once it was fixed I saw a lot of breaking tests because of deserializing legacy InputRow objects. So I introduced a new class to consolidate the somewhat involved tricks to convert an old ```int``` variable into a new ```long``` value. This wasn't pretty IMO, but it's the only way (that I know of) to do it while keeping deserialization compatibility.