### PR TITLE
Add remote components to Spark deps

### DIFF
--- a/engine/env/spark/pom.xml
+++ b/engine/env/spark/pom.xml
@@ -170,6 +170,25 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-remote-components</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.metamodel</groupId>
 			<artifactId>MetaModel-hadoop</artifactId>
 			<exclusions>


### PR DESCRIPTION
This adds the remote components module to the dependencies of the Spark module.

Fixes #1225