### PR TITLE
Fixes #1074: Create crucial repository folders automatically.

### DIFF
--- a/monitor/api/src/main/java/org/datacleaner/monitor/configuration/AbstractTenantContext.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/configuration/AbstractTenantContext.java
@@ -86,30 +86,21 @@ public abstract class AbstractTenantContext implements TenantContext {
     @Override
     public final RepositoryFolder getJobFolder() {
         final RepositoryFolder tenantFolder = getTenantRootFolder();
-        final RepositoryFolder jobsFolder = tenantFolder.getFolder(PATH_JOBS);
-        if (jobsFolder == null) {
-            throw new IllegalArgumentException("No job folder for tenant: " + getTenantId());
-        }
+        final RepositoryFolder jobsFolder = tenantFolder.getOrCreateFolder(PATH_JOBS);
         return jobsFolder;
     }
 
     @Override
     public final RepositoryFolder getResultFolder() {
         final RepositoryFolder tenantFolder = getTenantRootFolder();
-        final RepositoryFolder resultsFolder = tenantFolder.getFolder(PATH_RESULTS);
-        if (resultsFolder == null) {
-            throw new IllegalArgumentException("No result folder for tenant: " + getTenantId());
-        }
+        final RepositoryFolder resultsFolder = tenantFolder.getOrCreateFolder(PATH_RESULTS);
         return resultsFolder;
     }
 
     @Override
     public final RepositoryFolder getTimelineFolder() {
         final RepositoryFolder tenantFolder = getTenantRootFolder();
-        final RepositoryFolder timelinesFolder = tenantFolder.getFolder(PATH_TIMELINES);
-        if (timelinesFolder == null) {
-            throw new IllegalArgumentException("No timeline folder for tenant: " + getTenantId());
-        }
+        final RepositoryFolder timelinesFolder = tenantFolder.getOrCreateFolder(PATH_TIMELINES);
         return timelinesFolder;
     }
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/configuration/ComponentStoreImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/configuration/ComponentStoreImpl.java
@@ -42,25 +42,20 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @since 24.7.15
  */
 public class ComponentStoreImpl implements ComponentStore {
-    private static final Logger logger = LoggerFactory.getLogger(ComponentStore.class);
 
+    public static final String FOLDER_NAME = "components";
+    
+    private static final Logger logger = LoggerFactory.getLogger(ComponentStore.class);
+    
     private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
     private final Lock readLock = rwLock.readLock();
     private final Lock writeLock = rwLock.writeLock();
-
-    public static final String FOLDER_NAME = "components";
-
-    private RepositoryFolder componentsFolder;
-
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RepositoryFolder componentsFolder;
 
     public ComponentStoreImpl(Repository repository, String tenantId) {
         RepositoryFolder tenantFolder = repository.getFolder(tenantId);
-        componentsFolder = tenantFolder.getFolder(FOLDER_NAME);
-        if (componentsFolder == null) {
-            componentsFolder = tenantFolder.createFolder(FOLDER_NAME);
-        }
-
+        componentsFolder = tenantFolder.getOrCreateFolder(FOLDER_NAME);
     }
 
     /**

--- a/monitor/services/src/test/java/org/datacleaner/monitor/configuration/ComponentStoreImplTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/configuration/ComponentStoreImplTest.java
@@ -47,7 +47,7 @@ public class ComponentStoreImplTest {
 
     private RepositoryFolder getRepositoryFolderMock() {
         RepositoryFolder repositoryFolder = createNiceMock(RepositoryFolder.class);
-        expect(repositoryFolder.getFolder(ComponentStoreImpl.FOLDER_NAME)).andReturn(getComponentsFolderMock()).anyTimes();
+        expect(repositoryFolder.getOrCreateFolder(ComponentStoreImpl.FOLDER_NAME)).andReturn(getComponentsFolderMock()).anyTimes();
         replay(repositoryFolder);
 
         return repositoryFolder;


### PR DESCRIPTION
Fixes #1074 by using ```getOrCreateFolder(...)``` for crucial folders instead of ```getFolder(...)```