### PR TITLE
Issue #1079: Implemented general purpose CLOB rendering for DCTables

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTableCellRenderer.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTableCellRenderer.java
@@ -47,95 +47,95 @@ import org.slf4j.LoggerFactory;
 
 public class DCTableCellRenderer implements TableCellRenderer {
 
-	private static final Logger logger = LoggerFactory.getLogger(DCTableCellRenderer.class);
+    private static final Logger logger = LoggerFactory.getLogger(DCTableCellRenderer.class);
 
-	private final DCTable _table;
-	private final Map<Integer, Alignment> _alignmentOverrides;
-	private final DefaultTableCellRenderer _delegate;
+    private final DCTable _table;
+    private final Map<Integer, Alignment> _alignmentOverrides;
+    private final DefaultTableCellRenderer _delegate;
 
-	public DCTableCellRenderer(DCTable table) {
-		super();
-		_table = table;
-		_alignmentOverrides = new HashMap<Integer, Alignment>();
-		_delegate = new DefaultTableCellRenderer();
-	}
+    public DCTableCellRenderer(DCTable table) {
+        super();
+        _table = table;
+        _alignmentOverrides = new HashMap<Integer, Alignment>();
+        _delegate = new DefaultTableCellRenderer();
+    }
 
-	@Override
-	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
-			int row, int column) {
-		logger.debug("getTableCellRendererComponent({},{})", row, column);
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+            int row, int column) {
+        logger.debug("getTableCellRendererComponent({},{})", row, column);
 
-		if (value != null && value.getClass().isArray()) {
+        if (value != null && value.getClass().isArray()) {
             // arrays are printed nicely this way
             value = ArrayUtils.toString(value);
-		}
+        }
 
-		// icons are displayed as labels
-		if (value instanceof Icon) {
-			final JLabel label = new JLabel((Icon) value);
-			label.setOpaque(true);
-			value = label;
-		}
-		
-		if (value instanceof Clob) {
-		    final Clob clob = (Clob) value;
-		    try {
-		        final Reader reader = clob.getCharacterStream();
-		        value = FileHelper.readAsString(reader);
-		    } catch (Exception e) {
-		        logger.error("Failed to read String from CLOB: {}", clob, e);
-		    }
-		}
+        // icons are displayed as labels
+        if (value instanceof Icon) {
+            final JLabel label = new JLabel((Icon) value);
+            label.setOpaque(true);
+            value = label;
+        }
 
-		final Component result;
+        if (value instanceof Clob) {
+            final Clob clob = (Clob) value;
+            try {
+                final Reader reader = clob.getCharacterStream();
+                value = FileHelper.readAsString(reader);
+            } catch (Exception e) {
+                logger.error("Failed to read String from CLOB: {}", clob, e);
+            }
+        }
 
-		// render components directly
-		if (value instanceof JComponent) {
-			final JComponent component = (JComponent) value;
+        final Component result;
 
-			component.setOpaque(true);
+        // render components directly
+        if (value instanceof JComponent) {
+            final JComponent component = (JComponent) value;
 
-			if (component.getMouseListeners().length == 0) {
-				component.addMouseListener(new MouseAdapter() {
-					@Override
-					public void mouseClicked(MouseEvent e) {
-						MouseEvent newEvent = SwingUtilities.convertMouseEvent(component, e, _table);
-						_table.consumeMouseClick(newEvent);
-					}
-				});
-			}
-			
-			result = component;
-		} else {
-			result = _delegate.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-			assert result instanceof JLabel;
-		}
+            component.setOpaque(true);
 
-		// alignment is applied to all labels or panels (with flowlayout)
-		Alignment alignment = _alignmentOverrides.get(column);
-		if (alignment == null) {
-			alignment = Alignment.LEFT;
-		}
+            if (component.getMouseListeners().length == 0) {
+                component.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        MouseEvent newEvent = SwingUtilities.convertMouseEvent(component, e, _table);
+                        _table.consumeMouseClick(newEvent);
+                    }
+                });
+            }
 
