### PR TITLE
Bug/filter transitivity

### DIFF
--- a/components/network-tools/src/test/java/org/datacleaner/extension/networktools/ResolveHostnameTransformerTest.java
+++ b/components/network-tools/src/test/java/org/datacleaner/extension/networktools/ResolveHostnameTransformerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import org.datacleaner.data.MockInputColumn;
 import org.datacleaner.data.MockInputRow;
 import org.datacleaner.test.TestHelper;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,9 +54,8 @@ public class ResolveHostnameTransformerTest {
     
     @Test
     public void testTransformInternet() throws Exception {
-        if (!TestHelper.isInternetConnected()) {
-            return;
-        }
+        Assume.assumeTrue(TestHelper.isInternetConnected());
+        
         assertEquals("94.142.215.39", t.transform(new MockInputRow().put(col, "eobjects.org"))[0]);
     }
 

--- a/components/network-tools/src/test/java/org/datacleaner/extension/networktools/ResolveHostnameTransformerTest.java
+++ b/components/network-tools/src/test/java/org/datacleaner/extension/networktools/ResolveHostnameTransformerTest.java
@@ -19,38 +19,48 @@
  */
 package org.datacleaner.extension.networktools;
 
+import static org.junit.Assert.assertEquals;
+
 import org.datacleaner.data.MockInputColumn;
 import org.datacleaner.data.MockInputRow;
+import org.datacleaner.test.TestHelper;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class ResolveHostnameTransformerTest {
 
-public class ResolveHostnameTransformerTest extends TestCase {
+    private final ResolveHostnameTransformer t = new ResolveHostnameTransformer();
+    private final MockInputColumn<String> col = new MockInputColumn<String>("host", String.class);
 
-	public void testTransform() throws Exception {
-		ResolveHostnameTransformer t = new ResolveHostnameTransformer();
-		MockInputColumn<String> col = new MockInputColumn<String>("host",
-				String.class);
-		t.hostnameColumn = col;
+    @Before
+    public void setUp() {
+        t.hostnameColumn = col;
+    }
 
-		assertEquals("OutputColumns[host (ip address)]", t.getOutputColumns()
-				.toString());
+    @Test
+    public void testTransformLocal() throws Exception {
+        assertEquals("127.0.0.1", t.transform(new MockInputRow().put(col, "localhost"))[0]);
 
-		assertEquals("127.0.0.1",
-				t.transform(new MockInputRow().put(col, "localhost"))[0]);
+        assertEquals("127.0.0.1", t.transform(new MockInputRow().put(col, "127.0.0.1"))[0]);
+        
+        assertEquals(null, t.transform(new MockInputRow().put(col, ""))[0]);
+        
+        assertEquals(null, t.transform(new MockInputRow().put(col, null))[0]);
+        
+        assertEquals(null, t.transform(new MockInputRow().put(col,
+                "lmdslfsm flskmf lskmfls kmslf kdmlfsk mflsk fmsl kfdmsl"))[0]);
+    }
+    
+    @Test
+    public void testTransformInternet() throws Exception {
+        if (!TestHelper.isInternetConnected()) {
+            return;
+        }
+        assertEquals("94.142.215.39", t.transform(new MockInputRow().put(col, "eobjects.org"))[0]);
+    }
 
-		assertEquals("127.0.0.1",
-				t.transform(new MockInputRow().put(col, "127.0.0.1"))[0]);
-
-		assertEquals("94.142.215.39",
-				t.transform(new MockInputRow().put(col, "eobjects.org"))[0]);
-		
-		assertEquals(null,
-				t.transform(new MockInputRow().put(col, ""))[0]);
-		
-		assertEquals(null,
-				t.transform(new MockInputRow().put(col, null))[0]);
-		
-		assertEquals(null,
-				t.transform(new MockInputRow().put(col, "lmdslfsm flskmf lskmfls kmslf kdmlfsk mflsk fmsl kfdmsl"))[0]);
-	}
+    @Test
+    public void testGetOutputColumns() throws Exception {
+        assertEquals("OutputColumns[host (ip address)]", t.getOutputColumns().toString());
+    }
 }

--- a/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
@@ -450,25 +450,25 @@ public class PreviewTransformedDataActionListenerTest {
                 .getMethodName() + ".analysis.xml";
         final File analysisFile = new File("src/test/resources/previewfiles/" + baseFilename);
 
-        JaxbJobReader reader = new JaxbJobReader(analysisJobBuilder.getConfiguration());
+        final JaxbJobReader reader = new JaxbJobReader(analysisJobBuilder.getConfiguration());
 
         final AnalysisJobBuilder readAnalysisJobBuilder = reader.create(new FileInputStream(analysisFile));
         final List<TransformerComponentBuilder<?>> transformerComponentBuilders =
                 readAnalysisJobBuilder.getTransformerComponentBuilders();
 
-        TransformerComponentBuilder<?> whitespaceTransformerComponentBuilder = transformerComponentBuilders.get(2);
+        final TransformerComponentBuilder<?> whitespaceTrimmer = transformerComponentBuilders.get(2);
+        
+        // verify that we got the right transformer - the trimmer
+        assertEquals("Whitespace trimmer", whitespaceTrimmer.getDescriptor().getDisplayName());
 
         final PreviewTransformedDataActionListener action = new PreviewTransformedDataActionListener(null, null,
-                whitespaceTransformerComponentBuilder, 500);
-
+                whitespaceTrimmer, 500);
+        
         final TableModel tableModel = action.call();
 
         assertEquals(1, tableModel.getRowCount());
-
-        for (int i = 0; i < tableModel.getRowCount(); i++) {
-            assertTrue(printRow(tableModel, i), tableModel.getValueAt(i, 0) == null || tableModel.getValueAt(i,
-                    1) == null);
-        }
+        
+        assertTrue(tableModel.getValueAt(0, 1).toString().contains("5307.98"));
     }
 
     private void compareWithBenchmark(PreviewTransformedDataActionListener action) throws IOException {

--- a/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/actions/PreviewTransformedDataActionListenerTest.java
@@ -112,7 +112,7 @@ public class PreviewTransformedDataActionListenerTest {
     }
     
     @Test
-    public void PreviewTransformationAfterFilteredTransformation() throws Exception {
+    public void testPreviewTransformationAfterQueryOptimizedFilteredTransformation() throws Exception {
         analysisJobBuilder.addSourceColumns("employees.lastname");
 
         // add a "lastname=Patterson" filter on the email transformer - only 3
@@ -445,7 +445,7 @@ public class PreviewTransformedDataActionListenerTest {
     }
 
     @Test
-    public void testCompleteConcatJob() throws Exception {
+    public void testPreviewTransformationAfterNonOptimizedFilteredTransformation() throws Exception {
         final String baseFilename = getClass().getSimpleName() + "-" + testName
                 .getMethodName() + ".analysis.xml";
         final File analysisFile = new File("src/test/resources/previewfiles/" + baseFilename);

--- a/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingConsumerSorterTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/job/runner/RowProcessingConsumerSorterTest.java
@@ -46,6 +46,7 @@ import org.datacleaner.job.TransformerJob;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.FilterComponentBuilder;
 import org.datacleaner.job.builder.TransformerComponentBuilder;
+import org.datacleaner.test.MockTransformer;
 
 public class RowProcessingConsumerSorterTest extends TestCase {
 
@@ -76,7 +77,7 @@ public class RowProcessingConsumerSorterTest extends TestCase {
         fjb1.setName("fjb1");
 
         // 2: trim (depends on filter)
-        TransformerComponentBuilder<TransformerMock> tjb1 = ajb.addTransformer(TransformerMock.class);
+        TransformerComponentBuilder<MockTransformer> tjb1 = ajb.addTransformer(MockTransformer.class);
         tjb1.addInputColumn(inputColumn);
         tjb1.setRequirement(fjb1, MockFilter.Category.VALID);
         tjb1.setName("tjb1");
@@ -108,7 +109,7 @@ public class RowProcessingConsumerSorterTest extends TestCase {
         assertEquals(5, consumers.size());
 
         assertEquals("ImmutableFilterJob[name=fjb1,filter=Mock filter]", consumers.get(0).getComponentJob().toString());
-        assertEquals("ImmutableTransformerJob[name=tjb1,transformer=Transformer mock]", consumers.get(1)
+        assertEquals("ImmutableTransformerJob[name=tjb1,transformer=Mock transformer]", consumers.get(1)
                 .getComponentJob().toString());
         assertEquals("ImmutableTransformerJob[name=null,transformer=Fuse / Coalesce fields]", consumers.get(2)
                 .getComponentJob().toString());

--- a/desktop/ui/src/test/java/org/datacleaner/regexswap/RegexSwapClientTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/regexswap/RegexSwapClientTest.java
@@ -29,15 +29,14 @@ import java.util.List;
 
 import org.apache.http.impl.client.HttpClients;
 import org.datacleaner.test.TestHelper;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class RegexSwapClientTest {
 
     @Test
     public void testUpdateContent() throws Exception {
-        if (!TestHelper.isInternetConnected()) {
-            return;
-        }
+        Assume.assumeTrue(TestHelper.isInternetConnected());
 
         RegexSwapClient client = new RegexSwapClient(HttpClients.createSystem());
         client.getCategories();

--- a/desktop/ui/src/test/java/org/datacleaner/regexswap/RegexSwapClientTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/regexswap/RegexSwapClientTest.java
@@ -19,16 +19,26 @@
  */
 package org.datacleaner.regexswap;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.http.impl.client.HttpClients;
+import org.datacleaner.test.TestHelper;
+import org.junit.Test;
 
-public class RegexSwapClientTest extends TestCase {
+public class RegexSwapClientTest {
 
+    @Test
     public void testUpdateContent() throws Exception {
+        if (!TestHelper.isInternetConnected()) {
+            return;
+        }
+
         RegexSwapClient client = new RegexSwapClient(HttpClients.createSystem());
         client.getCategories();
         Collection<Category> categories = client.getCategories();

--- a/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testFilterWithCoalesce.analysis.xml
+++ b/desktop/ui/src/test/resources/benchmark/PreviewTransformedDataActionListenerTest-testFilterWithCoalesce.analysis.xml
@@ -29,7 +29,7 @@
             <output id="col_customernumbernonenglish" name="CUSTOMERNUMBER (Non-English)"/>
             <output id="col_fooasstring2" name="&quot;foo&quot; (as string)"/>
         </transformer>
-        <transformer requires="outcome_2">
+        <transformer>
             <descriptor ref="Fuse / Coalesce fields"/>
             <properties>
                 <property name="Consider empty string as null" value="true"/>
@@ -60,7 +60,7 @@
         </filter>
     </transformation>
     <analysis>
-        <analyzer requires="outcome_2">
+        <analyzer>
             <descriptor ref="Preview transformed data analyzer"/>
             <properties/>
             <input ref="col_customernumberenglish"/>

--- a/desktop/ui/src/test/resources/previewfiles/PreviewTransformedDataActionListenerTest-testPreviewTransformationAfterNonOptimizedFilteredTransformation.analysis.xml
+++ b/desktop/ui/src/test/resources/previewfiles/PreviewTransformedDataActionListenerTest-testPreviewTransformationAfterNonOptimizedFilteredTransformation.analysis.xml
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
-    <job-metadata>
-        <job-description>Created with DataCleaner Enterprise edition 5.0-SNAPSHOT</job-description>
-        <author>claudiap</author>
-        <updated-date>2016-03-11+01:00</updated-date>
-        <metadata-properties>
-            <property name="CoordinatesX.PUBLIC.ORDERS">56</property>
-            <property name="CoordinatesX.PUBLIC.CUSTOMERS">50</property>
-            <property name="CoordinatesY.PUBLIC.CUSTOMERS">83</property>
-            <property name="CoordinatesY.PUBLIC.PAYMENTS">33</property>
-            <property name="CoordinatesX.PUBLIC.PAYMENTS">30</property>
-            <property name="CoordinatesY.PUBLIC.ORDERS">56</property>
-        </metadata-properties>
-    </job-metadata>
     <source>
         <data-context ref="orderdb"/>
         <columns>
@@ -25,10 +12,6 @@
     <transformation>
         <transformer>
             <descriptor ref="Convert to number"/>
-            <metadata-properties>
-                <property name="CoordinatesY">166</property>
-                <property name="CoordinatesX">86</property>
-            </metadata-properties>
             <properties>
                 <property name="Decimal separator" value="&amp;#44;"/>
                 <property name="Minus sign" value="-"/>
@@ -40,10 +23,6 @@
         </transformer>
         <transformer requires="outcome_0">
             <descriptor ref="Concatenator"/>
-            <metadata-properties>
-                <property name="CoordinatesY">231</property>
-                <property name="CoordinatesX">388</property>
-            </metadata-properties>
             <properties>
                 <property name="Separator" value=" &amp;#44; "/>
             </properties>
@@ -56,10 +35,6 @@
         </transformer>
         <transformer>
             <descriptor ref="Whitespace trimmer"/>
-            <metadata-properties>
-                <property name="CoordinatesY">350</property>
-                <property name="CoordinatesX">651</property>
-            </metadata-properties>
             <properties>
                 <property name="Trim left" value="true"/>
                 <property name="Trim right" value="true"/>
@@ -70,10 +45,6 @@
         </transformer>
         <filter>
             <descriptor ref="Equals"/>
-            <metadata-properties>
-                <property name="CoordinatesY">261</property>
-                <property name="CoordinatesX">201</property>
-            </metadata-properties>
             <properties>
                 <property name="Compare values" value="[ 5307.98 ]"/>
             </properties>
@@ -84,10 +55,6 @@
     <analysis>
         <analyzer>
             <descriptor ref="Create CSV file"/>
-            <metadata-properties>
-                <property name="CoordinatesX">680</property>
-                <property name="CoordinatesY">40</property>
-            </metadata-properties>
             <properties>
                 <property name="File" value="file://datastores/orderdb-Whitespace trimmer.csv"/>
                 <property name="Separator char" value="&amp;#44;"/>

--- a/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingConsumer.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingConsumer.java
@@ -40,6 +40,7 @@ import org.datacleaner.job.FilterOutcome;
 import org.datacleaner.job.FilterOutcomes;
 import org.datacleaner.job.HasComponentRequirement;
 import org.datacleaner.job.InputColumnSinkJob;
+import org.datacleaner.job.InputColumnSourceJob;
 import org.datacleaner.job.OutputDataStreamJob;
 import org.datacleaner.util.SourceColumnFinder;
 import org.slf4j.Logger;
@@ -91,11 +92,8 @@ abstract class AbstractRowProcessingConsumer implements RowProcessingConsumer {
     }
 
     private boolean isAlwaysSatisfiedForConsume() {
-        if (_sourceJobsOfInputColumns.isEmpty()) {
-            return true;
-        }
-
-        if (isAlwaysSatisfiedRequirement()) {
+        final ComponentRequirement componentRequirement = _hasComponentRequirement.getComponentRequirement();
+        if (_sourceJobsOfInputColumns.isEmpty() && (componentRequirement == null || componentRequirement instanceof AnyComponentRequirement)) {
             return true;
         }
         return false;
@@ -121,7 +119,7 @@ abstract class AbstractRowProcessingConsumer implements RowProcessingConsumer {
         final Set<Object> sourceJobsOfInputColumns = sourceColumnFinder.findAllSourceJobs(inputColumnSinkJob);
         for (Iterator<Object> it = sourceJobsOfInputColumns.iterator(); it.hasNext();) {
             final Object sourceJob = it.next();
-            if (sourceJob instanceof HasComponentRequirement) {
+            if (sourceJob instanceof HasComponentRequirement && sourceJob instanceof InputColumnSourceJob) {
                 final HasComponentRequirement sourceOutcomeSinkJob = (HasComponentRequirement) sourceJob;
                 final ComponentRequirement componentRequirement = sourceOutcomeSinkJob.getComponentRequirement();
                 if (componentRequirement != null) {
@@ -137,11 +135,11 @@ abstract class AbstractRowProcessingConsumer implements RowProcessingConsumer {
      */
     @Override
     public final boolean satisfiedForConsume(FilterOutcomes outcomes, InputRow row) {
-        boolean satisfiedOutcomesForConsume = satisfiedOutcomesForConsume(_hasComponentRequirement, row, outcomes);
+        final boolean satisfiedOutcomesForConsume = satisfiedOutcomesForConsume(_hasComponentRequirement, row, outcomes);
         if (!satisfiedOutcomesForConsume) {
             return false;
         }
-        boolean satisfiedInputsForConsume = satisfiedInputsForConsume(row, outcomes);
+        final boolean satisfiedInputsForConsume = satisfiedInputsForConsume(row, outcomes);
         return satisfiedInputsForConsume;
     }
 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/JnlpUrlLaunchArtifactProviderTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/JnlpUrlLaunchArtifactProviderTest.java
@@ -21,11 +21,17 @@ package org.datacleaner.monitor.server;
 
 import java.util.List;
 
+import org.datacleaner.test.TestHelper;
+
 import junit.framework.TestCase;
 
 public class JnlpUrlLaunchArtifactProviderTest extends TestCase {
 
     public void testGetFilenames() throws Exception {
+        if (!TestHelper.isInternetConnected()) {
+            return;
+        }
+        
         JnlpUrlLaunchArtifactProvider provider = new JnlpUrlLaunchArtifactProvider();
 
         assertTrue(provider.isAvailable());

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/JnlpUrlLaunchArtifactProviderTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/JnlpUrlLaunchArtifactProviderTest.java
@@ -22,15 +22,14 @@ package org.datacleaner.monitor.server;
 import java.util.List;
 
 import org.datacleaner.test.TestHelper;
+import org.junit.Assume;
 
 import junit.framework.TestCase;
 
 public class JnlpUrlLaunchArtifactProviderTest extends TestCase {
 
     public void testGetFilenames() throws Exception {
-        if (!TestHelper.isInternetConnected()) {
-            return;
-        }
+        Assume.assumeTrue(TestHelper.isInternetConnected());
         
         JnlpUrlLaunchArtifactProvider provider = new JnlpUrlLaunchArtifactProvider();
 

--- a/testware/src/main/java/org/datacleaner/test/TestHelper.java
+++ b/testware/src/main/java/org/datacleaner/test/TestHelper.java
@@ -20,6 +20,8 @@
 package org.datacleaner.test;
 
 import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import javax.sql.DataSource;
 
@@ -59,5 +61,18 @@ public class TestHelper {
             return null;
         }
         return xml.trim().replace("\r\n", "\n");
+    }
+    
+    public static boolean isInternetConnected() {
+        return isInternetConnected("google.com");
+    }
+
+    public static boolean isInternetConnected(String hostnameToCheck) {
+        try {
+            InetAddress.getByName(hostnameToCheck);
+            return true;
+        } catch (UnknownHostException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Fixes #1192

Approach taken was to check whether the transformer being previewed was already under some filter condition. If so, we only apply Max rows condition to the existing filters. That ensures that it becomes an AND filtering scenario instead of a logical OR.

The __second__ approach taken was not related to the preview per se, but at the engine level (`AbstractRowProcessingConsumer`). Here I found that the `_sourceJobsOfInputColumns` which is used to determine if filtered sources of columns (transformers with filter requirements on them) are handled in a logical OR fashion. In the case of the reproducing .analysis.xml file, a filter was added to this list and thus it acted as a gate-opener for the OR condition which shouldn't have happened.

So, actually this PR fixes two bugs :-)

(also a small commit to make internet-dependent unittests pass automagically if you're offline).

Note from my side: I think this change is testament that our "flattening" of the graph into a list of components is starting to show it's weaknesses. I believe that it is fixed now, but I could imagine that with more and more complex jobs we will see an increase in complexity also in the calculation of requirements for processing a particular item in the list. It does seem like we soon should refactor the engine to do true graph processing - it starts to seem that it would simplify rather than make more complex.