### PR TITLE
Upgraded to MetaModel 4.5.1 and updated test benchmark differences

### DIFF
--- a/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testPreviewTransformationInMultiStreamGeneratedOutputDataStream.analysis.xml
+++ b/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testPreviewTransformationInMultiStreamGeneratedOutputDataStream.analysis.xml
@@ -27,7 +27,7 @@
                 <job>
                     <source>
                         <columns>
-                            <column id="col_email2" path="EMAIL" type="VARCHAR"/>
+                            <column id="col_email2" path="EMAIL" type="STRING"/>
                         </columns>
                     </source>
                     <transformation>

--- a/engine/xml-config/src/test/resources/JaxbJobWriterTest-testReadAndWriteOutputDataStreamsJob.xml
+++ b/engine/xml-config/src/test/resources/JaxbJobWriterTest-testReadAndWriteOutputDataStreamsJob.xml
@@ -37,7 +37,7 @@
                 <job>
                     <source>
                         <columns>
-                            <column id="col_concatoffirstnamelastname" path="Concat of FIRSTNAME,LASTNAME" type="VARCHAR"/>
+                            <column id="col_concatoffirstnamelastname" path="Concat of FIRSTNAME,LASTNAME" type="STRING"/>
                             <column id="col_reportsto2" path="REPORTSTO" type="INTEGER"/>
                         </columns>
                     </source>
@@ -62,7 +62,7 @@
                 <job>
                     <source>
                         <columns>
-                            <column id="col_concatoffirstnamelastname2" path="Concat of FIRSTNAME,LASTNAME" type="VARCHAR"/>
+                            <column id="col_concatoffirstnamelastname2" path="Concat of FIRSTNAME,LASTNAME" type="STRING"/>
                             <column id="col_reportsto3" path="REPORTSTO" type="INTEGER"/>
                         </columns>
                     </source>

--- a/pom.xml
+++ b/pom.xml
@@ -52,19 +52,6 @@
 	<url>http://datacleaner.org</url>
 	<packaging>pom</packaging>
 	
-	<repositories>
-		<repository>
-        <id>metamodel-staging</id>
-        <url>https://repository.apache.org/content/repositories/orgapachemetamodel-1016/</url>
-        <releases>
-           <enabled>true</enabled>
-        </releases>
-        <snapshots>
-          <enabled>false</enabled>
-        </snapshots>
-     </repository>
-	</repositories>
-	
 	<profiles>
 		<profile>
 			<!-- Default profile -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<httpcomponents.version>4.4.1</httpcomponents.version>
 		<guava.version>16.0.1</guava.version>
 		<curator.version>2.6.0</curator.version>
-		<metamodel.version>4.5.0</metamodel.version>
+		<metamodel.version>4.5.1</metamodel.version>
 		<metamodel.extras.version>4.4.0</metamodel.extras.version>
 		<gwt.version>2.7.0</gwt.version>
 		<spring.core.version>4.1.9.RELEASE</spring.core.version>
@@ -51,6 +51,19 @@
 		almost any kind of data, eg. CSV files, databases, Excel spreadsheets, NoSQL databases and more.</description>
 	<url>http://datacleaner.org</url>
 	<packaging>pom</packaging>
+	
+	<repositories>
+		<repository>
+        <id>metamodel-staging</id>
+        <url>https://repository.apache.org/content/repositories/orgapachemetamodel-1016/</url>
+        <releases>
+           <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+     </repository>
+	</repositories>
 	
 	<profiles>
 		<profile>


### PR DESCRIPTION
This branch applies the new Apache MetaModel 4.5.1 which is currently _staged_ for release.

A few changes in test benchmark files, but those make sense.

__Do not merge yet__ - the Apache MetaModel release has to finish and then we need to remove the staging repository from ```pom.xml```