### PR TITLE
Enable custom execute buttons and analysis runners

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/actions/RunAnalysisActionListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/actions/RunAnalysisActionListener.java
@@ -39,9 +39,16 @@ public class RunAnalysisActionListener implements ActionListener {
     private final DCModule _dcModule;
     private final AnalysisJobBuilder _analysisJobBuilder;
     private long _lastClickTime = 0;
+    private Class<? extends ResultWindow> _windowType;
 
     @Inject
     public RunAnalysisActionListener(DCModule dcModule, AnalysisJobBuilder analysisJobBuilder) {
+        this(dcModule, analysisJobBuilder, ResultWindow.class);
+    }
+
+    public RunAnalysisActionListener(DCModule dcModule, AnalysisJobBuilder analysisJobBuilder,
+            Class<? extends ResultWindow> windowType) {
+        _windowType = windowType;
         _dcModule = dcModule;
         _analysisJobBuilder = analysisJobBuilder;
     }
@@ -66,7 +73,7 @@ public class RunAnalysisActionListener implements ActionListener {
         injectorBuilder.with(DataCleanerConfiguration.class, _analysisJobBuilder.getConfiguration());
         injectorBuilder.with(AnalysisJob.class, _analysisJobBuilder.toAnalysisJob(false));
 
-        final ResultWindow window = injectorBuilder.getInstance(ResultWindow.class);
+        final ResultWindow window = injectorBuilder.getInstance(_windowType);
         window.open();
         window.startAnalysis();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/AnalysisRunnerSwingWorker.java
@@ -25,7 +25,6 @@ import javax.swing.SwingWorker;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.job.AnalysisJob;
-import org.datacleaner.job.runner.AnalysisListener;
 import org.datacleaner.job.runner.AnalysisResultFuture;
 import org.datacleaner.job.runner.AnalysisRunner;
 import org.datacleaner.job.runner.AnalysisRunnerImpl;
@@ -45,8 +44,11 @@ public final class AnalysisRunnerSwingWorker extends SwingWorker<AnalysisResultF
     private final ResultWindow _resultWindow;
 
     public AnalysisRunnerSwingWorker(DataCleanerConfiguration configuration, AnalysisJob job, ResultWindow resultWindow) {
-        final AnalysisListener analysisListener = resultWindow.createAnalysisListener();
-        _analysisRunner = new AnalysisRunnerImpl(configuration, analysisListener);
+        this(new AnalysisRunnerImpl(configuration, resultWindow.createAnalysisListener()), job, resultWindow);
+    }
+
+    public AnalysisRunnerSwingWorker(AnalysisRunner analysisRunner, AnalysisJob job, ResultWindow resultWindow) {
+        _analysisRunner = analysisRunner;
         _job = job;
         _resultWindow = resultWindow;
     }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -105,7 +105,7 @@ import org.slf4j.LoggerFactory;
  * Window in which the result (and running progress information) of job
  * execution is shown.
  */
-public final class ResultWindow extends AbstractWindow implements WindowListener {
+public class ResultWindow extends AbstractWindow implements WindowListener {
     private static final Logger logger = LoggerFactory.getLogger(ResultWindow.class);
 
     public static final List<Func<ResultWindow, JComponent>> PLUGGABLE_BANNER_COMPONENTS = new ArrayList<>(0);
@@ -237,7 +237,7 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
         if (running) {
             // run the job in a swing worker
             _result = null;
-            _worker = new AnalysisRunnerSwingWorker(_configuration, _job, this);
+            _worker = getAnalysisRunnerSwingWorker();
 
             _cancelButton.addActionListener(new ActionListener() {
                 @Override
@@ -271,6 +271,10 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
         }
 
         updateButtonVisibility(running);
+    }
+
+    protected AnalysisRunnerSwingWorker getAnalysisRunnerSwingWorker() {
+        return new AnalysisRunnerSwingWorker(_configuration, _job, this);
     }
 
     public void startAnalysis() {


### PR DESCRIPTION
Make it possible to add extra execute buttons to the job builder window and make it possible to have these jobs run using custom `AnalysisRunner` implementations.

You can add your own `ExecutionMenuItem` implementations and register them through the "datacleaner.ui.desktop.extra.execute.buttons" system property so they will be added to the execute buttons in the job builder window.

Such an `ExecutionMenuItem` implementation can run in a custom implemented `ResultWindow` using a custom `AnalysisRunner`.