### PR TITLE
Catch errors in component close methods

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareTaskRunnerWrapper.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/ErrorAwareTaskRunnerWrapper.java
@@ -38,10 +38,10 @@ final class ErrorAwareTaskRunnerWrapper implements TaskRunner, ErrorAware {
     
     private static final Logger logger = LoggerFactory.getLogger(ErrorAwareTaskRunnerWrapper.class);
 
-	// a single shared exception is used if previous exceptions have been
+	// A per-job exception is used if previous exceptions have been
 	// reported. This is to make sure that the error message
 	// ("A previous exception has occurred") will only be saved once.
-	private static final PreviousErrorsExistException PREVIOUS_ERROR_EXCEPTION = new PreviousErrorsExistException(
+	private final PreviousErrorsExistException _previousErrorsExistException = new PreviousErrorsExistException(
 			"A previous exception has occurred");
 
 	private final TaskRunner _taskRunner;
@@ -55,10 +55,10 @@ final class ErrorAwareTaskRunnerWrapper implements TaskRunner, ErrorAware {
 	@Override
 	public void run(Task task, TaskListener taskListener) {
 		if (isErrornous()) {
-			taskListener.onError(task, PREVIOUS_ERROR_EXCEPTION);
+			taskListener.onError(task, _previousErrorsExistException);
 		} else if (isCancelled()) {
 		    logger.info("Ignoring task because job has been cancelled: {}", task);
-		    taskListener.onError(task, PREVIOUS_ERROR_EXCEPTION);
+		    taskListener.onError(task, _previousErrorsExistException);
 		} else {
 			_taskRunner.run(task, taskListener);
 		}

--- a/engine/core/src/main/java/org/datacleaner/job/tasks/CloseTaskListener.java
+++ b/engine/core/src/main/java/org/datacleaner/job/tasks/CloseTaskListener.java
@@ -90,6 +90,7 @@ public class CloseTaskListener implements TaskListener {
             cleanup();
         } catch (Exception e) {
             onErrorInternal(task, e, false);
+            return;
         }
         if (_nextTaskListener != null) {
             _nextTaskListener.onComplete(task);
@@ -102,6 +103,8 @@ public class CloseTaskListener implements TaskListener {
     }
 
     private void onErrorInternal(Task task, Throwable throwable, boolean doCleanup) {
+        final boolean previouslySuccessful = _success.getAndSet(false);
+
         if (doCleanup) {
             try {
                 cleanup();
@@ -110,7 +113,6 @@ public class CloseTaskListener implements TaskListener {
             }
         }
 
-        final boolean previouslySuccessful = _success.getAndSet(false);
         if (previouslySuccessful) {
             // only report the first such error
             _analysisListener.errorUnknown(_analysisJob, throwable);

--- a/engine/core/src/test/java/org/datacleaner/job/tasks/CloseTaskListenerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/job/tasks/CloseTaskListenerTest.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.job.tasks;
 
 import java.util.List;


### PR DESCRIPTION
To avoid hangs, closing tasks must always continue, even with an error in a component's `@Close`-annotated methods.
We may want to do more elaborate reporting, but for now an error is just logged.

Fixes #1247