### PR TITLE
Make CoalesceUnit path-based for physical columns

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/data/MockInputColumn.java
+++ b/engine/core/src/main/java/org/datacleaner/data/MockInputColumn.java
@@ -33,14 +33,24 @@ public class MockInputColumn<E> extends AbstractInputColumn<E> {
 
     private String _name;
     private final Class<? extends E> _clazz;
+    private final Column _physicalColumn;
+
+    public MockInputColumn(Column physicalColumn, Class<? extends E> clazz) {
+        this(physicalColumn.getName(), clazz, physicalColumn);
+    }
 
     public MockInputColumn(String name) {
         this(name, null);
     }
 
     public MockInputColumn(String name, Class<? extends E> clazz) {
+        this(name, clazz, null);
+    }
+
+    public MockInputColumn(String name, Class<? extends E> clazz, Column physicalColumn) {
         _name = name;
         _clazz = clazz;
+        _physicalColumn = physicalColumn;
     }
 
     public void setName(String name) {
@@ -59,7 +69,7 @@ public class MockInputColumn<E> extends AbstractInputColumn<E> {
 
     @Override
     protected Column getPhysicalColumnInternal() {
-        return null;
+        return _physicalColumn;
     }
 
     @Override

--- a/engine/core/src/main/java/org/datacleaner/data/TransformedInputColumn.java
+++ b/engine/core/src/main/java/org/datacleaner/data/TransformedInputColumn.java
@@ -144,7 +144,7 @@ public class TransformedInputColumn<E> implements MutableInputColumn<E>, Seriali
     public boolean equals(Object obj) {
         // transformed input columns should always rely on identity equality -
         // other transformed columns with the same name, id etc. are NOT
-        // necesarily equal (may come from another job, or even a copy of the
+        // necessarily equal (may come from another job, or even a copy of the
         // job).
         return this == obj;
     }


### PR DESCRIPTION
This is the first attempt at making CoalesceUnit use paths instead of names. This avoids clashes between two tables with the same name.

Potential issues:
- Transformed columns may still very much clash
- Dots in names will probably cause problems
- Test test test... And then test some more. We have had many unexpected problems, and while this is a pretty minor change code-wise, the change could have big implications.

 Fixes #1056