### PR TITLE
show unselected output columns

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/OutputColumnVisibilityButton.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/OutputColumnVisibilityButton.java
@@ -50,6 +50,6 @@ public class OutputColumnVisibilityButton extends DCCheckBox<MutableInputColumn<
 
     @Override
     public void onItemSelected(MutableInputColumn<?> item, boolean selected) {
-        item.setHidden(!selected);
+       //do nothing on the visibility of the button. It should be visible 
     }
 }


### PR DESCRIPTION
It should fix #970.  

I managed to show the hidden columns. However, the columns are selected by default. I tried to deselect them, but it did not work.  


