### PR TITLE
Bug/1143 remote enum after reload

### DIFF
--- a/api/src/main/java/org/datacleaner/descriptors/ConfiguredPropertyDescriptor.java
+++ b/api/src/main/java/org/datacleaner/descriptors/ConfiguredPropertyDescriptor.java
@@ -58,12 +58,12 @@ public interface ConfiguredPropertyDescriptor extends PropertyDescriptor, HasAli
     public boolean isRequired();
 
     /**
-     * Gets an optional custom {@link Converter} class, in case the configured
+     * Gets an optional custom {@link Converter} instance, in case the configured
      * property should be converted using custom rules.
      * 
      * @see Convertable
      * 
      * @return a custom converter, or null
      */
-    public Class<? extends Converter<?>> getCustomConverter();
+    public Converter<?> createCustomConverter();
 }

--- a/engine/core/src/main/java/org/datacleaner/descriptors/ConfiguredPropertyDescriptorImpl.java
+++ b/engine/core/src/main/java/org/datacleaner/descriptors/ConfiguredPropertyDescriptorImpl.java
@@ -102,7 +102,20 @@ final class ConfiguredPropertyDescriptorImpl extends AbstractPropertyDescriptor 
     }
 
     @Override
-    public Class<? extends Converter<?>> getCustomConverter() {
+    public Converter<?> createCustomConverter() {
+        Class<? extends Converter<?>> converterClass = getCustomConverterClass();
+        if(converterClass != null) {
+            try {
+                return converterClass.newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private Class<? extends Converter<?>> getCustomConverterClass() {
         Convertable convertable = getAnnotation(Convertable.class);
         if (convertable != null) {
             return convertable.value();

--- a/engine/core/src/test/java/org/datacleaner/util/convert/StringConverterTest.java
+++ b/engine/core/src/test/java/org/datacleaner/util/convert/StringConverterTest.java
@@ -75,7 +75,7 @@ public class StringConverterTest extends TestCase {
 
         String serializedForm1 = stringConverter.serialize(convertable);
         assertEquals("foo:bar", serializedForm1);
-        String serializedForm2 = stringConverter.serialize(convertable, SecondaryConverter.class);
+        String serializedForm2 = stringConverter.serialize(convertable, SecondaryConverter.class.newInstance());
         assertEquals("foo|bar", serializedForm2);
 
         {

--- a/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/descriptors/RemoteConfiguredPropertyDescriptor.java
@@ -69,7 +69,7 @@ public abstract class RemoteConfiguredPropertyDescriptor implements ConfiguredPr
     }
 
     @Override
-    public Class<? extends Converter<?>> getCustomConverter() {
+    public Converter<?> createCustomConverter() {
         return null;
     }
 
@@ -91,7 +91,7 @@ public abstract class RemoteConfiguredPropertyDescriptor implements ConfiguredPr
 
     public void setDefaultValue(Object component) {
         if (defaultValue != null) {
-            ((RemoteTransformer) component).setPropertyValue(getName(), createDefaultValue());
+            setValue(component, createDefaultValue());
         }
     }
 

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -1474,7 +1474,7 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
                 }
 
                 Object configuredValue = stringConverter.deserialize(propertyValue, configuredProperty.getType(),
-                        configuredProperty.getCustomConverter());
+                        configuredProperty.createCustomConverter());
 
                 configuredProperty.setValue(result, configuredValue);
             }

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -950,7 +950,7 @@ public class JaxbJobReader implements JobReader<InputStream> {
                             DATACLEANER_JAXB_VARIABLE_PREFIX + configuredProperty.getName(), variableRef);
                 }
 
-                final Class<? extends Converter<?>> customConverter = configuredProperty.getCustomConverter();
+                final Converter<?> customConverter = configuredProperty.createCustomConverter();
                 final Object value = stringConverter.deserialize(stringValue, configuredProperty.getType(),
                         customConverter);
 

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
@@ -394,7 +394,7 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
                                 ExpressionBasedInputColumn<?> expressionBasedInputColumn = (ExpressionBasedInputColumn<?>) inputColumn;
                                 Object columnValue = expressionBasedInputColumn.getExpression();
                                 inputType.setValue(stringConverter.serialize(columnValue, property
-                                        .getCustomConverter()));
+                                        .createCustomConverter()));
                             } else {
                                 inputType.setRef(getColumnId(inputColumn, columnMappings));
                             }
@@ -429,7 +429,7 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
                     propertyType.setRef(componentMetadataProperties.get(variableNameWithPrefix));
                 } else {
                     Object value = configuration.getProperty(property);
-                    String stringValue = stringConverter.serialize(value, property.getCustomConverter());
+                    String stringValue = stringConverter.serialize(value, property.createCustomConverter());
 
                     if (stringValue != null && stringValue.indexOf('\n') != -1) {
                         // multi-line values are put as simple content of the

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/CustomJobContext.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/CustomJobContext.java
@@ -80,7 +80,7 @@ public class CustomJobContext implements XmlJobContext {
         final String filename = _file.getName();
         return filename.substring(0, filename.length() - extensionLength);
     }
-    
+
     @Override
     public TenantContext getTenantContext() {
         return _tenantContext;
@@ -108,7 +108,7 @@ public class CustomJobContext implements XmlJobContext {
             Object value = beanConfiguration.getProperty(configuredProperty);
             String valueString = null;
             try {
-                final Class<? extends Converter<?>> customConverter = configuredProperty.getCustomConverter();
+                final Converter<?> customConverter = configuredProperty.createCustomConverter();
                 valueString = stringConverter.serialize(value, customConverter);
             } catch (Exception e) {
                 if (logger.isWarnEnabled()) {
@@ -125,7 +125,7 @@ public class CustomJobContext implements XmlJobContext {
     /**
      * Gets a {@link ComponentDescriptor} for the {@link CustomJob}
      * component that this {@link JobContext} represents.
-     * 
+     *
      * @return
      */
     public ComponentDescriptor<?> getDescriptor() {
@@ -172,7 +172,7 @@ public class CustomJobContext implements XmlJobContext {
         final Map<ConfiguredPropertyDescriptor, Object> propertyMap = new HashMap<ConfiguredPropertyDescriptor, Object>();
         final PropertiesType propertiesType = getCustomJavaComponentJob().getProperties();
         final StringConverter stringConverter = new StringConverter(_injectionManager);
-        
+
         // build initial map based on default values from the customJob instance
         if (customJavaJob != null) {
             final Set<ConfiguredPropertyDescriptor> configuredProperties = descriptor.getConfiguredProperties();
@@ -181,7 +181,7 @@ public class CustomJobContext implements XmlJobContext {
                 propertyMap.put(property, value);
             }
         }
-        
+
         // then build/override map based upon specified <property> elements in the XML file
         if (propertiesType != null) {
             final List<Property> propertyTypes = propertiesType.getProperty();
@@ -191,18 +191,18 @@ public class CustomJobContext implements XmlJobContext {
                 setProperty(descriptor, propertyMap, name, value, stringConverter);
             }
         }
-        
+
         return new ImmutableComponentConfiguration(propertyMap);
     }
 
     private void setProperty(ComponentDescriptor<?> descriptor, Map<ConfiguredPropertyDescriptor, Object> propertyMap,
-            String name, String valueString, StringConverter stringConverter) {
+                             String name, String valueString, StringConverter stringConverter) {
         final ConfiguredPropertyDescriptor configuredProperty = descriptor.getConfiguredProperty(name);
         if (configuredProperty == null) {
             throw new ComponentConfigurationException("No such configured property in class '"
                     + getDescriptor().getComponentClass().getName() + "': " + name);
         }
-        final Class<? extends Converter<?>> customConverter = configuredProperty.getCustomConverter();
+        final Converter<?> customConverter = configuredProperty.createCustomConverter();
         final Object value = stringConverter.deserialize(valueString, configuredProperty.getType(), customConverter);
         propertyMap.put(configuredProperty, value);
     }


### PR DESCRIPTION
For the remote transformers we need to support "dynamic enumerations" for component properties. It means for cases where some property of remote transformer has not a corresponding java enum class on the client side (DC Desktop).

This branch fixes problem of deserialization of such enumeration from String. We needed a Serializer that "knows" about the property descriptor. Without breaking a Serializer API, we changed the way of creation of the Serializers - now the property descriptor is responsible for Serializer creation. This makes our fix possible: The property descriptor of a "remote" enumeration can then create a Serializer that converts a String to enumeration value using the stored values from the property descriptor.