### PR TITLE
Cdtable fix get menuitems

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
@@ -64,7 +64,7 @@ public class DCTable extends JXTable implements MouseListener {
     public static final int EDITABLE_TABLE_ROW_HEIGHT = 30;
 
     private final transient DCTableCellRenderer _tableCellRenderer;
-    protected final transient List<JMenuItem> _rightClickMenuItems;
+    protected transient List<JMenuItem> _rightClickMenuItems;
     protected transient DCPanel _panel;
 
     public DCTable(String... columnNames) {
@@ -84,7 +84,6 @@ public class DCTable extends JXTable implements MouseListener {
         setEditable(true);
 
         addMouseListener(this);
-        _rightClickMenuItems = getCopyMenuItems();
         _tableCellRenderer = new DCTableCellRenderer(this);
     }
 
@@ -210,7 +209,7 @@ public class DCTable extends JXTable implements MouseListener {
         if (e.getClickCount() == 1) {
             int button = e.getButton();
             if (button == MouseEvent.BUTTON2 || button == MouseEvent.BUTTON3) {
-                if (_rightClickMenuItems != null && _rightClickMenuItems.size() > 0) {
+                if (rightClickMenuHasItems()) {
                     JPopupMenu popup = new JPopupMenu();
                     for (JMenuItem item : _rightClickMenuItems) {
                         popup.add(item);
@@ -220,6 +219,16 @@ public class DCTable extends JXTable implements MouseListener {
                 }
             }
         }
+    }
+
+    private boolean rightClickMenuHasItems() {
+        if(_rightClickMenuItems==null) {
+            _rightClickMenuItems = getCopyMenuItems();
+            if(_rightClickMenuItems==null) {
+                _rightClickMenuItems = new ArrayList<>();
+            }
+        }
+        return !_rightClickMenuItems.isEmpty();
     }
 
     private boolean forwardMouseEvent(MouseEvent e) {

--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
@@ -209,7 +209,7 @@ public class DCTable extends JXTable implements MouseListener {
         if (e.getClickCount() == 1) {
             int button = e.getButton();
             if (button == MouseEvent.BUTTON2 || button == MouseEvent.BUTTON3) {
-                if (rightClickMenuHasItems()) {
+                if (initializeRightClickMenuItems()) {
                     JPopupMenu popup = new JPopupMenu();
                     for (JMenuItem item : _rightClickMenuItems) {
                         popup.add(item);
@@ -221,7 +221,7 @@ public class DCTable extends JXTable implements MouseListener {
         }
     }
 
-    private boolean rightClickMenuHasItems() {
+    private boolean initializeRightClickMenuItems() {
         if(_rightClickMenuItems==null) {
             _rightClickMenuItems = getCopyMenuItems();
             if(_rightClickMenuItems==null) {


### PR DESCRIPTION
The constructor of DCTable was invoking the protected method getCopyMenuItems(). If a derived class overrides getCopyMenuItems(), then the DCtable constructor would thus invoke the getCopyMenuItems() on the derived class before the instance was constructed.

The change moves the call to getCopyMenuItems() to the consumeMouseClick method.

Please review, and hopefully merge. (and you can also add a nice heart emoticon...)