### PR TITLE
Lower timeout for HdfsUrlChooser

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/util/HdfsUtils.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/HdfsUtils.java
@@ -25,13 +25,15 @@ import java.net.URI;
 import javax.ws.rs.core.UriBuilder;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.datacleaner.server.HadoopClusterInformation;
 
 public class HdfsUtils {
 
     public static Configuration getHadoopConfiguration(URI uri) {
-        final Configuration conf = new Configuration();
+        final Configuration conf = getHadoopConfigurationWithTimeout(null);
         conf.set("fs.defaultFS", uri.toString());
         return conf;
     }
@@ -47,5 +49,19 @@ public class HdfsUtils {
 
     public static FileSystem getFileSystemFromPath(Path path){
         return getFileSystemFromUri(path.toUri());
+    }
+
+    public static Configuration getHadoopConfigurationWithTimeout(final HadoopClusterInformation clusterInformation) {
+        Configuration configuration = null;
+        
+        if (clusterInformation == null) {
+            configuration = new Configuration();
+        } else {
+            configuration = clusterInformation.getConfiguration();
+        }
+
+        configuration.set(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY, String
+                .valueOf(1));
+        return configuration;
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/HdfsUrlChooser.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/HdfsUrlChooser.java
@@ -513,7 +513,7 @@ public class HdfsUrlChooser extends JComponent {
         }
 
         final Configuration configuration = HdfsUtils.getHadoopConfigurationWithTimeout(clusterInformation);
-        
+
         _currentDirectory = new Path("/");
 
         try {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/HdfsUrlChooser.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/HdfsUrlChooser.java
@@ -55,7 +55,6 @@ import javax.swing.WindowConstants;
 import javax.ws.rs.core.UriBuilder;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -513,10 +512,7 @@ public class HdfsUrlChooser extends JComponent {
             return false;
         }
 
-        final Configuration configuration = clusterInformation.getConfiguration();
-
-        configuration.set(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY, String
-                .valueOf(1));
+        final Configuration configuration = HdfsUtils.getHadoopConfigurationWithTimeout(clusterInformation);
         
         _currentDirectory = new Path("/");
 


### PR DESCRIPTION
Fixes #1150.

Changed the max number of retries for trying to connect with an HDFS to 1 (where the default is 45) when selecting a File from an HDFS and refactored the code a bit, so no more attempts to retrieve files from the HDFS are done if the scanning of the Hadoop config files isn't successful.