### PR TITLE
Launching spark job with resultfile URI fails

### DIFF
--- a/engine/env/spark/src/main/java/org/datacleaner/spark/ApplicationDriver.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/ApplicationDriver.java
@@ -189,8 +189,8 @@ public class ApplicationDriver {
             properties.setProperty("datacleaner.result.hdfs.path", resultHdfsPath);
             File tempFile = File.createTempFile("job-", ".properties");
             properties.store(new FileWriter(tempFile), "DataCleaner Spark runner properties");
-            final URI uri = copyFileToHdfs(tempFile,
-                    _fileSystem.getHomeDirectory().toUri().resolve("temp/" + tempFile).toString());
+            final URI uri = copyFileToHdfs(tempFile, _fileSystem.getHomeDirectory().toUri().resolve("temp/" + tempFile
+                    .getName()).toString());
             sparkLauncher.addAppArgs(uri.toString());
         }
 


### PR DESCRIPTION
When you provide a location for the results of the job which is executed on the Hadoop cluster through the SparkLauncher, a temporary properties file is created containing the location for the results. This properties file is then copied to the Hadoop file system, but this doesn't work (and silently fails), because the hdfs path which is created (and to which the properties file is copied) contains the absolute location of the properties file as it has been created on your local machine. This is easily fixed by just adding the properties file name to the hdfs path, instead of its absolute location.