### PR TITLE
Fix for preview filter issue.

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
+++ b/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
@@ -202,7 +202,7 @@ public final class PreviewTransformedDataActionListener implements ActionListene
                                         .getComponentRequirement();
                                 if (existingRequirement != null) {
                                     componentBuilder.setComponentRequirement(new CompoundComponentRequirement(
-                                            CompoundComponentRequirement.CompundingType.ALL,
+                                            CompoundComponentRequirement.CompoundingType.ALL,
                                             existingRequirement, maxRowFilter.getFilterOutcome(
                                             MaxRowsFilter.Category.VALID)));
                                 } else {

--- a/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
+++ b/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
@@ -202,8 +202,9 @@ public final class PreviewTransformedDataActionListener implements ActionListene
                                         .getComponentRequirement();
                                 if (existingRequirement != null) {
                                     componentBuilder.setComponentRequirement(new CompoundComponentRequirement(
+                                            CompoundComponentRequirement.CompundingType.ALL,
                                             existingRequirement, maxRowFilter.getFilterOutcome(
-                                                    MaxRowsFilter.Category.VALID)));
+                                            MaxRowsFilter.Category.VALID)));
                                 } else {
                                     componentBuilder.setComponentRequirement(new SimpleComponentRequirement(maxRowFilter
                                             .getFilterOutcome(MaxRowsFilter.Category.VALID)));

--- a/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
+++ b/desktop/api/src/main/java/org/datacleaner/actions/PreviewTransformedDataActionListener.java
@@ -63,7 +63,20 @@ import org.slf4j.LoggerFactory;
  */
 public final class PreviewTransformedDataActionListener implements ActionListener, Callable<TableModel> {
 
-    private static final String METADATA_PROPERTY_MARKER = "org.datacleaner.preview.targetcomponent";
+    public static class PreviewJob {
+        public final AnalysisJobBuilder analysisJobBuilder;
+        public final AnalyzerComponentBuilder<?> rowCollectorAnalyzer;
+        public final TransformerComponentBuilder<?> previewedTransformer;
+
+        public PreviewJob(AnalysisJobBuilder analysisJobBuilder, AnalyzerComponentBuilder<?> rowCollectorAnalyzer,
+                TransformerComponentBuilder<?> previewedTransformer) {
+            this.analysisJobBuilder = analysisJobBuilder;
+            this.rowCollectorAnalyzer = rowCollectorAnalyzer;
+            this.previewedTransformer = previewedTransformer;
+        }
+    }
+
+    public static final String METADATA_PROPERTY_MARKER = "org.datacleaner.preview.targetcomponent";
 
     private static final Logger logger = LoggerFactory.getLogger(PreviewTransformedDataActionListener.class);
 
@@ -108,8 +121,7 @@ public final class PreviewTransformedDataActionListener implements ActionListene
         _latestWindow = window;
     }
 
-    @Override
-    public TableModel call() throws Exception {
+    protected PreviewJob createPreviewJob() {
         if (_transformerJobBuilderPresenter != null) {
             _transformerJobBuilderPresenter.applyPropertyValues();
         }
@@ -156,7 +168,7 @@ public final class PreviewTransformedDataActionListener implements ActionListene
         if (sourceColumns.isEmpty()) {
             logger.error("No source columns left after removing irrelevant source tables. Component: {}",
                     _transformerJobBuilder);
-            return new DefaultTableModel(0, 0);
+            return null;
         }
 
         // add the result collector (a dummy analyzer)
@@ -201,10 +213,11 @@ public final class PreviewTransformedDataActionListener implements ActionListene
                                 final ComponentRequirement existingRequirement = componentBuilder
                                         .getComponentRequirement();
                                 if (existingRequirement != null) {
-                                    componentBuilder.setComponentRequirement(new CompoundComponentRequirement(
-                                            CompoundComponentRequirement.CompoundingType.ALL,
-                                            existingRequirement, maxRowFilter.getFilterOutcome(
-                                            MaxRowsFilter.Category.VALID)));
+                                    if (componentBuilder.getDescriptor().isMultiStreamComponent()) {
+                                        componentBuilder.setComponentRequirement(new CompoundComponentRequirement(
+                                                existingRequirement, maxRowFilter.getFilterOutcome(
+                                                        MaxRowsFilter.Category.VALID)));
+                                    }
                                 } else {
                                     componentBuilder.setComponentRequirement(new SimpleComponentRequirement(maxRowFilter
                                             .getFilterOutcome(MaxRowsFilter.Category.VALID)));
@@ -216,13 +229,26 @@ public final class PreviewTransformedDataActionListener implements ActionListene
             }
         }
 
+        return new PreviewJob(rootJobBuilder, rowCollector, tjb);
+    }
+
+    @Override
+    public TableModel call() throws Exception {
+        final PreviewJob previewJob = createPreviewJob();
+
+        if (previewJob == null) {
+            return new DefaultTableModel(0, 0);
+        }
+
+        final AnalyzerComponentBuilder<?> rowCollector = previewJob.rowCollectorAnalyzer;
+
         final String[] columnNames = new String[rowCollector.getInputColumns().size()];
         for (int i = 0; i < columnNames.length; i++) {
             columnNames[i] = rowCollector.getInputColumns().get(i).getName();
         }
 
-        final AnalysisRunner runner = new AnalysisRunnerImpl(ajb.getConfiguration());
-        final AnalysisResultFuture resultFuture = runner.run(rootJobBuilder.toAnalysisJob());
+        final AnalysisRunner runner = new AnalysisRunnerImpl(previewJob.analysisJobBuilder.getConfiguration());
+        final AnalysisResultFuture resultFuture = runner.run(previewJob.analysisJobBuilder.toAnalysisJob());
 
         resultFuture.await();
 

--- a/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
+++ b/desktop/api/src/main/java/org/datacleaner/panels/TransformerComponentBuilderPanel.java
@@ -24,7 +24,6 @@ import java.awt.FlowLayout;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
@@ -19,6 +19,9 @@
  */
 package org.datacleaner.actions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.swing.table.TableModel;
 
 import org.datacleaner.beans.filter.EqualsFilter;
@@ -51,6 +54,8 @@ import org.datacleaner.test.MockTransformer;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import com.google.common.base.Joiner;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
@@ -300,8 +305,17 @@ public class PreviewTransformedDataActionListenerTest {
         assertEquals(200, tableModel.getRowCount());
 
         for(int i=0; i<tableModel.getRowCount();i++){
-            assertNotEquals(tableModel.getValueAt(i,0).toString(), tableModel.getValueAt(i,1).toString());
+            assertTrue(printRow(tableModel, i), tableModel.getValueAt(i,0) == null || tableModel.getValueAt(i,1) == null);
         }
+    }
+
+    private String printRow(TableModel tableModel, int row) {
+        List<String> values = new ArrayList<>(tableModel.getColumnCount());
+        for (int i = 0;i<tableModel.getColumnCount(); i++) {
+            Object value = tableModel.getValueAt(row, i);
+            values.add(value == null?"<null>":value.toString());
+        }
+        return Joiner.on(',').join(values);
     }
 
     @Test()

--- a/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
@@ -254,7 +254,6 @@ public class PreviewTransformedDataActionListenerTest {
     }
 
     @Test
-    @Ignore
     public void testFilterWithCoalesce() throws Exception {
         analysisJobBuilder.removeAllComponents();
         analysisJobBuilder.removeAllSourceColumns();

--- a/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testFilterWithCoalesce.analysis.xml
+++ b/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testFilterWithCoalesce.analysis.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <updated-date>2016-02-09+01:00</updated-date>
+        <metadata-properties>
+            <property name="org.datacleaner.preview.targetcomponent">test</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="orderdb"/>
+        <columns>
+            <column id="col_customernumber" path="CUSTOMERS.CUSTOMERNUMBER" type="INTEGER"/>
+            <column id="col_country" path="CUSTOMERS.COUNTRY" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation>
+        <transformer requires="outcome_0" name="English customers">
+            <descriptor ref="Convert to string"/>
+            <properties>
+                <property name="Null replacement" value="&amp;lt;null&amp;gt;"/>
+            </properties>
+            <input ref="col_customernumber"/>
+            <input value="foo"/>
+            <output id="col_customernumberenglish" name="CUSTOMERNUMBER (English)"/>
+            <output id="col_fooasstring" name="&quot;foo&quot; (as string)"/>
+        </transformer>
+        <transformer requires="outcome_1" name="Non-English customers">
+            <descriptor ref="Convert to string"/>
+            <properties>
+                <property name="Null replacement" value="&amp;lt;null&amp;gt;"/>
+            </properties>
+            <input ref="col_customernumber"/>
+            <input value="foo"/>
+            <output id="col_customernumbernonenglish" name="CUSTOMERNUMBER (Non-English)"/>
+            <output id="col_fooasstring2" name="&quot;foo&quot; (as string)"/>
+        </transformer>
+        <transformer requires="outcome_2">
+            <descriptor ref="Fuse / Coalesce fields"/>
+            <properties>
+                <property name="Consider empty string as null" value="true"/>
+                <property name="Units" value="[&amp;#91;CUSTOMERNUMBER (English)&amp;#44;CUSTOMERNUMBER (Non-English)&amp;#93;]"/>
+            </properties>
+            <input ref="col_customernumberenglish"/>
+            <input ref="col_customernumbernonenglish"/>
+            <output id="col_fusecoalescefields1" name="Fuse / Coalesce fields (1)"/>
+        </transformer>
+        <filter requires="outcome_2">
+            <descriptor ref="Equals"/>
+            <properties>
+                <property name="Compare values" value="[US,UK,GB,USA]"/>
+            </properties>
+            <input ref="col_country" name="Input column"/>
+            <outcome id="outcome_0" category="EQUALS"/>
+            <outcome id="outcome_1" category="NOT_EQUALS"/>
+        </filter>
+        <filter name="org.datacleaner.actions.PreviewTransformedDataActionListener-CUSTOMERS-MaxRows">
+            <descriptor ref="Max rows"/>
+            <properties>
+                <property name="Apply ordering" value="false"/>
+                <property name="First row" value="1"/>
+                <property name="Max rows" value="200"/>
+            </properties>
+            <input ref="col_customernumber"/>
+            <outcome id="outcome_2" category="VALID"/>
+        </filter>
+    </transformation>
+    <analysis>
+        <analyzer requires="outcome_2">
+            <descriptor ref="Preview transformed data analyzer"/>
+            <properties/>
+            <input ref="col_customernumberenglish"/>
+            <input ref="col_customernumbernonenglish"/>
+            <input ref="col_fusecoalescefields1"/>
+        </analyzer>
+    </analysis>
+</job>

--- a/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testPreviewTransformationInMultiStreamGeneratedOutputDataStream.analysis.xml
+++ b/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testPreviewTransformationInMultiStreamGeneratedOutputDataStream.analysis.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <updated-date>2016-02-09+01:00</updated-date>
+        <metadata-properties>
+            <property name="org.datacleaner.preview.targetcomponent">test</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="orderdb"/>
+        <columns>
+            <column id="col_email" path="EMPLOYEES.EMAIL" type="VARCHAR"/>
+            <column id="col_phone" path="CUSTOMERS.PHONE" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation>
+        <transformer requires="outcome_0">
+            <descriptor ref="Email standardizer"/>
+            <properties/>
+            <input ref="col_email"/>
+            <output id="col_username" name="Username"/>
+            <output id="col_domain" name="Domain"/>
+        </transformer>
+        <transformer requires="outcome_0 OR outcome_1">
+            <descriptor ref="Union"/>
+            <properties>
+                <property name="Units" value="[&amp;#91;PUBLIC.EMPLOYEES.EMAIL&amp;#44;PUBLIC.CUSTOMERS.PHONE&amp;#93;]"/>
+            </properties>
+            <input ref="col_email"/>
+            <input ref="col_phone"/>
+            <output-data-stream name="output">
+                <job>
+                    <source>
+                        <columns>
+                            <column id="col_email2" path="EMAIL" type="VARCHAR"/>
+                        </columns>
+                    </source>
+                    <transformation>
+                        <transformer>
+                            <descriptor ref="Mock transformer"/>
+                            <properties/>
+                            <input ref="col_email2"/>
+                            <output id="col_mockoutput" name="mock output"/>
+                        </transformer>
+                    </transformation>
+                    <analysis>
+                        <analyzer>
+                            <descriptor ref="Preview transformed data analyzer"/>
+                            <properties/>
+                            <input ref="col_email2"/>
+                            <input ref="col_mockoutput"/>
+                        </analyzer>
+                    </analysis>
+                </job>
+            </output-data-stream>
+        </transformer>
+        <filter name="org.datacleaner.actions.PreviewTransformedDataActionListener-EMPLOYEES-MaxRows">
+            <descriptor ref="Max rows"/>
+            <properties>
+                <property name="Apply ordering" value="false"/>
+                <property name="First row" value="1"/>
+                <property name="Max rows" value="5"/>
+            </properties>
+            <input ref="col_email"/>
+            <outcome id="outcome_0" category="VALID"/>
+        </filter>
+        <filter name="org.datacleaner.actions.PreviewTransformedDataActionListener-CUSTOMERS-MaxRows">
+            <descriptor ref="Max rows"/>
+            <properties>
+                <property name="Apply ordering" value="false"/>
+                <property name="First row" value="1"/>
+                <property name="Max rows" value="5"/>
+            </properties>
+            <input ref="col_phone"/>
+            <outcome id="outcome_1" category="VALID"/>
+        </filter>
+    </transformation>
+    <analysis/>
+</job>

--- a/engine/core/src/main/java/org/datacleaner/job/AnalysisJobImmutabilizer.java
+++ b/engine/core/src/main/java/org/datacleaner/job/AnalysisJobImmutabilizer.java
@@ -92,7 +92,8 @@ public final class AnalysisJobImmutabilizer {
             }
         } else if (req instanceof CompoundComponentRequirement) {
             boolean changed = false;
-            final Set<FilterOutcome> originalOutcomes = ((CompoundComponentRequirement) req).getOutcomes();
+            final CompoundComponentRequirement componentRequirement = (CompoundComponentRequirement) req;
+            final Set<FilterOutcome> originalOutcomes = componentRequirement.getOutcomes();
             final List<FilterOutcome> loadedOutcomes = new ArrayList<>(originalOutcomes.size());
             for (final FilterOutcome originalOutcome : originalOutcomes) {
                 final FilterOutcome loadedOutcome = load(originalOutcome);
@@ -102,7 +103,7 @@ public final class AnalysisJobImmutabilizer {
                 loadedOutcomes.add(loadedOutcome);
             }
             if (changed) {
-                return new CompoundComponentRequirement(loadedOutcomes);
+                return new CompoundComponentRequirement(componentRequirement.getCompoundingType(), loadedOutcomes);
             }
         }
         return req;

--- a/engine/core/src/main/java/org/datacleaner/job/AnalysisJobImmutabilizer.java
+++ b/engine/core/src/main/java/org/datacleaner/job/AnalysisJobImmutabilizer.java
@@ -103,7 +103,7 @@ public final class AnalysisJobImmutabilizer {
                 loadedOutcomes.add(loadedOutcome);
             }
             if (changed) {
-                return new CompoundComponentRequirement(componentRequirement.getCompoundingType(), loadedOutcomes);
+                return new CompoundComponentRequirement(loadedOutcomes);
             }
         }
         return req;

--- a/engine/core/src/main/java/org/datacleaner/job/CompoundComponentRequirement.java
+++ b/engine/core/src/main/java/org/datacleaner/job/CompoundComponentRequirement.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.metamodel.util.HasName;
 import org.datacleaner.api.InputRow;
 
 /**
@@ -35,56 +34,21 @@ import org.datacleaner.api.InputRow;
 public class CompoundComponentRequirement implements ComponentRequirement {
     private static final long serialVersionUID = 1L;
 
-    public enum CompoundingType implements HasName {
-        ANY("OR"), ALL("AND");
-
-        private final String _name;
-
-        CompoundingType(String name) {
-            _name = name;
-        }
-
-        public String getName() {
-            return _name;
-        }
-
-        public String toString() {
-            return " " + getName() + " ";
-        }
-    }
-
     private final Set<FilterOutcome> _outcomes;
-    private final CompoundingType _compoundingType;
-
-    public CompoundComponentRequirement(CompoundingType compoundingType, Collection<? extends FilterOutcome> outcomes) {
-        _outcomes = new LinkedHashSet<>(outcomes);
-        _compoundingType = compoundingType;
-    }
 
     public CompoundComponentRequirement(Collection<? extends FilterOutcome> outcomes) {
-        this(CompoundingType.ANY, outcomes);
-    }
-
-    public CompoundComponentRequirement(CompoundingType compoundingType, FilterOutcome... outcomes) {
-        _outcomes = new LinkedHashSet<>();
-        Collections.addAll(_outcomes, outcomes);
-        _compoundingType = compoundingType;
+        _outcomes = new LinkedHashSet<>(outcomes);
     }
 
     public CompoundComponentRequirement(FilterOutcome... outcomes) {
-        this(CompoundingType.ANY, outcomes);
-    }
-
-    public CompoundComponentRequirement(CompoundingType compoundingType, ComponentRequirement existingRequirement,
-            FilterOutcome filterOutcome) {
         _outcomes = new LinkedHashSet<>();
-        _outcomes.addAll(existingRequirement.getProcessingDependencies());
-        _outcomes.add(filterOutcome);
-        _compoundingType = compoundingType;
+        Collections.addAll(_outcomes, outcomes);
     }
 
     public CompoundComponentRequirement(ComponentRequirement existingRequirement, FilterOutcome filterOutcome) {
-        this(CompoundingType.ANY, existingRequirement, filterOutcome);
+        _outcomes = new LinkedHashSet<>();
+        _outcomes.addAll(existingRequirement.getProcessingDependencies());
+        _outcomes.add(filterOutcome);
     }
 
     /**
@@ -95,10 +59,6 @@ public class CompoundComponentRequirement implements ComponentRequirement {
      */
     public Set<FilterOutcome> getOutcomes() {
         return _outcomes;
-    }
-
-    public CompoundingType getCompoundingType() {
-        return _compoundingType;
     }
 
     public Set<FilterOutcome> getOutcomesFrom(HasFilterOutcomes producingComponent) {
@@ -130,21 +90,12 @@ public class CompoundComponentRequirement implements ComponentRequirement {
 
     @Override
     public boolean isSatisfied(InputRow row, FilterOutcomes outcomes) {
-        if(_compoundingType == CompoundingType.ANY || row == null) {
-            for (FilterOutcome outcome : outcomes.getOutcomes()) {
-                if (_outcomes.contains(outcome)) {
-                    return true;
-                }
+        for (FilterOutcome outcome : outcomes.getOutcomes()) {
+            if (_outcomes.contains(outcome)) {
+                return true;
             }
-            return false;
-        } else {
-            for (FilterOutcome outcome : outcomes.getOutcomes()) {
-                if (!_outcomes.contains(outcome)) {
-                    return false;
-                }
-            }
-            return true;
         }
+        return false;
     }
 
     @Override
@@ -152,7 +103,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
         final StringBuilder sb = new StringBuilder();
         for (FilterOutcome outcome : _outcomes) {
             if (sb.length() != 0) {
-                sb.append(_compoundingType);
+                sb.append(" OR ");
             }
             sb.append(outcome.getSimpleName());
         }
@@ -164,7 +115,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
         final StringBuilder sb = new StringBuilder();
         for (FilterOutcome outcome : _outcomes) {
             if (sb.length() != 0) {
-                sb.append(_compoundingType);
+                sb.append(" OR ");
             }
             sb.append(outcome.toString());
         }
@@ -173,7 +124,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(_outcomes, _compoundingType);
+        return Objects.hash(_outcomes);
     }
 
     @Override
@@ -186,6 +137,6 @@ public class CompoundComponentRequirement implements ComponentRequirement {
             return false;
         final CompoundComponentRequirement other = (CompoundComponentRequirement) obj;
 
-        return Objects.equals(_outcomes, other._outcomes) && _compoundingType == other._compoundingType;
+        return Objects.equals(_outcomes, other._outcomes);
     }
 }

--- a/engine/core/src/main/java/org/datacleaner/job/CompoundComponentRequirement.java
+++ b/engine/core/src/main/java/org/datacleaner/job/CompoundComponentRequirement.java
@@ -35,12 +35,12 @@ import org.datacleaner.api.InputRow;
 public class CompoundComponentRequirement implements ComponentRequirement {
     private static final long serialVersionUID = 1L;
 
-    public enum CompundingType implements HasName {
+    public enum CompoundingType implements HasName {
         ANY("OR"), ALL("AND");
 
         private final String _name;
 
-        CompundingType(String name) {
+        CompoundingType(String name) {
             _name = name;
         }
 
@@ -54,28 +54,28 @@ public class CompoundComponentRequirement implements ComponentRequirement {
     }
 
     private final Set<FilterOutcome> _outcomes;
-    private final CompundingType _compoundingType;
+    private final CompoundingType _compoundingType;
 
-    public CompoundComponentRequirement(CompundingType compoundingType, Collection<? extends FilterOutcome> outcomes) {
+    public CompoundComponentRequirement(CompoundingType compoundingType, Collection<? extends FilterOutcome> outcomes) {
         _outcomes = new LinkedHashSet<>(outcomes);
         _compoundingType = compoundingType;
     }
 
     public CompoundComponentRequirement(Collection<? extends FilterOutcome> outcomes) {
-        this(CompundingType.ANY, outcomes);
+        this(CompoundingType.ANY, outcomes);
     }
 
-    public CompoundComponentRequirement(CompundingType compoundingType, FilterOutcome... outcomes) {
+    public CompoundComponentRequirement(CompoundingType compoundingType, FilterOutcome... outcomes) {
         _outcomes = new LinkedHashSet<>();
         Collections.addAll(_outcomes, outcomes);
         _compoundingType = compoundingType;
     }
 
     public CompoundComponentRequirement(FilterOutcome... outcomes) {
-        this(CompundingType.ANY, outcomes);
+        this(CompoundingType.ANY, outcomes);
     }
 
-    public CompoundComponentRequirement(CompundingType compoundingType, ComponentRequirement existingRequirement,
+    public CompoundComponentRequirement(CompoundingType compoundingType, ComponentRequirement existingRequirement,
             FilterOutcome filterOutcome) {
         _outcomes = new LinkedHashSet<>();
         _outcomes.addAll(existingRequirement.getProcessingDependencies());
@@ -84,7 +84,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
     }
 
     public CompoundComponentRequirement(ComponentRequirement existingRequirement, FilterOutcome filterOutcome) {
-        this(CompundingType.ANY, existingRequirement, filterOutcome);
+        this(CompoundingType.ANY, existingRequirement, filterOutcome);
     }
 
     /**
@@ -97,7 +97,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
         return _outcomes;
     }
 
-    public CompundingType getCompoundingType() {
+    public CompoundingType getCompoundingType() {
         return _compoundingType;
     }
 
@@ -130,7 +130,7 @@ public class CompoundComponentRequirement implements ComponentRequirement {
 
     @Override
     public boolean isSatisfied(InputRow row, FilterOutcomes outcomes) {
-        if(_compoundingType == CompundingType.ANY || row == null) {
+        if(_compoundingType == CompoundingType.ANY || row == null) {
             for (FilterOutcome outcome : outcomes.getOutcomes()) {
                 if (_outcomes.contains(outcome)) {
                     return true;
@@ -186,7 +186,6 @@ public class CompoundComponentRequirement implements ComponentRequirement {
             return false;
         final CompoundComponentRequirement other = (CompoundComponentRequirement) obj;
 
-        // TODO: This wasn't anything equivalent to deepEquals before... But should it have been?
         return Objects.equals(_outcomes, other._outcomes) && _compoundingType == other._compoundingType;
     }
 }

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobWriterTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobWriterTest.java
@@ -31,11 +31,8 @@ import java.util.List;
 
 import javax.xml.datatype.DatatypeFactory;
 
-import junit.framework.TestCase;
-
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.Table;
-import org.apache.metamodel.util.FileHelper;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.beans.CompletenessAnalyzer;
@@ -69,6 +66,8 @@ import org.datacleaner.job.jaxb.JobMetadataType;
 import org.datacleaner.test.MockAnalyzer;
 import org.datacleaner.test.TestHelper;
 import org.easymock.EasyMock;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("deprecation")
 public class JaxbJobWriterTest extends TestCase {
@@ -444,15 +443,8 @@ public class JaxbJobWriterTest extends TestCase {
             _writer.write(analysisJob, bos);
             bos.flush();
         }
-
-        String output = FileHelper.readFileAsString(outputFile);
-        File benchmarkFile = new File(benchmarkFolder, filename);
-
-        if (!benchmarkFile.exists()) {
-            assertEquals("No benchmark file '" + filename + "' exists!", output);
-        }
-
-        String benchmark = FileHelper.readFileAsString(benchmarkFile);
-        assertEquals(benchmark, output);
+        
+        final File benchmarkFile = new File(benchmarkFolder, filename);
+        TestHelper.assertXmlFilesEquals(benchmarkFile, outputFile);
     }
 }

--- a/testware/src/main/java/org/datacleaner/test/TestHelper.java
+++ b/testware/src/main/java/org/datacleaner/test/TestHelper.java
@@ -19,10 +19,14 @@
  */
 package org.datacleaner.test;
 
+import java.io.File;
+
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.metamodel.util.FileHelper;
 import org.datacleaner.connection.Datastore;
+import org.junit.Assert;
 
 public class TestHelper {
 
@@ -39,4 +43,21 @@ public class TestHelper {
         return new TestDatastore(name, createSampleDatabaseDataSource());
     }
 
+    public static void assertXmlFilesEquals(File benchmarkFile, File outputFile) {
+        final String output = FileHelper.readFileAsString(outputFile);
+
+        if (!benchmarkFile.exists()) {
+            Assert.assertEquals("No benchmark file '" + benchmarkFile + "' exists!", output);
+        }
+
+        final String benchmark = FileHelper.readFileAsString(benchmarkFile);
+        Assert.assertEquals(trimXmlForComparison(benchmark), trimXmlForComparison(output));
+    }
+
+    public static String trimXmlForComparison(String xml) {
+        if (xml == null) {
+            return null;
+        }
+        return xml.trim().replace("\r\n", "\n");
+    }
 }


### PR DESCRIPTION
Issue was that max rows filter was added using OR compound filter, meaning that all other filters was essentially nuked (as well as the max rows filter if the other filters has an outcome).

I extended the filter to also support ALL scenario, though it is a bit of weird hybrid now (normally ALL scenario is done by chaining requirements).

For some reason, this does NOT fix the test case, allthough it fixed a manual test in DC (I used the first example Kasper provided in fixed case).

This fix is obviously not mergeable with a broken unit test, but I'd like some feedback to my approach.

## DO NOT MERGE IN CURRENT STATE!

Fixes #1047