### PR TITLE
Bug/411-regexp-search-replace-empty-replacement

### DIFF
--- a/api/src/main/java/org/datacleaner/api/PatternProperty.java
+++ b/api/src/main/java/org/datacleaner/api/PatternProperty.java
@@ -1,0 +1,47 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Annotation containing supplementary metadata about a {@link Configured}
+ * pattern property. This metadata can be used as a way to give hints to the UI
+ * as to how the content should be presented.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+@Documented
+@Inherited
+@Qualifier
+public @interface PatternProperty {
+
+    /**
+     * @return true if an empty string value is acceptable
+     */
+    public boolean emptyString() default false;
+}

--- a/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/RegexSearchReplaceTransformer.java
+++ b/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/RegexSearchReplaceTransformer.java
@@ -31,6 +31,7 @@ import org.datacleaner.api.ExternalDocumentation;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.api.OutputColumns;
+import org.datacleaner.api.PatternProperty;
 import org.datacleaner.api.Transformer;
 import org.datacleaner.api.ExternalDocumentation.DocumentationLink;
 import org.datacleaner.api.ExternalDocumentation.DocumentationType;
@@ -52,7 +53,8 @@ public class RegexSearchReplaceTransformer implements Transformer {
 
     @Configured(order = 3)
     @Description("Regular expression pattern used for replacement.\nExample: 'Mister $1'")
-    Pattern replacementPattern;
+    @PatternProperty(emptyString = true)
+    Pattern replacementPattern = Pattern.compile("");
 
     @Override
     public OutputColumns getOutputColumns() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SinglePatternPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SinglePatternPropertyWidget.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.datacleaner.api.PatternProperty;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.util.WidgetFactory;
@@ -40,11 +41,15 @@ import org.jdesktop.swingx.JXTextField;
 public class SinglePatternPropertyWidget extends AbstractPropertyWidget<Pattern> implements DocumentListener {
 
 	private final JXTextField _textField;
+    private final PatternProperty patternPropertyAnnotation;
 
 	@Inject
 	public SinglePatternPropertyWidget(ConfiguredPropertyDescriptor propertyDescriptor,
 			ComponentBuilder componentBuilder) {
         super(componentBuilder, propertyDescriptor);
+        
+        patternPropertyAnnotation = propertyDescriptor.getAnnotation(PatternProperty.class);
+        
 		_textField = WidgetFactory.createTextField(propertyDescriptor.getName());
 		_textField.getDocument().addDocumentListener(this);
 		Pattern currentValue = getCurrentValue();
@@ -55,7 +60,12 @@ public class SinglePatternPropertyWidget extends AbstractPropertyWidget<Pattern>
 
 	@Override
 	public boolean isSet() {
-		return _textField.getText() != null && _textField.getText().length() > 0 && isValidPattern();
+	    if (_textField.getText() == null) {
+	        return false;
+	    }
+	    
+        return ((patternPropertyAnnotation != null && patternPropertyAnnotation.emptyString()) 
+                || _textField.getText().length() > 0) && isValidPattern();
 	}
 
 	@Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SinglePatternPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SinglePatternPropertyWidget.java
@@ -40,85 +40,85 @@ import org.jdesktop.swingx.JXTextField;
  */
 public class SinglePatternPropertyWidget extends AbstractPropertyWidget<Pattern> implements DocumentListener {
 
-	private final JXTextField _textField;
+    private final JXTextField _textField;
     private final PatternProperty patternPropertyAnnotation;
 
-	@Inject
-	public SinglePatternPropertyWidget(ConfiguredPropertyDescriptor propertyDescriptor,
-			ComponentBuilder componentBuilder) {
+    @Inject
+    public SinglePatternPropertyWidget(ConfiguredPropertyDescriptor propertyDescriptor,
+            ComponentBuilder componentBuilder) {
         super(componentBuilder, propertyDescriptor);
-        
-        patternPropertyAnnotation = propertyDescriptor.getAnnotation(PatternProperty.class);
-        
-		_textField = WidgetFactory.createTextField(propertyDescriptor.getName());
-		_textField.getDocument().addDocumentListener(this);
-		Pattern currentValue = getCurrentValue();
-		setValue(currentValue);
-		updateColor();
-		add(_textField);
-	}
 
-	@Override
-	public boolean isSet() {
-	    if (_textField.getText() == null) {
-	        return false;
-	    }
-	    
+        patternPropertyAnnotation = propertyDescriptor.getAnnotation(PatternProperty.class);
+
+        _textField = WidgetFactory.createTextField(propertyDescriptor.getName());
+        _textField.getDocument().addDocumentListener(this);
+        Pattern currentValue = getCurrentValue();
+        setValue(currentValue);
+        updateColor();
+        add(_textField);
+    }
+
+    @Override
+    public boolean isSet() {
+        if (_textField.getText() == null) {
+            return false;
+        }
+
         return ((patternPropertyAnnotation != null && patternPropertyAnnotation.emptyString()) 
                 || _textField.getText().length() > 0) && isValidPattern();
-	}
+    }
 
-	@Override
-	public Pattern getValue() {
-		try {
-			return Pattern.compile(_textField.getText());
-		} catch (PatternSyntaxException e) {
-			return null;
-		}
-	}
+    @Override
+    public Pattern getValue() {
+        try {
+            return Pattern.compile(_textField.getText());
+        } catch (PatternSyntaxException e) {
+            return null;
+        }
+    }
 
-	public boolean isValidPattern() {
-		try {
-			Pattern.compile(_textField.getText());
-		} catch (PatternSyntaxException e) {
-			return false;
-		}
-		return true;
-	}
+    public boolean isValidPattern() {
+        try {
+            Pattern.compile(_textField.getText());
+        } catch (PatternSyntaxException e) {
+            return false;
+        }
+        return true;
+    }
 
-	private void updateColor() {
-		if (_textField.getText() == null || _textField.getText().length() == 0) {
-			_textField.setBackground(Color.white);
-		} else if (isValidPattern()) {
-			_textField.setBackground(Color.green);
-			fireValueChanged();
-		} else {
-			_textField.setBackground(Color.red);
-		}
-	}
+    private void updateColor() {
+        if (_textField.getText() == null || _textField.getText().length() == 0) {
+            _textField.setBackground(Color.white);
+        } else if (isValidPattern()) {
+            _textField.setBackground(Color.green);
+            fireValueChanged();
+        } else {
+            _textField.setBackground(Color.red);
+        }
+    }
 
-	@Override
-	public void changedUpdate(DocumentEvent e) {
-		updateColor();
-	}
+    @Override
+    public void changedUpdate(DocumentEvent e) {
+        updateColor();
+    }
 
-	@Override
-	public void insertUpdate(DocumentEvent e) {
-		updateColor();
-	}
+    @Override
+    public void insertUpdate(DocumentEvent e) {
+        updateColor();
+    }
 
-	@Override
-	public void removeUpdate(DocumentEvent e) {
-		updateColor();
-	}
+    @Override
+    public void removeUpdate(DocumentEvent e) {
+        updateColor();
+    }
 
-	@Override
-	protected void setValue(Pattern value) {
-		if (value != null) {
-			String pattern = value.pattern();
-			if (!pattern.equals(_textField.getText())) {
-				_textField.setText(pattern);
-			}
-		}
-	}
+    @Override
+    protected void setValue(Pattern value) {
+        if (value != null) {
+            String pattern = value.pattern();
+            if (!pattern.equals(_textField.getText())) {
+                _textField.setText(pattern);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I added a PatternProperty annotation which can be used to indicate that a Pattern property is allowed to contain an empty string.

I added this annotation the the RegexSearchReplaceTransformer's replacePattern field and extended the SinglePatternPropertyWidget so it allows such a property to be empty if the annotation is used.