### PR TITLE
Fixes #1107 - resolving tenant ID from serialized User object.

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SecureGwtServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SecureGwtServlet.java
@@ -103,8 +103,8 @@ public class SecureGwtServlet extends RemoteServiceServlet {
 
         final Authentication authentication = (Authentication) principal;
 
-        final UserBean user = new UserBean(getTenantResolver());
-        user.updateUser(authentication);
+        final UserBean user = new UserBean();
+        user.updateUser(authentication, getTenantResolver());
 
         return user.hasRole(roleName);
     }
@@ -122,8 +122,8 @@ public class SecureGwtServlet extends RemoteServiceServlet {
 
         final Authentication authentication = (Authentication) principal;
 
-        final UserBean user = new UserBean(getTenantResolver());
-        user.updateUser(authentication);
+        final UserBean user = new UserBean();
+        user.updateUser(authentication, getTenantResolver());
 
         final Method method = request.getMethod();
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/TenantInfoController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/TenantInfoController.java
@@ -19,9 +19,7 @@
  */
 package org.datacleaner.monitor.server.controllers;
 
-import org.datacleaner.monitor.server.security.TenantResolver;
 import org.datacleaner.monitor.server.security.UserBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,14 +33,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/_user")
 public class TenantInfoController {
 
-    @Autowired
-    private TenantResolver _tenantResolver;
-
     @ResponseBody
     @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public UserInfo getUserInfo() {
         UserInfo userInfo = new UserInfo();
-        final UserBean user = new UserBean(_tenantResolver);
+        final UserBean user = new UserBean();
         user.updateUser();
         userInfo.tenant = user.getTenant();
         userInfo.username= user.getUsername();

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/security/TenantCheckFilter.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/security/TenantCheckFilter.java
@@ -70,8 +70,8 @@ public class TenantCheckFilter extends GenericFilterBean {
                     logger.warn("Could not perform tenant check because Authentication is null");
                 } else {
 
-                    final UserBean user = new UserBean(_tenantResolver);
-                    user.updateUser(authentication);
+                    final UserBean user = new UserBean();
+                    user.updateUser(authentication, _tenantResolver);
 
                     final String userTenantId = user.getTenant();
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/security/UserBean.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/security/UserBean.java
@@ -27,14 +27,16 @@ import java.util.List;
 import java.util.Set;
 
 import org.datacleaner.monitor.shared.model.SecurityRoles;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.WebApplicationContext;
+
+import com.google.common.base.Strings;
 
 @Component("user")
 @Scope(WebApplicationContext.SCOPE_SESSION)
@@ -42,14 +44,21 @@ public class UserBean implements User, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final transient TenantResolver _tenantResolver;
     private final Set<String> _roles;
     private String _username;
     private String _tenant;
-
-    @Autowired
+    
+    /**
+     * 
+     * @param tenantResolver
+     * @deprecated use {@link #UserBean()} instead
+     */
+    @Deprecated
     public UserBean(TenantResolver tenantResolver) {
-        _tenantResolver = tenantResolver;
+        this();
+    }
+
+    public UserBean() {
         _roles = new HashSet<String>();
     }
 
@@ -59,6 +68,12 @@ public class UserBean implements User, Serializable {
     }
 
     public void updateUser(final Authentication authentication) {
+        final WebApplicationContext applicationContext = ContextLoader.getCurrentWebApplicationContext();
+        final TenantResolver tenantResolver = applicationContext.getBean(TenantResolver.class);
+        updateUser(authentication, tenantResolver);
+    }
+
+    public void updateUser(final Authentication authentication, final TenantResolver tenantResolver) {
         _roles.clear();
 
         if (authentication == null || !authentication.isAuthenticated()
@@ -67,7 +82,14 @@ public class UserBean implements User, Serializable {
             _tenant = null;
         } else {
             _username = authentication.getName();
-            _tenant = (_tenantResolver == null ? null : _tenantResolver.getTenantId(_username));
+            if (tenantResolver == null) {
+                // can happen in deserialized object cases
+                if (Strings.isNullOrEmpty(_tenant)) {
+                    throw new IllegalArgumentException("TenantResolver cannot be null when tenant is also null");
+                }
+            } else {
+                _tenant = tenantResolver.getTenantId(_username);
+            }
 
             final Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
             for (GrantedAuthority authority : authorities) {
@@ -107,7 +129,7 @@ public class UserBean implements User, Serializable {
 
     @Override
     public String getTenant() {
-        if (_tenant == null) {
+        if (Strings.isNullOrEmpty(_tenant)) {
             updateUser();
         }
         return _tenant;

--- a/monitor/services/src/main/java/org/datacleaner/result/renderer/InteractiveWriteDataResultHtmlRenderer.java
+++ b/monitor/services/src/main/java/org/datacleaner/result/renderer/InteractiveWriteDataResultHtmlRenderer.java
@@ -73,7 +73,7 @@ public class InteractiveWriteDataResultHtmlRenderer implements Renderer<WriteDat
         // TODO: Dirty way of obtaining the user bean - ideally we would be able
         // to just inject it, but SpringInjectionManager does not support
         // session scoped beans.
-        final UserBean user = new UserBean(_tenantResolver);
+        final UserBean user = new UserBean();
         user.updateUser();
 
         final WriteDataResultHtmlRenderer delegateRenderer = new WriteDataResultHtmlRenderer();


### PR DESCRIPTION
Fixes #1107 

After much investigation I finally found out what this was about - that the tenant ID was actually set as null by ```UserBean.updateUser()``` in cases where the UserBean had been deserialized by Tomcat! The way this happened was that TenantResolver was transient and in the ```updateUser``` call there was a "if tenant resolver is null, then tenant ID is null" kind of logic. Now instead we do not keep the tenant resolver in the UserBean, so it should never be null.