### PR TITLE
Issue #1160: Fixed by adding "file://" prefix support in FileResolver

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/TextFileDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/TextFileDictionaryDialog.java
@@ -161,14 +161,14 @@ public final class TextFileDictionaryDialog extends AbstractDialog {
                 }
 
                 final String encoding = (String) _encodingComboBox.getSelectedItem();
-                if (StringUtils.isNullOrEmpty(path)) {
+                if (StringUtils.isNullOrEmpty(encoding)) {
                     JOptionPane.showMessageDialog(TextFileDictionaryDialog.this, "Please select a character encoding");
                     return;
                 }
 
                 final boolean caseSensitive = _caseSensitiveCheckBox.isSelected();
 
-                TextFileDictionary dict = new TextFileDictionary(name, path, encoding, caseSensitive);
+                final TextFileDictionary dict = new TextFileDictionary(name, path, encoding, caseSensitive);
 
                 if (_originalDictionary != null) {
                     _catalog.removeDictionary(_originalDictionary);

--- a/engine/core/src/main/java/org/datacleaner/util/FileResolver.java
+++ b/engine/core/src/main/java/org/datacleaner/util/FileResolver.java
@@ -61,6 +61,11 @@ public class FileResolver {
         if (filename == null) {
             return null;
         }
+        
+        filename = filename.trim();
+        if (filename.toLowerCase().startsWith("file://")) {
+            filename = filename.substring("file://".length());
+        }
 
         final File file;
         final File nonParentCandidate = new File(filename);

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -512,7 +512,7 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
         return environment.getStorageProvider();
     }
 
-    @SuppressWarnings("deprecation")
+    @Deprecated
     private String createFilename(String filename) {
         return _interceptor.createFilename(filename);
     }
@@ -559,8 +559,8 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
 
                         addVariablePath(name);
 
-                        String filenamePath = getStringVariable("filename", tfdt.getFilename());
-                        String filename = createFilename(filenamePath);
+                        final String filenamePath = getStringVariable("filename", tfdt.getFilename());
+                        final String filename = createFilename(filenamePath);
                         String encoding = getStringVariable("encoding", tfdt.getEncoding());
                         if (encoding == null) {
                             encoding = FileHelper.UTF_8_ENCODING;

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbConfigurationReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbConfigurationReaderTest.java
@@ -584,9 +584,17 @@ public class JaxbConfigurationReaderTest extends TestCase {
         TextFileDictionary dictionary = (TextFileDictionary) configuration.getReferenceDataCatalog().getDictionary(
                 "dictionary");
         assertEquals("C:/absolute/path/to/dictionary.txt", dictionary.getFilename());
+        
+        TextFileDictionary dictionary2 = (TextFileDictionary) configuration.getReferenceDataCatalog().getDictionary(
+                "dictionary2");
+        assertEquals("C:/absolute/path/to/dictionary.txt", dictionary2.getFilename());
 
         TextFileSynonymCatalog synonyms = (TextFileSynonymCatalog) configuration.getReferenceDataCatalog()
                 .getSynonymCatalog("synonyms");
         assertEquals("relative/path/to/synonyms.txt", synonyms.getFilename());
+        
+        TextFileSynonymCatalog synonyms2 = (TextFileSynonymCatalog) configuration.getReferenceDataCatalog()
+                .getSynonymCatalog("synonyms2");
+        assertEquals("relative/path/to/synonyms.txt", synonyms2.getFilename());
     }
 }

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbConfigurationReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbConfigurationReaderTest.java
@@ -72,6 +72,8 @@ import org.datacleaner.reference.StringPattern;
 import org.datacleaner.reference.StringPatternConnection;
 import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.reference.SynonymCatalogConnection;
+import org.datacleaner.reference.TextFileDictionary;
+import org.datacleaner.reference.TextFileSynonymCatalog;
 import org.datacleaner.result.renderer.HtmlRenderingFormat;
 import org.datacleaner.result.renderer.TextRenderingFormat;
 import org.datacleaner.storage.BerkeleyDbStorageProvider;
@@ -573,5 +575,18 @@ public class JaxbConfigurationReaderTest extends TestCase {
         RemoteServerConfiguration remoteConf = configuration.getEnvironment().getRemoteServerConfiguration();
         Assert.assertEquals(true, remoteConf.getServerList().isEmpty());
         Assert.assertEquals(0, remoteConf.getServerList().size());
+    }
+
+    public void testReadReferenceDataWithResources() throws Exception {
+        DataCleanerConfiguration configuration = reader.create(new File(
+                "src/test/resources/example-configuration-reference-data-resource-paths.xml"));
+
+        TextFileDictionary dictionary = (TextFileDictionary) configuration.getReferenceDataCatalog().getDictionary(
+                "dictionary");
+        assertEquals("C:/absolute/path/to/dictionary.txt", dictionary.getFilename());
+
+        TextFileSynonymCatalog synonyms = (TextFileSynonymCatalog) configuration.getReferenceDataCatalog()
+                .getSynonymCatalog("synonyms");
+        assertEquals("relative/path/to/synonyms.txt", synonyms.getFilename());
     }
 }

--- a/engine/xml-config/src/test/resources/example-configuration-reference-data-resource-paths.xml
+++ b/engine/xml-config/src/test/resources/example-configuration-reference-data-resource-paths.xml
@@ -8,11 +8,23 @@
 				<encoding>UTF-8</encoding>
 				<case-sensitive>false</case-sensitive>
 			</text-file-dictionary>
+			
+			<text-file-dictionary name="dictionary2">
+				<filename>C:/absolute/path/to/dictionary.txt</filename>
+				<encoding>UTF-8</encoding>
+				<case-sensitive>false</case-sensitive>
+			</text-file-dictionary>
 		</dictionaries>
 		<synonym-catalogs>
 
 			<text-file-synonym-catalog name="synonyms">
 				<filename>file://relative/path/to/synonyms.txt</filename>
+				<encoding>UTF8</encoding>
+				<case-sensitive>false</case-sensitive>
+			</text-file-synonym-catalog>
+			
+			<text-file-synonym-catalog name="synonyms2">
+				<filename>relative/path/to/synonyms.txt</filename>
 				<encoding>UTF8</encoding>
 				<case-sensitive>false</case-sensitive>
 			</text-file-synonym-catalog>

--- a/engine/xml-config/src/test/resources/example-configuration-reference-data-resource-paths.xml
+++ b/engine/xml-config/src/test/resources/example-configuration-reference-data-resource-paths.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configuration xmlns="http://eobjects.org/analyzerbeans/configuration/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<reference-data-catalog>
+		<dictionaries>
+			<text-file-dictionary name="dictionary">
+				<filename>file://C:/absolute/path/to/dictionary.txt</filename>
+				<encoding>UTF-8</encoding>
+				<case-sensitive>false</case-sensitive>
+			</text-file-dictionary>
+		</dictionaries>
+		<synonym-catalogs>
+
+			<text-file-synonym-catalog name="synonyms">
+				<filename>file://relative/path/to/synonyms.txt</filename>
+				<encoding>UTF8</encoding>
+				<case-sensitive>false</case-sensitive>
+			</text-file-synonym-catalog>
+		</synonym-catalogs>
+	</reference-data-catalog>
+
+</configuration>


### PR DESCRIPTION
Fixes #1160 

Actually the solution is not very pretty because it is a file-only (as in - not any other resource types) fix. But it seems to be the minimum-impact resolution of the bug. The more general issue is that loading of dictionary and synonym resource is using the deprecated ```createFilename(...)``` method on the ```ConfigurationReaderInterceptor```.

It would be better (but a separate issue IMO) to use a real resource implementation but that would leak then also into standardizing how we write resource paths in XML (see ```DomConfigurationWriter.toFilename(Resource)``` which only does a partial job at this - candidate for a refactoring I would say).