### PR TITLE
Wrong property shown for input columns mapped to enum

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/PropertyWidgetFactoryImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/PropertyWidgetFactoryImpl.java
@@ -99,8 +99,8 @@ public final class PropertyWidgetFactoryImpl implements PropertyWidgetFactory {
                 final MultipleMappedStringsPropertyWidget propertyWidget = new MultipleMappedStringsPropertyWidget(
                         getComponentBuilder(), mappedToProperty, mappedProperty);
                 final PropertyWidgetMapping mapping = new PropertyWidgetMapping();
-                mapping.putMapping(mappedProperty, propertyWidget);
-                mapping.putMapping(mappedToProperty, propertyWidget.getMappedStringsPropertyWidget());
+                mapping.putMapping(mappedProperty, propertyWidget.getMappedStringsPropertyWidget());
+                mapping.putMapping(mappedToProperty, propertyWidget);
                 return mapping;
             }
 
@@ -109,8 +109,8 @@ public final class PropertyWidgetFactoryImpl implements PropertyWidgetFactory {
                 final MultipleMappedEnumsPropertyWidget propertyWidget = new MultipleMappedEnumsPropertyWidget(
                         getComponentBuilder(), mappedToProperty, mappedProperty);
                 final PropertyWidgetMapping mapping = new PropertyWidgetMapping();
-                mapping.putMapping(mappedProperty, propertyWidget);
-                mapping.putMapping(mappedToProperty, propertyWidget.getMappedEnumsPropertyWidget());
+                mapping.putMapping(mappedProperty, propertyWidget.getMappedEnumsPropertyWidget());
+                mapping.putMapping(mappedToProperty, propertyWidget);
                 return mapping;
             }
         }


### PR DESCRIPTION
When you map input columns to an enum type input field using the `@MappedProperty` annotation, the wrong property was rendered, the input columns should be rendered, not the property to which they are mapped.