### PR TITLE
Improved exception message when SaxExecutionIdentifierReader fails

### DIFF
--- a/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
@@ -21,8 +21,6 @@ package org.datacleaner.actions;
 
 import javax.swing.table.TableModel;
 
-import junit.framework.TestCase;
-
 import org.datacleaner.beans.filter.RangeFilterCategory;
 import org.datacleaner.beans.filter.StringLengthRangeFilter;
 import org.datacleaner.beans.standardize.EmailStandardizerTransformer;
@@ -45,10 +43,11 @@ import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.job.builder.FilterComponentBuilder;
 import org.datacleaner.job.builder.TransformerComponentBuilder;
-import org.datacleaner.job.builder.UnconfiguredConfiguredPropertyException;
 import org.datacleaner.test.MockOutputDataStreamAnalyzer;
 import org.datacleaner.test.MockTransformer;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("deprecation")
 public class PreviewTransformedDataActionListenerTest extends TestCase {
@@ -242,6 +241,7 @@ public class PreviewTransformedDataActionListenerTest extends TestCase {
     @Test()
     public void testUnchainedTransformers() throws Exception{
        
+        @SuppressWarnings("unused")
         final TransformerComponentBuilder<ConcatenatorTransformer> lengthTransformerBuilder = analysisJobBuilder
                 .addTransformer(ConcatenatorTransformer.class);
         

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -209,8 +209,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         for (RepositoryFolder tenantFolder : tenantFolders) {
             final String tenantId = tenantFolder.getName();
             try {
-                final Set<TriggerKey> triggerKeys = _scheduler
-                        .getTriggerKeys(GroupMatcher.triggerGroupEquals(tenantId));
+                final Set<TriggerKey> triggerKeys = _scheduler.getTriggerKeys(GroupMatcher.triggerGroupEquals(
+                        tenantId));
                 if (triggerKeys == null || triggerKeys.isEmpty()) {
                     logger.info("No triggers initialized for tenant: {}", tenantId);
                 } else {
@@ -263,8 +263,9 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         }
 
         final Map<String, String> immutableJobMetadataProperties = jobContext.getMetadataProperties();
-        //Convert Immutable map to mutable map as it will be transferred to a GWT object on the front end .
-        final Map<String, String> jobMetadataProperties = new HashMap<String,String>(immutableJobMetadataProperties); 
+        // Convert Immutable map to mutable map as it will be transferred to a
+        // GWT object on the front end .
+        final Map<String, String> jobMetadataProperties = new HashMap<String, String>(immutableJobMetadataProperties);
 
         final String groupName = jobContext.getGroupName();
 
@@ -292,7 +293,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     @Override
-    public ScheduleDefinition updateSchedule(final TenantIdentifier tenant, final ScheduleDefinition scheduleDefinition) {
+    public ScheduleDefinition updateSchedule(final TenantIdentifier tenant,
+            final ScheduleDefinition scheduleDefinition) {
 
         initializeSchedule(scheduleDefinition);
 
@@ -347,8 +349,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                     final String scheduleExpression = schedule.getCronExpression();
                     final CronExpression cronExpression = toCronExpression(scheduleExpression);
                     final CronScheduleBuilder cronSchedule = CronScheduleBuilder.cronSchedule(cronExpression);
-                    final CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(jobName, tenantId)
-                            .forJob(jobDetail).withSchedule(cronSchedule).startNow().build();
+                    final CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(jobName, tenantId).forJob(
+                            jobDetail).withSchedule(cronSchedule).startNow().build();
 
                     logger.info("Adding trigger to scheduler: {} | {}", jobName, cronExpression);
                     _scheduler.scheduleJob(jobDetail, trigger);
@@ -361,8 +363,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                     Date nextValidTimeAfter = cronExpression.getNextValidTimeAfter(new Date());
                     if (nextValidTimeAfter != null) {
                         final CronScheduleBuilder cronSchedule = CronScheduleBuilder.cronSchedule(cronExpression);
-                        final CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(jobName, tenantId)
-                                .forJob(jobDetail).withSchedule(cronSchedule).startNow().build();
+                        final CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(jobName, tenantId).forJob(
+                                jobDetail).withSchedule(cronSchedule).startNow().build();
                         logger.info("Adding trigger to scheduler for One time schedule: {} | {}", jobName,
                                 cronExpression);
                         _scheduler.scheduleJob(jobDetail, trigger);
@@ -392,11 +394,10 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
             dateInfoExtractor.setTime(oneTimeSchedule);
             int month = dateInfoExtractor.get(Calendar.MONTH) + 1;
             StringBuilder cronStringBuilder = new StringBuilder();
-            String cronBuilder = cronStringBuilder.append(" ").append(dateInfoExtractor.get(Calendar.SECOND))
-                    .append(" ").append(dateInfoExtractor.get(Calendar.MINUTE)).append(" ")
-                    .append(dateInfoExtractor.get(Calendar.HOUR_OF_DAY)).append(" ")
-                    .append(dateInfoExtractor.get(Calendar.DAY_OF_MONTH)).append(" ").append(month).append(" ? ")
-                    .append(dateInfoExtractor.get(Calendar.YEAR)).toString();
+            String cronBuilder = cronStringBuilder.append(" ").append(dateInfoExtractor.get(Calendar.SECOND)).append(
+                    " ").append(dateInfoExtractor.get(Calendar.MINUTE)).append(" ").append(dateInfoExtractor.get(
+                            Calendar.HOUR_OF_DAY)).append(" ").append(dateInfoExtractor.get(Calendar.DAY_OF_MONTH))
+                    .append(" ").append(month).append(" ? ").append(dateInfoExtractor.get(Calendar.YEAR)).toString();
             cronExpression = new CronExpression(cronBuilder);
         } catch (ParseException e) {
             throw new IllegalStateException("Failed to parse cron expression for one time schedule: "
@@ -492,8 +493,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                 }
             }
             if (addJob) {
-                final JobDetail jobDetail = JobBuilder.newJob(ExecuteJob.class)
-                        .withIdentity(jobNameToBeTriggered, tenant.getId()).storeDurably().build();
+                final JobDetail jobDetail = JobBuilder.newJob(ExecuteJob.class).withIdentity(jobNameToBeTriggered,
+                        tenant.getId()).storeDurably().build();
                 _scheduler.addJob(jobDetail, true);
             }
 
@@ -540,17 +541,17 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) {
         final TenantContext tenantContext = _tenantContextFactory.getContext(tenant);
         final RepositoryFolder resultFolder = tenantContext.getResultFolder();
-        final List<RepositoryFile> files = resultFolder.getFiles(job.getName(),
-                FileFilters.ANALYSIS_EXECUTION_LOG_XML.getExtension());
+        final List<RepositoryFile> files = resultFolder.getFiles(job.getName(), FileFilters.ANALYSIS_EXECUTION_LOG_XML
+                .getExtension());
 
         final List<ExecutionIdentifier> executionIdentifiers = CollectionUtils.map(files,
                 new Func<RepositoryFile, ExecutionIdentifier>() {
                     @Override
-                    public ExecutionIdentifier eval(RepositoryFile file) {
+                    public ExecutionIdentifier eval(final RepositoryFile file) {
                         ExecutionIdentifier result = file.readFile(new Func<InputStream, ExecutionIdentifier>() {
                             @Override
                             public ExecutionIdentifier eval(InputStream in) {
-                                return SaxExecutionIdentifierReader.read(in);
+                                return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
                             }
                         });
                         return result;
@@ -576,8 +577,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         final TenantContext tenantContext = _tenantContextFactory.getContext(tenant);
         final RepositoryFolder resultFolder = tenantContext.getResultFolder();
 
-        final RepositoryFile file = resultFolder.getFile(resultId
-                + FileFilters.ANALYSIS_EXECUTION_LOG_XML.getExtension());
+        final RepositoryFile file = resultFolder.getFile(resultId + FileFilters.ANALYSIS_EXECUTION_LOG_XML
+                .getExtension());
         if (file == null) {
             throw new IllegalArgumentException("No execution with result id: " + resultId);
         }
@@ -598,7 +599,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                     return reader.read(in, jobIdentifier, tenant);
                 } catch (JaxbException e) {
                     if (retries > 0) {
-                        logger.debug("Failed to read execution log in first pass. This could be because it is also being written at this time. Retrying.");
+                        logger.debug(
+                                "Failed to read execution log in first pass. This could be because it is also being written at this time. Retrying.");
                         return null;
                     } else {
                         logger.info("Failed to read execution log, returning unknown status.");

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/SaxExecutionIdentifierReader.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/SaxExecutionIdentifierReader.java
@@ -51,16 +51,27 @@ public class SaxExecutionIdentifierReader extends DefaultHandler {
         private static final long serialVersionUID = 1L;
     }
 
+    private final String _name;
     private final Map<String, String> _valueMap;
     private final StringBuilder _valueBuilder;
 
     private boolean _readChars;
 
+    @Deprecated
     public static ExecutionIdentifier read(InputStream in) {
         return new SaxExecutionIdentifierReader().parse(in);
     }
-
+    
+    public static ExecutionIdentifier read(InputStream in, String name) {
+        return new SaxExecutionIdentifierReader(name).parse(in);
+    }
+    
     private SaxExecutionIdentifierReader() {
+        this("<unknown>");
+    }
+
+    private SaxExecutionIdentifierReader(String name) {
+        _name = name;
         _valueMap = new HashMap<String, String>();
         _valueBuilder = new StringBuilder();
 
@@ -86,7 +97,7 @@ public class SaxExecutionIdentifierReader extends DefaultHandler {
             if (e instanceof StopParsingException) {
                 // parsing was stopped intentionally
             } else {
-                throw new IllegalStateException("Failed to parse ExecutionIdentifier document", e);
+                throw new IllegalStateException("Failed to parse ExecutionIdentifier document: " + _name, e);
             }
         }
         return createExecutionIdentifier();

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/xml/SaxExecutionIdentifierReaderTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/xml/SaxExecutionIdentifierReaderTest.java
@@ -24,8 +24,8 @@ import java.io.ByteArrayOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import junit.framework.TestCase;
-
+import org.apache.metamodel.util.DateUtils;
+import org.apache.metamodel.util.Month;
 import org.datacleaner.monitor.scheduling.model.ExecutionIdentifier;
 import org.datacleaner.monitor.scheduling.model.ExecutionLog;
 import org.datacleaner.monitor.scheduling.model.ExecutionStatus;
@@ -35,15 +35,15 @@ import org.datacleaner.monitor.server.jaxb.JaxbExecutionLogWriter;
 import org.datacleaner.monitor.server.jaxb.SaxExecutionIdentifierReader;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
 import org.datacleaner.monitor.shared.model.TenantIdentifier;
-import org.apache.metamodel.util.DateUtils;
-import org.apache.metamodel.util.Month;
+
+import junit.framework.TestCase;
 
 public class SaxExecutionIdentifierReaderTest extends TestCase {
 
     public void testRead() throws Exception {
 
-        final ScheduleDefinition schedule = new ScheduleDefinition(new TenantIdentifier("DC"),
-                new JobIdentifier("job1"), "my_ds");
+        final ScheduleDefinition schedule = new ScheduleDefinition(new TenantIdentifier("DC"), new JobIdentifier(
+                "job1"), "my_ds");
         schedule.setDependentJob(new JobIdentifier("job2"));
         final ExecutionLog executionLog = new ExecutionLog();
         executionLog.setResultId("my-result");
@@ -63,7 +63,7 @@ public class SaxExecutionIdentifierReaderTest extends TestCase {
 
         final ByteArrayInputStream in = new ByteArrayInputStream(bytes);
 
-        final ExecutionIdentifier result = SaxExecutionIdentifierReader.read(in);
+        final ExecutionIdentifier result = SaxExecutionIdentifierReader.read(in, "test file");
 
         assertEquals("my-result", result.getResultId());
         assertEquals(ExecutionStatus.SUCCESS, result.getExecutionStatus());


### PR DESCRIPTION
I made a small improvement here to ensure that if parsing fails, then the exception includes the file name so that investigation is easier. We recently had this happen for a customer and figuring out what went wrong wasn't very easy ...