### PR TITLE
Fixes #1196: Only check there are enough (but not same amount) columns

### DIFF
--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -676,7 +676,7 @@ public class JaxbJobReader implements JobReader<InputStream> {
                         final List<MutableInputColumn<?>> outputColumns = transformerBuilder.getOutputColumns();
                         final List<OutputType> output = transformerType.getOutput();
 
-                        if (outputColumns.size() != output.size()) {
+                        if (outputColumns.size() < output.size()) {
                             final String message = "Expected " + outputColumns.size() + " output column(s), but found "
                                     + output.size() + " (" + transformerBuilder + ")";
                             if (outputColumns.isEmpty()) {

--- a/engine/xml-config/src/test/resources/example-job-job-title-analytics.analysis.xml
+++ b/engine/xml-config/src/test/resources/example-job-job-title-analytics.analysis.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+	<source>
+		<data-context ref="my database" />
+		<columns>
+			<column id="col_4" path="CUSTOMERS.JOBTITLE" type="STRING" />
+		</columns>
+	</source>
+	<transformation>
+		<transformer name="Job title synonym replacement">
+			<descriptor ref="Synonym lookup" />
+			<metadata-properties>
+				<property name="CoordinatesY">229</property>
+				<property name="CoordinatesX">139</property>
+			</metadata-properties>
+			<properties>
+				<property name="Look up every token" value="false" />
+				<property name="Retain original value" value="false" />
+				<property name="Synonym catalog" value="Job titles" />
+			</properties>
+			<input ref="col_4" />
+			<output id="col_14" name="Recognized job title" />
+		</transformer>
+		<transformer requires="outcome_0">
+			<descriptor ref="Text case transformer" />
+			<metadata-properties>
+				<property name="CoordinatesY">492</property>
+				<property name="CoordinatesX">295</property>
+			</metadata-properties>
+			<properties>
+				<property name="Mode" value="CAPITALIZE_SENTENCES" />
+			</properties>
+			<input ref="col_4" />
+			<output id="col_15" name="job_title (Capitalize sentences)" />
+		</transformer>
+		<transformer>
+			<descriptor ref="Whitespace trimmer" />
+			<metadata-properties>
+				<property name="CoordinatesY">486</property>
+				<property name="CoordinatesX">462</property>
+			</metadata-properties>
+			<properties>
+				<property name="Trim left" value="true" />
+				<property name="Trim right" value="true" />
+				<property name="Trim multiple to single space" value="false" />
+			</properties>
+			<input ref="col_15" />
+			<output id="col_16" name="Trimmed job title" />
+		</transformer>
+		<filter name="Is job title recognized?">
+			<descriptor ref="Null check" />
+			<metadata-properties>
+				<property name="CoordinatesY">370</property>
+				<property name="CoordinatesX">169</property>
+			</metadata-properties>
+			<properties>
+				<property name="Consider empty string as null" value="false" />
+				<property name="Evaluation mode" value="ANY_FIELD" />
+			</properties>
+			<input ref="col_14" />
+			<outcome id="outcome_0" category="NULL" />
+			<outcome id="outcome_1" category="NOT_NULL" />
+		</filter>
+	</transformation>
+	<analysis>
+		<analyzer requires="outcome_1" name="Job title distribution">
+			<descriptor ref="Value distribution" />
+			<metadata-properties>
+				<property name="CoordinatesY">213</property>
+				<property name="CoordinatesX">470</property>
+			</metadata-properties>
+			<properties>
+				<property name="Record unique values" value="true" />
+				<property name="Record drill-down information" value="true" />
+				<property name="Top n most frequent values" value="&lt;null&gt;" />
+				<property name="Bottom n most frequent values" value="&lt;null&gt;" />
+			</properties>
+			<input ref="col_14" name="Column" />
+		</analyzer>
+		<analyzer name="Unrecognized job titles">
+			<descriptor ref="Value distribution" />
+			<metadata-properties>
+				<property name="CoordinatesY">375</property>
+				<property name="CoordinatesX">573</property>
+			</metadata-properties>
+			<properties>
+				<property name="Record unique values" value="true" />
+				<property name="Record drill-down information" value="false" />
+				<property name="Top n most frequent values" value="&lt;null&gt;" />
+				<property name="Bottom n most frequent values" value="&lt;null&gt;" />
+			</properties>
+			<input ref="col_16" name="Column" />
+		</analyzer>
+	</analysis>
+</job>


### PR DESCRIPTION
Fixes #1196 

Does so by using `<` instead of `!=` when comparing expected vs actual output columns on loading a job. The effect is that it's OK for component authors to add output columns, but not to remove them. A corner case (which also existed before) is if the meaning of an output column is changed - in that case the component developer has (still) buried a hole for himself ;-)