### PR TITLE
Allow column renames of fuse input

### DIFF
--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceMultipleFieldsTransformer.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceMultipleFieldsTransformer.java
@@ -35,6 +35,7 @@ import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.api.OutputColumns;
 import org.datacleaner.api.Transformer;
+import org.datacleaner.api.Validate;
 import org.datacleaner.components.categories.CompositionCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,14 @@ public class CoalesceMultipleFieldsTransformer implements Transformer {
         _initializedUnits = new CoalesceUnit[_units.length];
         for (int i = 0; i < _units.length; i++) {
             _initializedUnits[i] = _units[i].updateInputColumns(_input);
+        }
+    }
+
+    @Validate
+    public void validate() {
+        for (final CoalesceUnit _unit : _units) {
+            // Ensure that initialization is actually possible.
+            _unit.updateInputColumns(_input);
         }
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
@@ -25,6 +25,7 @@ import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -90,7 +91,7 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
         if (_componentBuilder.isConfigured()) {
             outputColumns = safeGetOutputColumns(transformerJobBuilder);
         } else {
-            outputColumns = new ArrayList<>(0);
+            outputColumns = Collections.emptyList();
         }
 
         _outputColumnsTable = new ColumnListTable(outputColumns, getAnalysisJobBuilder(), false, _windowContext);
@@ -148,7 +149,7 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
             return _componentBuilder.getOutputColumns();
         } catch (Exception e) {
             logger.warn("Could not get outputColumns for transformer {}", transformerJobBuilder.getName(), e);
-            return new ArrayList<>(0);
+            return Collections.emptyList();
         }
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
@@ -47,6 +47,8 @@ import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.ComboButton;
 import org.datacleaner.widgets.properties.PropertyWidgetFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Specialization of {@link AbstractComponentBuilderPanel} for
@@ -60,6 +62,7 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
         implements TransformerComponentBuilderPresenter, TransformerChangeListener {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger logger = LoggerFactory.getLogger(TransformerComponentBuilderPanel.class);
 
     private final TransformerComponentBuilder<?> _componentBuilder;
     private final ColumnListTable _outputColumnsTable;
@@ -85,10 +88,11 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
 
         final List<MutableInputColumn<?>> outputColumns;
         if (_componentBuilder.isConfigured()) {
-            outputColumns = _componentBuilder.getOutputColumns();
+            outputColumns = safeGetOutputColumns(transformerJobBuilder);
         } else {
-            outputColumns = new ArrayList<MutableInputColumn<?>>(0);
+            outputColumns = new ArrayList<>(0);
         }
+
         _outputColumnsTable = new ColumnListTable(outputColumns, getAnalysisJobBuilder(), false, _windowContext);
 
         _writeDataButton = WidgetFactory.createDefaultButton("Write data", IconUtils.COMPONENT_TYPE_WRITE_DATA);
@@ -136,6 +140,16 @@ public class TransformerComponentBuilderPanel extends AbstractComponentBuilderPa
                 menu.show(_previewAlternativesButton, horizontalPosition, _previewAlternativesButton.getHeight());
             }
         });
+    }
+
+    private List<MutableInputColumn<?>> safeGetOutputColumns(
+            final TransformerComponentBuilder<?> transformerJobBuilder) {
+        try {
+            return _componentBuilder.getOutputColumns();
+        } catch (Exception e) {
+            logger.warn("Could not get outputColumns for transformer {}", transformerJobBuilder.getName(), e);
+            return new ArrayList<>(0);
+        }
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
@@ -42,13 +42,15 @@ import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.DCComboBox;
 import org.datacleaner.widgets.SchemaStructureComboBoxListRenderer;
 import org.jdesktop.swingx.VerticalLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Panel that presents and edits a single {@link CoalesceUnit}.
  */
 public class CoalesceUnitPanel extends DCPanel {
-
     private static final long serialVersionUID = 1L;
+    private static final Logger logger = LoggerFactory.getLogger(CoalesceUnitPanel.class);
 
     private final ColumnListMultipleCoalesceUnitPropertyWidget _parent;
     private final DCComboBox<InputColumn<?>> _comboBox;
@@ -95,10 +97,14 @@ public class CoalesceUnitPanel extends DCPanel {
         setAvailableInputColumns(availableInputColumns);
 
         if (unit != null) {
-            InputColumn<?>[] inputColumns = unit.updateInputColumns(availableInputColumns
-                    .toArray(new InputColumn[availableInputColumns.size()])).getInputColumns();
-            for (InputColumn<?> inputColumn : inputColumns) {
-                addInputColumn(inputColumn);
+            try  {
+                InputColumn<?>[] inputColumns = unit.updateInputColumns(availableInputColumns
+                        .toArray(new InputColumn[availableInputColumns.size()])).getInputColumns();
+                for (InputColumn<?> inputColumn : inputColumns) {
+                    addInputColumn(inputColumn);
+                }
+            } catch (IllegalStateException e){
+                logger.warn("Could not update columns on component {}", parent.getComponentBuilder().getName(), e);
             }
         }
     }


### PR DESCRIPTION
This makes the fuse/coalesce transformer survive column renames. The connections will still be lost, though.

Fixes #1090