### PR TITLE
Fixes #1191 by doing an eager check if displayed TableModel is OK

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/actions/PreviewSourceDataActionListener.java
+++ b/desktop/api/src/main/java/org/datacleaner/actions/PreviewSourceDataActionListener.java
@@ -80,8 +80,8 @@ public class PreviewSourceDataActionListener implements ActionListener {
 		}
 
 		try (final DatastoreConnection con = _datastore.openConnection()) {
-			DataContext dc = con.getDataContext();
-			Query q = dc.query().from(columns[0].getTable()).select(columns).toQuery();
+		    final DataContext dc = con.getDataContext();
+			final Query q = dc.query().from(columns[0].getTable()).select(columns).toQuery();
 
 			DataSetWindow window = new DataSetWindow(q, dc, PAGE_SIZE, _windowContext);
 			window.open();

--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
@@ -307,17 +307,11 @@ public class DCTable extends JXTable implements MouseListener {
 
     @Override
     public Object getValueAt(int row, int column) {
-        try {
-            Object value = super.getValueAt(row, column);
-            if (value == null) {
-                value = LabelUtils.NULL_LABEL;
-            }
-            return value;
-        } catch (Exception e) {
-            // TODO
-            System.out.println("!!! " + e.getMessage());
-            return null;
+        Object value = super.getValueAt(row, column);
+        if (value == null) {
+            value = LabelUtils.NULL_LABEL;
         }
+        return value;
     }
 
     public void setVisibleColumns(int min, int max) {

--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
@@ -307,11 +307,17 @@ public class DCTable extends JXTable implements MouseListener {
 
     @Override
     public Object getValueAt(int row, int column) {
-        Object value = super.getValueAt(row, column);
-        if (value == null) {
-            value = LabelUtils.NULL_LABEL;
+        try {
+            Object value = super.getValueAt(row, column);
+            if (value == null) {
+                value = LabelUtils.NULL_LABEL;
+            }
+            return value;
+        } catch (Exception e) {
+            // TODO
+            System.out.println("!!! " + e.getMessage());
+            return null;
         }
-        return value;
     }
 
     public void setVisibleColumns(int min, int max) {


### PR DESCRIPTION
Fixes #1191

See #1191 for investigation details.
I also updated the error dialog shown when a DataSetWindow is unable to render. This was to add a little bit of detail around the error (but still referring to the log file for more details).

![screen shot 2016-03-10 at 23 01 10](https://cloud.githubusercontent.com/assets/291450/13686056/17038000-e714-11e5-97db-1d47e7cdea09.png)
