### PR TITLE
AbstractMethodError in swagger JSON controller.

### DIFF
--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -301,8 +301,8 @@
 		<!-- Jetty used for dev mode testing -->
 		<dependency>
 			<groupId>org.eclipse.jetty.aggregate</groupId>
-			<artifactId>jetty-all</artifactId>
-			<version>7.2.0.v20101020</version>
+			<artifactId>jetty-all-server</artifactId>
+			<version>8.1.18.v20150929</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
#1145  

At http://localhost:8888/DataCleaner-monitor/repository/swagger.json there was an exception AbstractMethodError. Problem was in provided dependency in jetty (servlet-api). It means in localhost development mode/environment. New version of jetty-server-all fixed the problem.  