### PR TITLE
Metering message - providing null value in details should be the same as empty string.

### DIFF
--- a/api/src/main/java/org/datacleaner/api/UsageMeteringMessage.java
+++ b/api/src/main/java/org/datacleaner/api/UsageMeteringMessage.java
@@ -82,6 +82,8 @@ public class UsageMeteringMessage implements Serializable, ComponentMessage {
     /** Escapes value for a CSV line and appends it to the 'target'. */
     private void escapeValueTo(String field, StringBuilder target) {
         if(field == null) {
+            target.append(DETAILS_QUOTE_CHAR);
+            target.append(DETAILS_QUOTE_CHAR);
             return;
         }
         target.append(DETAILS_QUOTE_CHAR);

--- a/api/src/test/java/org/datacleaner/api/UsageMeteringMessageTest.java
+++ b/api/src/test/java/org/datacleaner/api/UsageMeteringMessageTest.java
@@ -46,4 +46,23 @@ public class UsageMeteringMessageTest {
         Assert.assertEquals("myType", msg.getType());
         Assert.assertEquals("\"ab,cd\",\"ef\\\"g\",\"h\\\\i\"", msg.getDetails());
     }
+
+    @Test
+    public void testEmptyDetailFields() {
+        // empty strings
+        UsageMeteringMessage msg = new UsageMeteringMessage("myType", "abcd", "");
+        Assert.assertEquals("myType", msg.getType());
+        Assert.assertEquals("\"abcd\",\"\"", msg.getDetails());
+        msg = new UsageMeteringMessage("myType", "", "abcd");
+        Assert.assertEquals("myType", msg.getType());
+        Assert.assertEquals("\"\",\"abcd\"", msg.getDetails());
+
+        // null values
+        msg = new UsageMeteringMessage("myType", "abcd", null);
+        Assert.assertEquals("myType", msg.getType());
+        Assert.assertEquals("\"abcd\",\"\"", msg.getDetails());
+        msg = new UsageMeteringMessage("myType", null, "abcd");
+        Assert.assertEquals("myType", msg.getType());
+        Assert.assertEquals("\"\",\"abcd\"", msg.getDetails());
+    }
 }


### PR DESCRIPTION
Previously providing null value in details array caused nothing was added at that position. But we rely on the fields position when analysing the metering message. 