-		// set alignment
-		if (value instanceof JPanel) {
-			final LayoutManager layout = ((JPanel) value).getLayout();
-			if (layout instanceof FlowLayout) {
-				final FlowLayout flowLayout = (FlowLayout) layout;
-				flowLayout.setAlignment(alignment.getFlowLayoutAlignment());
-			}
-		} else if (result instanceof JLabel) {
-			final JLabel label = (JLabel) result;
-			label.setHorizontalAlignment(alignment.getSwingContstantsAlignment());
+            result = component;
+        } else {
+            result = _delegate.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            assert result instanceof JLabel;
+        }
 
-			WidgetUtils.setAppropriateFont(label);
-		}
+        // alignment is applied to all labels or panels (with flowlayout)
+        Alignment alignment = _alignmentOverrides.get(column);
+        if (alignment == null) {
+            alignment = Alignment.LEFT;
+        }
 
-		return result;
-	}
+        // set alignment
+        if (value instanceof JPanel) {
+            final LayoutManager layout = ((JPanel) value).getLayout();
+            if (layout instanceof FlowLayout) {
+                final FlowLayout flowLayout = (FlowLayout) layout;
+                flowLayout.setAlignment(alignment.getFlowLayoutAlignment());
+            }
+        } else if (result instanceof JLabel) {
+            final JLabel label = (JLabel) result;
+            label.setHorizontalAlignment(alignment.getSwingContstantsAlignment());
 
-	public void setAlignment(int column, Alignment alignment) {
-		_alignmentOverrides.put(column, alignment);
-	}
+            WidgetUtils.setAppropriateFont(label);
+        }
+
+        return result;
+    }
+
+    public void setAlignment(int column, Alignment alignment) {
+        _alignmentOverrides.put(column, alignment);
+    }
 
 }

--- a/desktop/api/src/test/java/org/datacleaner/widgets/table/DCTableCellRendererTest.java
+++ b/desktop/api/src/test/java/org/datacleaner/widgets/table/DCTableCellRendererTest.java
@@ -1,0 +1,85 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.widgets.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Component;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.sql.Clob;
+
+import javax.sql.rowset.serial.SerialClob;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+
+import org.datacleaner.widgets.DCLabel;
+import org.junit.Test;
+
+public class DCTableCellRendererTest {
+
+    @Test
+    public void testRenderClob() throws Exception {
+        final Clob clob = new SerialClob("foo bar baz".toCharArray());
+
+        // assert that the toString() method is not "foo bar baz" because that
+        // could be a potential implementation detail that would disturb the
+        // validity of the below assertions.
+        assertFalse("foo bar baz".equals(clob.toString()));
+
+        final DCTableCellRenderer renderer = new DCTableCellRenderer(null);
+        final Component component = renderer.getTableCellRendererComponent(new JTable(), clob, false, false, 1, 1);
+        assertTrue(component instanceof JLabel);
+
+        final JLabel label = (JLabel) component;
+        assertEquals("foo bar baz", label.getText());
+    }
+
+    @Test
+    public void testRenderIcon() throws Exception {
+        final Image image = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+        final Icon icon = new ImageIcon(image);
+
+        final DCTableCellRenderer renderer = new DCTableCellRenderer(null);
+        final Component component = renderer.getTableCellRendererComponent(new JTable(), icon, false, false, 1, 1);
+        assertTrue(component instanceof JLabel);
+
+        final JLabel label = (JLabel) component;
+        assertEquals(icon, label.getIcon());
+    }
+
+    @Test
+    public void testRenderJComponent() throws Exception {
+        final JComponent inputComponent = DCLabel.dark("hello world");
+
+        final DCTableCellRenderer renderer = new DCTableCellRenderer(null);
+        final Component component = renderer.getTableCellRendererComponent(new JTable(), inputComponent, false, false,
+                1, 1);
+        assertTrue(component instanceof JLabel);
+
+        assertSame(inputComponent, component);
+    }
+}


### PR DESCRIPTION
Fixes #1079 

The approach was not to go "narrowly" just after the preview source table window, but to take all data sets displayed. To do this I made the fix in the DCTableCellRenderer which is applied to all tables in DC desktop.