### PR TITLE
Allow spaces in (some) reference data

### DIFF
--- a/api/src/main/java/org/datacleaner/reference/DictionaryConnection.java
+++ b/api/src/main/java/org/datacleaner/reference/DictionaryConnection.java
@@ -23,8 +23,9 @@ import java.io.Closeable;
 import java.util.Iterator;
 
 public interface DictionaryConnection extends Closeable {
-
     public boolean containsValue(String value);
+
+    public Iterator<String> getLengthSortedValues();
 
     public Iterator<String> getAllValues();
 

--- a/api/src/main/java/org/datacleaner/reference/SynonymCatalogConnection.java
+++ b/api/src/main/java/org/datacleaner/reference/SynonymCatalogConnection.java
@@ -21,8 +21,14 @@ package org.datacleaner.reference;
 
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.List;
 
 public interface SynonymCatalogConnection extends Closeable {
+    interface Replacement {
+        String getReplacedString();
+        List<String> getSynonyms();
+        List<String> getMasterTerms();
+    }
 
     /**
      * @return all synonyms contained within this catalog
@@ -37,7 +43,14 @@ public interface SynonymCatalogConnection extends Closeable {
      * @return the master term found, or null if none is found
      */
     public String getMasterTerm(String term);
-    
+
+    /**
+     * Replaces all synonyms with master terms in a sentence.
+     *
+     * @param sentence The sentence to run the replacement on.
+     */
+    public Replacement replaceInline(String sentence);
+
     @Override
     public void close();
 }

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
@@ -52,9 +52,7 @@ public class JavaScriptTransformer implements Transformer {
 	private static final Logger logger = LoggerFactory
 			.getLogger(JavaScriptTransformer.class);
 
-	public static enum ReturnType {
-		STRING, NUMBER, BOOLEAN;
-	}
+	public enum ReturnType {STRING, NUMBER, BOOLEAN}
 
 	@Configured
 	InputColumn<?>[] columns;

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
@@ -52,7 +52,9 @@ public class JavaScriptTransformer implements Transformer {
 	private static final Logger logger = LoggerFactory
 			.getLogger(JavaScriptTransformer.class);
 
-	public enum ReturnType {STRING, NUMBER, BOOLEAN}
+	public static enum ReturnType {
+		STRING, NUMBER, BOOLEAN;
+	}
 
 	@Configured
 	InputColumn<?>[] columns;

--- a/components/reference-data/src/main/java/org/datacleaner/beans/transform/RemoveDictionaryMatchesTransformer.java
+++ b/components/reference-data/src/main/java/org/datacleaner/beans/transform/RemoveDictionaryMatchesTransformer.java
@@ -48,9 +48,7 @@ import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.reference.DictionaryConnection;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
 @Named("Remove dictionary matches")
@@ -94,8 +92,8 @@ public class RemoveDictionaryMatchesTransformer implements Transformer {
     @Provided
     DataCleanerConfiguration _configuration;
 
-    private DictionaryConnection dictionaryConnection;
-    private List<String> dictionary;
+    private DictionaryConnection _dictionaryConnection;
+    private List<String> dictionaryValues;
 
     public RemoveDictionaryMatchesTransformer() {
     }
@@ -134,20 +132,20 @@ public class RemoveDictionaryMatchesTransformer implements Transformer {
 
     @Initialize
     public void init() {
-        dictionaryConnection = _dictionary.openConnection(_configuration);
-        dictionary = new ArrayList<>();
+        _dictionaryConnection = _dictionary.openConnection(_configuration);
+        dictionaryValues = new ArrayList<>();
 
-        final Iterator<String> allValues = dictionaryConnection.getAllValues();
+        final Iterator<String> allValues = _dictionaryConnection.getLengthSortedValues();
         while (allValues.hasNext()) {
-            dictionary.add(allValues.next());
+            dictionaryValues.add(allValues.next());
         }
     }
 
     @Close
     public void close() {
-        if (dictionaryConnection != null) {
-            dictionaryConnection.close();
-            dictionaryConnection = null;
+        if (_dictionaryConnection != null) {
+            _dictionaryConnection.close();
+            _dictionaryConnection = null;
         }
     }
 
@@ -160,7 +158,7 @@ public class RemoveDictionaryMatchesTransformer implements Transformer {
     public Object[] transform(String value) {
         final List<String> removedParts = new ArrayList<>(2);
         if (!Strings.isNullOrEmpty(value)) {
-            for(String entry : dictionary) {
+            for(String entry : dictionaryValues) {
                 final Matcher matcher = Pattern.compile("\\b" + Pattern.quote(entry) + "\\b").matcher(value);
                 while(matcher.find()){
                     final int start;

--- a/components/reference-data/src/test/java/org/datacleaner/beans/transform/RemoveDictionaryMatchesTransformerTest.java
+++ b/components/reference-data/src/test/java/org/datacleaner/beans/transform/RemoveDictionaryMatchesTransformerTest.java
@@ -74,31 +74,30 @@ public class RemoveDictionaryMatchesTransformerTest extends TestCase {
         assertEquals("Software Engineer", transformer.transform("Senior Software Engineer")[0]);
         assertEquals("Senior", transformer.transform("Senior Software Engineer")[1]);
         
-        assertEquals("Designer", transformer.transform("  Lead   Designer  ")[0]);
+        assertEquals("    Designer  ", transformer.transform("  Lead   Designer  ")[0]);
         assertEquals("Lead", transformer.transform("  Lead   Designer  ")[1]);
         
-        assertEquals("Software Engineer", transformer.transform("Software  Engineer")[0]);
+        assertEquals("Software  Engineer", transformer.transform("Software  Engineer")[0]);
         assertEquals("", transformer.transform("Software  Engineer")[1]);
         
         assertEquals("Guru of employees", transformer.transform("Principal Senior Lead Guru of Junior employees")[0]);
-        assertEquals("Principal Senior Lead Junior", transformer.transform("Principal Senior Lead Guru of Junior employees")[1]);
+        assertEquals("Principal Junior Senior Lead", transformer.transform("Principal Senior Lead Guru of Junior employees")[1]);
    
     }
     public void testJobTitleScenarioRemovedMatchesAsList() throws Throwable {
-    
         transformer._removedMatchesType= RemovedMatchesType.LIST;
         
         assertEquals("Software Engineer", transformer.transform("Senior Software Engineer")[0]);
         assertEquals("[Senior]", transformer.transform("Senior Software Engineer")[1].toString());
         
-        assertEquals("Designer", transformer.transform("  Lead   Designer  ")[0]);
+        assertEquals("    Designer  ", transformer.transform("  Lead   Designer  ")[0]);
         assertEquals("[Lead]", transformer.transform("  Lead   Designer  ")[1].toString());
         
-        assertEquals("Software Engineer", transformer.transform("Software  Engineer")[0]);
+        assertEquals("Software  Engineer", transformer.transform("Software  Engineer")[0]);
         assertEquals("[]", transformer.transform("Software  Engineer")[1].toString());
         
         assertEquals("Guru of employees", transformer.transform("Principal Senior Lead Guru of Junior employees")[0]);
-        assertEquals("[Principal, Senior, Lead, Junior]", transformer.transform("Principal Senior Lead Guru of Junior employees")[1].toString());
+        assertEquals("[Principal, Junior, Senior, Lead]", transformer.transform("Principal Senior Lead Guru of Junior employees")[1].toString());
         
         assertEquals("", transformer.transform("")[0]);
         assertEquals("[]", transformer.transform("")[1].toString()); 

--- a/components/reference-data/src/test/java/org/datacleaner/beans/transform/SynonymLookupTransformerTest.java
+++ b/components/reference-data/src/test/java/org/datacleaner/beans/transform/SynonymLookupTransformerTest.java
@@ -70,6 +70,7 @@ public class SynonymLookupTransformerTest extends TestCase {
         // with retain original value
         SynonymLookupTransformer transformer = new SynonymLookupTransformer(col, sc, true, configuration);
         transformer.lookUpEveryToken = true;
+        transformer.replacedSynonymsType = SynonymLookupTransformer.ReplacedSynonymsType.LIST;
         transformer.init();
         assertEquals(3, transformer.getOutputColumns().getColumnCount());
         assertEquals("my col (synonyms replaced)", transformer.getOutputColumns().getColumnName(0));

--- a/components/reference-data/src/test/resources/synonym-countries.txt
+++ b/components/reference-data/src/test/resources/synonym-countries.txt
@@ -1,3 +1,3 @@
 DNK,Denmark,Danmark,DK
 ALB,Albania
-GBR,Great britain,Great Britain,UK,United kingdom,United Kingdom,England
+GBR,Britain,Great britain,Great Britain,UK,United kingdom,United Kingdom,England

--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/MockMonitoredDictionary.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/MockMonitoredDictionary.java
@@ -66,6 +66,11 @@ public class MockMonitoredDictionary extends AbstractReferenceData implements Di
     public DictionaryConnection openConnection(DataCleanerConfiguration arg0) {
         return new DictionaryConnection() {
             @Override
+            public Iterator<String> getLengthSortedValues() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public Iterator<String> getAllValues() {
                 throw new UnsupportedOperationException();
             }

--- a/desktop/ui/src/test/resources/documentation/synonym_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/synonym_lookup.html
@@ -145,6 +145,17 @@ h3 {
 					</li> 					<li class="list-group-item">
 						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+							 Replaced synonyms type
+						</h3> <p>How should the synonyms and the master terms that replaced them be returned? As a concatenated String or as a List.</p> <!-- type --> <span
+						class="label label-primary">Choice:</span>  <span class="label label-default">String</span>
+						 <span class="label label-default">List</span>
+						 
+
+						<!-- required/optional -->  <span
+						class="label label-info">Required</span> 
+					</li> 					<li class="list-group-item">
+						<h3>
+							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
 							 Retain original value
 						</h3> <p>Retain original value in case no synonym is found (otherwise null)</p> <!-- type --> <span
 						class="label label-primary">boolean</span>  

--- a/engine/core/src/main/java/org/datacleaner/reference/DatastoreDictionaryConnection.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/DatastoreDictionaryConnection.java
@@ -58,6 +58,11 @@ final class DatastoreDictionaryConnection implements DictionaryConnection {
     }
 
     @Override
+    public Iterator<String> getLengthSortedValues() {
+        return _dictionary.loadIntoMemory(_datastoreConnection).openConnection(null).getLengthSortedValues();
+    }
+
+    @Override
     public void close() {
         _datastoreConnection.close();
     }

--- a/engine/core/src/main/java/org/datacleaner/reference/DatastoreSynonymCatalogConnection.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/DatastoreSynonymCatalogConnection.java
@@ -72,6 +72,12 @@ final class DatastoreSynonymCatalogConnection implements SynonymCatalogConnectio
     }
 
     @Override
+    public Replacement replaceInline(final String sentence) {
+        final SimpleSynonymCatalog simpleSynonymCatalog = _synonymCatalog.loadIntoMemory(_datastoreConnection);
+        return simpleSynonymCatalog.openConnection(null).replaceInline(sentence);
+    }
+
+    @Override
     public void close() {
         _datastoreConnection.close();
     }

--- a/engine/core/src/main/java/org/datacleaner/reference/SimpleDictionary.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/SimpleDictionary.java
@@ -137,14 +137,18 @@ public final class SimpleDictionary extends AbstractReferenceData implements Dic
 
     @Override
     public DictionaryConnection openConnection(DataCleanerConfiguration configuration) {
-        final SortedSet<String> connectionValueSet = new TreeSet<>(Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
-        connectionValueSet.addAll(_valueSet);
         return new DictionaryConnection() {
-            SortedSet<String> _values = connectionValueSet;
 
             @Override
             public Iterator<String> getAllValues() {
-                return _values.iterator();
+                return _valueSet.iterator();
+            }
+
+            @Override
+            public Iterator<String> getLengthSortedValues() {
+                final SortedSet<String> connectionValueSet = new TreeSet<>(Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
+                connectionValueSet.addAll(_valueSet);
+                return connectionValueSet.iterator();
             }
 
             @Override
@@ -155,7 +159,7 @@ public final class SimpleDictionary extends AbstractReferenceData implements Dic
                 if (!_caseSensitive) {
                     value = value.toLowerCase();
                 }
-                return _values.contains(value);
+                return _valueSet.contains(value);
             }
 
             @Override

--- a/engine/core/src/main/java/org/datacleaner/reference/SimpleDictionary.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/SimpleDictionary.java
@@ -25,9 +25,12 @@ import java.io.ObjectInputStream.GetField;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.util.ReadObjectBuilder;
@@ -134,10 +137,14 @@ public final class SimpleDictionary extends AbstractReferenceData implements Dic
 
     @Override
     public DictionaryConnection openConnection(DataCleanerConfiguration configuration) {
+        final SortedSet<String> connectionValueSet = new TreeSet<>(Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
+        connectionValueSet.addAll(_valueSet);
         return new DictionaryConnection() {
+            SortedSet<String> _values = connectionValueSet;
+
             @Override
             public Iterator<String> getAllValues() {
-                return _valueSet.iterator();
+                return _values.iterator();
             }
 
             @Override
@@ -148,7 +155,7 @@ public final class SimpleDictionary extends AbstractReferenceData implements Dic
                 if (!_caseSensitive) {
                     value = value.toLowerCase();
                 }
-                return _valueSet.contains(value);
+                return _values.contains(value);
             }
 
             @Override
@@ -160,7 +167,6 @@ public final class SimpleDictionary extends AbstractReferenceData implements Dic
     public Set<String> getValueSet() {
         return _valueSet;
     }
-
     public boolean isCaseSensitive() {
         return _caseSensitive;
     }

--- a/engine/core/src/main/java/org/datacleaner/reference/SimpleSynonymCatalog.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/SimpleSynonymCatalog.java
@@ -133,6 +133,8 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
     @Override
     public SynonymCatalogConnection openConnection(DataCleanerConfiguration configuration) {
         return new SynonymCatalogConnection() {
+
+
             SortedMap<String, String> _sortedSynonymMap = createSortedSynonymMap();
 
             @Override

--- a/engine/core/src/main/java/org/datacleaner/reference/SimpleSynonymCatalog.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/SimpleSynonymCatalog.java
@@ -21,16 +21,20 @@ package org.datacleaner.reference;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.ObjectInputStream.GetField;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.util.ReadObjectBuilder;
@@ -46,10 +50,11 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
     private static final long serialVersionUID = 1L;
 
     private final Map<String, String> _synonymMap;
+
     private final boolean _caseSensitive;
 
     public SimpleSynonymCatalog(String name) {
-        this(name, new HashMap<String, String>());
+        this(name, new HashMap<>());
     }
 
     public SimpleSynonymCatalog(String name, Map<String, String> synonyms) {
@@ -58,17 +63,22 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
 
     public SimpleSynonymCatalog(String name, Map<String, String> synonyms, boolean caseSensitive) {
         super(name);
-        if (caseSensitive) {
-            _synonymMap = synonyms;
+        _caseSensitive = caseSensitive;
+        _synonymMap = synonyms;
+    }
+
+    private SortedMap<String, String> createSortedSynonymMap() {
+        SortedMap<String, String> synonymMap = new TreeMap<>(Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
+        if (_caseSensitive) {
+            synonymMap.putAll(_synonymMap);
         } else {
-            _synonymMap = new HashMap<String, String>();
-            final Set<Entry<String, String>> entries = synonyms.entrySet();
+            final Set<Entry<String, String>> entries = _synonymMap.entrySet();
             for (Entry<String, String> entry : entries) {
                 final String key = entry.getKey().toLowerCase();
-                _synonymMap.put(key, entry.getValue());
+                synonymMap.put(key, entry.getValue());
             }
         }
-        _caseSensitive = caseSensitive;
+        return synonymMap;
     }
 
     public SimpleSynonymCatalog(String name, Synonym... synonyms) {
@@ -88,7 +98,7 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
     private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
         Adaptor adaptor = new Adaptor() {
             @Override
-            public void deserialize(GetField getField, Serializable serializable) throws Exception {
+            public void deserialize(ObjectInputStream.GetField getField, Serializable serializable) throws Exception {
                 final boolean caseSensitive = getField.get("_caseSensitive", true);
                 Field field = SimpleSynonymCatalog.class.getDeclaredField("_caseSensitive");
                 field.setAccessible(true);
@@ -123,11 +133,12 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
     @Override
     public SynonymCatalogConnection openConnection(DataCleanerConfiguration configuration) {
         return new SynonymCatalogConnection() {
+            SortedMap<String, String> _sortedSynonymMap = createSortedSynonymMap();
 
             @Override
             public Collection<Synonym> getSynonyms() {
-                final Map<String, Synonym> synonyms = new TreeMap<String, Synonym>();
-                for (Entry<String, String> synonymEntry : _synonymMap.entrySet()) {
+                final Map<String, Synonym> synonyms = new TreeMap<>();
+                for (Entry<String, String> synonymEntry : _sortedSynonymMap.entrySet()) {
                     final String masterTerm = synonymEntry.getValue();
                     final String synonymValue = synonymEntry.getKey();
 
@@ -148,8 +159,50 @@ public final class SimpleSynonymCatalog extends AbstractReferenceData implements
                     return null;
                 }
                 final String key = _caseSensitive ? term : term.toLowerCase();
-                final String masterTerm = _synonymMap.get(key);
-                return masterTerm;
+                return _sortedSynonymMap.get(key);
+            }
+
+            @Override
+            public Replacement replaceInline(String sentence) {
+                final List<String> synonyms = new ArrayList<>();
+                final List<String> masterTerms = new ArrayList<>();
+
+                if(!_caseSensitive){
+                    sentence = sentence.toLowerCase();
+                }
+
+                for(String synonym : _sortedSynonymMap.keySet()) {
+                    if(masterTerms.contains(synonym)){
+                        continue;
+                    }
+
+                    final Matcher matcher = Pattern.compile("\\b" + synonym + "\\b").matcher(sentence);
+                    while(matcher.find()){
+                        final String masterTerm = _sortedSynonymMap.get(synonym);
+                        sentence =
+                                sentence.substring(0, matcher.start()) + masterTerm + sentence.substring(matcher.end());
+                        synonyms.add(synonym);
+                        masterTerms.add(masterTerm);
+                    }
+                }
+
+                final String finalSentence = sentence;
+                return new Replacement() {
+                    @Override
+                    public String getReplacedString() {
+                        return finalSentence;
+                    }
+
+                    @Override
+                    public List<String> getSynonyms() {
+                        return synonyms;
+                    }
+
+                    @Override
+                    public List<String> getMasterTerms() {
+                        return masterTerms;
+                    }
+                };
             }
 
             @Override

--- a/engine/core/src/test/java/org/datacleaner/reference/SimpleSynonymCatalogTest.java
+++ b/engine/core/src/test/java/org/datacleaner/reference/SimpleSynonymCatalogTest.java
@@ -41,6 +41,24 @@ public class SimpleSynonymCatalogTest extends TestCase {
         }
     }
 
+    public void testReplaceInline() {
+        final SimpleSynonymCatalog sc =
+                new SimpleSynonymCatalog("countries", Arrays.asList(new Synonym[] { new SimpleSynonym("Test", "land"),
+                        new SimpleSynonym("DNK", "Denmark", "Danmark"), new SimpleSynonym("NLD", "The netherlands") }));
+
+        final SynonymCatalogConnection connection = sc.openConnection(null);
+        final SynonymCatalogConnection.Replacement replacement =
+                connection.replaceInline("The netherlands, Denmark, Holland, land");
+        assertEquals("NLD, DNK, Holland, Test", replacement.getReplacedString());
+        assertEquals("The netherlands", replacement.getSynonyms().get(0));
+        assertEquals("Denmark", replacement.getSynonyms().get(1));
+        assertEquals("land", replacement.getSynonyms().get(2));
+        assertEquals("NLD", replacement.getMasterTerms().get(0));
+        assertEquals("DNK", replacement.getMasterTerms().get(1));
+        assertEquals("Test", replacement.getMasterTerms().get(2));
+
+    }
+
     public void testGetSynonyms() throws Exception {
         final SimpleSynonymCatalog sc = new SimpleSynonymCatalog("countries", Arrays.asList(new Synonym[] {
                 new SimpleSynonym("DNK", "Denmark", "Danmark"), new SimpleSynonym("NLD", "The netherlands") }));

--- a/engine/core/src/test/java/org/datacleaner/reference/TextFileSynonymCatalogTest.java
+++ b/engine/core/src/test/java/org/datacleaner/reference/TextFileSynonymCatalogTest.java
@@ -51,6 +51,7 @@ public class TextFileSynonymCatalogTest extends TestCase {
         }
     }
 
+
     public void testCountrySynonymsCaseInsensitive() throws Exception {
         SynonymCatalog cat = new TextFileSynonymCatalog("foobar", "src/test/resources/synonym-countries.txt", false,
                 "UTF-8");

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomDictionary.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomDictionary.java
@@ -20,8 +20,6 @@
 package org.datacleaner.configuration;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -29,6 +27,7 @@ import org.datacleaner.api.Configured;
 import org.datacleaner.connection.Datastore;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.reference.DictionaryConnection;
+import org.datacleaner.reference.SimpleDictionary;
 import org.junit.Ignore;
 
 @Ignore
@@ -65,14 +64,16 @@ public class SampleCustomDictionary implements Dictionary {
 
     @Override
     public DictionaryConnection openConnection(DataCleanerConfiguration arg0) {
-        final List<String> valueList = new ArrayList<String>();
+        final List<String> valueList = new ArrayList<>();
         for (int i = 0; i < SampleCustomDictionary.this.values; i++) {
             valueList.add("value" + i);
         }
 
-        Collections
-                .sort(valueList, Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
         return new DictionaryConnection() {
+            @Override
+            public Iterator<String> getLengthSortedValues() {
+                return new SimpleDictionary("test", valueList).openConnection(null).getLengthSortedValues();
+            }
 
             @Override
             public Iterator<String> getAllValues() {

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomDictionary.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomDictionary.java
@@ -20,6 +20,8 @@
 package org.datacleaner.configuration;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -67,6 +69,9 @@ public class SampleCustomDictionary implements Dictionary {
         for (int i = 0; i < SampleCustomDictionary.this.values; i++) {
             valueList.add("value" + i);
         }
+
+        Collections
+                .sort(valueList, Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo));
         return new DictionaryConnection() {
 
             @Override

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomSynonymCatalog.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/SampleCustomSynonymCatalog.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.datacleaner.api.Configured;
 import org.datacleaner.reference.SimpleSynonym;
+import org.datacleaner.reference.SimpleSynonymCatalog;
 import org.datacleaner.reference.Synonym;
 import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.reference.SynonymCatalogConnection;
@@ -56,7 +57,7 @@ public class SampleCustomSynonymCatalog implements SynonymCatalog {
 
             @Override
             public Collection<Synonym> getSynonyms() {
-                List<Synonym> result = new ArrayList<Synonym>();
+                List<Synonym> result = new ArrayList<>();
                 for (String[] strings : values) {
                     result.add(new SimpleSynonym(strings[0], strings));
                 }
@@ -77,6 +78,14 @@ public class SampleCustomSynonymCatalog implements SynonymCatalog {
                     }
                 }
                 return null;
+            }
+
+            @Override
+            public Replacement replaceInline(final String sentence) {
+                final Collection<Synonym> synonyms = getSynonyms();
+                final Synonym[] synonymsArray = synonyms.toArray(new Synonym[synonyms.size()]);
+                final SimpleSynonymCatalog simpleSynonymCatalog = new SimpleSynonymCatalog(getName(), synonymsArray);
+                return simpleSynonymCatalog.openConnection(null).replaceInline(sentence);
             }
 
             @Override


### PR DESCRIPTION
This allows spaces in dictionaries and synonym lists for RemoveDictionaryMatches and SynonymLookup transformers.

Fixes #1116
