### PR TITLE
Remove unwanted characters cannot be added to canvas

### DIFF
--- a/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/RemoveUnwantedCharsTransformer.java
+++ b/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/RemoveUnwantedCharsTransformer.java
@@ -34,7 +34,7 @@ import org.datacleaner.util.CharIterator;
 @Named("Remove unwanted characters")
 @Description("Removes characters from strings that are not wanted. Use it to cleanse codes and identifiers that may have additional dashes, punctuations, unwanted letters etc.")
 @Categorized(TextCategory.class)
-class RemoveUnwantedCharsTransformer implements Transformer {
+public class RemoveUnwantedCharsTransformer implements Transformer {
 
     @Configured
     InputColumn<String> column;


### PR DESCRIPTION
Fixes #1153 

RemoveUnwantedCharsTransformer was not declared as a public class. I didn't find the particular reason why package-private classes don't work, but making the class public (as other transformers) solves the problem. 