### PR TITLE
Ensured inclusion of scala-xml and scala-library in desktop+monitor

### DIFF
--- a/desktop/ui/pom.xml
+++ b/desktop/ui/pom.xml
@@ -97,6 +97,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-html-rendering</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
 			<artifactId>DataCleaner-remote-components</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/monitor/services/pom.xml
+++ b/monitor/services/pom.xml
@@ -21,6 +21,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-env-spark</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-html-rendering</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
 			<artifactId>DataCleaner-engine-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
While working with the latest master desktop UI I noticed these warnings:

```
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.DensityAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.ScatterAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.StackedAreaAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.DensityAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.ScatterAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
ERROR 11:58:45 DCClassVisitor - Failed to load class org.datacleaner.visualization.StackedAreaAnalyzerResultHtmlRenderer because of unsatisfied class dependency: scala/xml/MetaData
```

After digging into it a bit I found out that because we exclude scala-xml and scala-library in ```DataCleaner-env-spark``` then these exclusions trumped the other dependencies we have on this. Since it is required by the html-rendering module, I fixed the issue by adding that module as an explicit dependency in desktop-ui and monitor-services.