### PR TITLE
#1222 - HDFS resource (with template) loading on Spark

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
@@ -33,10 +33,22 @@ public class HadoopResourceBuilder {
     private final String _clusterReferenceName;
     private final Configuration _configuration;
 
-    private final Pattern _pattern = Pattern.compile("(?:[\\w\\+\\-\\.]+://)?\\{([\\w\\.]*)\\}(.*)");
+    /**
+     * A regular expression {@link Pattern} that matches resource URIs
+     * containing template items for the server definition, for instance:
+     * 
+     * hdfs://{myserver}/foo/bar.txt
+     * 
+     * <ul>
+     * <li>Group 1: The scheme (example 'hdfs')</li>
+     * <li>Group 2: The template name (example 'myserver')</li>
+     * <li>Group 3: The path (example '/foo/bar.txt')</li>
+     * </ul>
+     */
+    public static final Pattern RESOURCE_SCHEME_PATTERN = Pattern.compile("([\\w\\+\\-\\.]+)://\\{([\\w\\.]*)\\}(.*)");
 
     public HadoopResourceBuilder(ServerInformationCatalog catalog, String templatedUri) {
-        final Matcher matcher = _pattern.matcher(templatedUri);
+        final Matcher matcher = RESOURCE_SCHEME_PATTERN.matcher(templatedUri);
         if (!matcher.matches()) {
             _clusterReferenceName = null;
             final String fixedUri = templatedUri.replace(" ", "%20");
@@ -51,11 +63,11 @@ public class HadoopResourceBuilder {
             _configuration.set("fs.defaultFS", fixedUri);
             _uri = URI.create(fixedUri);
         } else {
-            _clusterReferenceName = matcher.group(1);
+            _clusterReferenceName = matcher.group(2);
             final HadoopClusterInformation hadoopClusterInformation = (HadoopClusterInformation) catalog.getServer(
                     _clusterReferenceName);
             _configuration = hadoopClusterInformation.getConfiguration();
-            _uri = URI.create(matcher.group(2).replace(" ", "%20"));
+            _uri = URI.create(matcher.group(3).replace(" ", "%20"));
         }
     }
 

--- a/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
@@ -33,7 +33,7 @@ public class HadoopResourceBuilder {
     private final String _clusterReferenceName;
     private final Configuration _configuration;
 
-    Pattern _pattern = Pattern.compile("(?:[\\w\\+\\-\\.]+://)?\\{([\\w\\.]*)\\}(.*)");
+    private final Pattern _pattern = Pattern.compile("(?:[\\w\\+\\-\\.]+://)?\\{([\\w\\.]*)\\}(.*)");
 
     public HadoopResourceBuilder(ServerInformationCatalog catalog, String templatedUri) {
         final Matcher matcher = _pattern.matcher(templatedUri);

--- a/engine/core/src/test/java/org/datacleaner/util/convert/HadoopResourceBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/util/convert/HadoopResourceBuilderTest.java
@@ -1,0 +1,51 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.util.convert;
+
+import static org.junit.Assert.*;
+
+import java.util.regex.Matcher;
+
+import org.junit.Test;
+
+public class HadoopResourceBuilderTest {
+
+    @Test
+    public void testPatternGroupsVanilla() throws Exception {
+        final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher("hdfs://{myserver}/foo/bar.txt");
+        assertTrue(matcher.find());
+        assertEquals("hdfs", matcher.group(1));
+        assertEquals("myserver", matcher.group(2));
+        assertEquals("/foo/bar.txt", matcher.group(3));
+    }
+
+    @Test
+    public void testPatternGroupsNoScheme() throws Exception {
+        final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher("/foo/bar.txt");
+        assertFalse(matcher.find());
+    }
+
+    @Test
+    public void testPatternGroupsNoServer() throws Exception {
+        final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher("hdfs:///foo/bar.txt");
+        assertFalse(matcher.find());
+    }
+
+}

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkConfigurationReaderInterceptor.java
@@ -63,7 +63,7 @@ public class SparkConfigurationReaderInterceptor extends DefaultConfigurationRea
     public Resource createResource(String resourceUrl, DataCleanerConfiguration tempConfiguration) {
         final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher(resourceUrl);
         if (matcher.find()) {
-            resourceUrl = matcher.group(1) + ":///" + matcher.group(3);
+            resourceUrl = matcher.group(1) + "://" + matcher.group(3);
         }
         final URI uri = URI.create(resourceUrl);
         return _hdfsHelper.getResourceToUse(uri);

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.metamodel.util.CollectionUtils;
+import org.apache.metamodel.util.HdfsResource;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.JaxbConfigurationReader;
@@ -146,7 +147,7 @@ public class SparkJobContext implements Serializable {
     public AnalysisJobBuilder getAnalysisJobBuilder() {
         if (_analysisJobBuilder == null) {
             // set HDFS as default scheme to avoid file resources
-            SystemProperties.setIfNotSpecified(SystemProperties.DEFAULT_RESOURCE_SCHEME, "hdfs");
+            SystemProperties.setIfNotSpecified(SystemProperties.DEFAULT_RESOURCE_SCHEME, HdfsResource.SCHEME_HDFS);
 
             final DataCleanerConfiguration configuration = getConfiguration();
             final JaxbJobReader jobReader = new JaxbJobReader(configuration);

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkConfigurationReaderInterceptorTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkConfigurationReaderInterceptorTest.java
@@ -1,0 +1,77 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.spark;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.metamodel.util.Resource;
+import org.datacleaner.configuration.DataCleanerConfigurationImpl;
+import org.datacleaner.spark.utils.HdfsHelper;
+import org.datacleaner.util.HadoopResource;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SparkConfigurationReaderInterceptorTest {
+
+    @Before
+    public void setup() {
+        // setup code needed to register the "last known" hadoop configuration
+        // in HdfsHelper.
+        new HdfsHelper(new Configuration());
+    }
+
+    @Test
+    public void testRemoveServerFromHdfsUrl() throws Exception {
+
+        final SparkConfigurationReaderInterceptor interceptor = new SparkConfigurationReaderInterceptor(
+                new HashMap<>());
+        final Resource resource = interceptor.createResource(
+                "hdfs://{foo.bar.hadoop.environment}/datacleaner/data/companies_1.csv",
+                new DataCleanerConfigurationImpl());
+
+        assertTrue("Found: " + resource.getClass().getName(), resource instanceof HadoopResource);
+        assertEquals("hdfs:///datacleaner/data/companies_1.csv", resource.getQualifiedPath());
+    }
+
+    @Test
+    public void testSimpleHdfsUrl() throws Exception {
+        final SparkConfigurationReaderInterceptor interceptor = new SparkConfigurationReaderInterceptor(
+                new HashMap<>());
+        final Resource resource = interceptor.createResource("hdfs:///datacleaner/data/companies_2.csv",
+                new DataCleanerConfigurationImpl());
+
+        assertTrue("Found: " + resource.getClass().getName(), resource instanceof HadoopResource);
+        assertEquals("hdfs:///datacleaner/data/companies_2.csv", resource.getQualifiedPath());
+    }
+
+    @Test
+    public void testSimpleSchemeLessUrl() throws Exception {
+        final SparkConfigurationReaderInterceptor interceptor = new SparkConfigurationReaderInterceptor(
+                new HashMap<>());
+        final Resource resource = interceptor.createResource("/datacleaner/data/companies_3.csv",
+                new DataCleanerConfigurationImpl());
+
+        assertTrue("Found: " + resource.getClass().getName(), resource instanceof HadoopResource);
+        assertEquals("hdfs:///datacleaner/data/companies_3.csv", resource.getQualifiedPath());
+    }
+}


### PR DESCRIPTION
Fixes #1222 

This is a bit of a dirty workaround since it just strips out any Hadoop-resource server definition from HDFS urls on Spark. I couldn't imagine another way to do it that wasn't more or less a complete rewrite of how resources are loaded. The (pretty significant) drawback of this approach is that now you cannot refer to a HDFS resource outside of the cluster that spark is running in. I guess that could be a future use case if someone has multiple Hadoop clusters (for some reason) that need to process data across in the same job?

For the reviewer: Please double check the regex Pattern that I've used. I think it's fine, but please give a second opinion.