### PR TITLE
Added "Remove all columns" button to Create table dialog

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/CreateTableDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/CreateTableDialog.java
@@ -220,8 +220,18 @@ public class CreateTableDialog extends AbstractDialog {
                 addColumnDefinitionPanel();
             }
         });
+        
+        final JButton removeAllColumnsButton = WidgetFactory.createSmallButton("Remove all column",
+                IconUtils.ACTION_REMOVE);
+        removeAllColumnsButton.setForeground(WidgetUtils.ADDITIONAL_COLOR_RED_BRIGHT);
+        removeAllColumnsButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                removeAllColumns();
+            }
+        });
 
-        final DCPanel buttonPanel = DCPanel.around(addColumnButton);
+        final DCPanel buttonPanel = DCPanel.flow(addColumnButton, removeAllColumnsButton);
         buttonPanel.setBorder(WidgetUtils.BORDER_EMPTY);
 
         final DCPanel panel = new DCPanel(WidgetUtils.COLOR_WELL_BACKGROUND);
@@ -272,6 +282,13 @@ public class CreateTableDialog extends AbstractDialog {
     public void addColumnDefinitionPanel() {
         final CreateTableColumnDefintionPanel columnDefintionPanel = new CreateTableColumnDefintionPanel(this);
         addColumnDefinitionPanel(columnDefintionPanel);
+    }
+    
+
+    protected void removeAllColumns() {
+        _columnDefinitionPanels.clear();
+        _columnsListPanel.removeAll();
+        _columnsListPanel.updateUI();
     }
 
     private void addColumnDefinitionPanel(CreateTableColumnDefintionPanel columnDefintionPanel) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/CreateTableDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/CreateTableDialog.java
@@ -221,7 +221,7 @@ public class CreateTableDialog extends AbstractDialog {
             }
         });
         
-        final JButton removeAllColumnsButton = WidgetFactory.createSmallButton("Remove all column",
+        final JButton removeAllColumnsButton = WidgetFactory.createSmallButton("Remove all columns",
                 IconUtils.ACTION_REMOVE);
         removeAllColumnsButton.setForeground(WidgetUtils.ADDITIONAL_COLOR_RED_BRIGHT);
         removeAllColumnsButton.addActionListener(new ActionListener() {


### PR DESCRIPTION
On a customer engagement today we faced that it is sometimes convenient to be able to remove all columns from the "Create table" dialog. This PR does that:

![image](https://cloud.githubusercontent.com/assets/291450/12751153/b855a9f4-c9bb-11e5-9fa5-9f1bede8ff2c.png)
