### PR TITLE
Add new partition index to Spark component key

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
@@ -59,7 +59,8 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
         AbstractComponentBuilder<AnalyzerDescriptor<A>, A, AnalyzerComponentBuilder<A>> {
 
     public static final String METADATA_PROPERTY_BUILDER_ID = "org.datacleaner.componentbuilder.id";
-    public static final String METADATA_PROPERTY_BUILDER_PARTITION_INDEX = "org.datacleaner.componentbuilder.partition.id";
+    public static final String METADATA_PROPERTY_BUILDER_PARTITION_INDEX =
+            "org.datacleaner.componentbuilder.partition.index";
 
     private static final Logger logger = LoggerFactory.getLogger(AnalysisJobBuilder.class);
 

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AnalyzerComponentBuilder.java
@@ -59,6 +59,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
         AbstractComponentBuilder<AnalyzerDescriptor<A>, A, AnalyzerComponentBuilder<A>> {
 
     public static final String METADATA_PROPERTY_BUILDER_ID = "org.datacleaner.componentbuilder.id";
+    public static final String METADATA_PROPERTY_BUILDER_PARTITION_INDEX = "org.datacleaner.componentbuilder.partition.id";
 
     private static final Logger logger = LoggerFactory.getLogger(AnalysisJobBuilder.class);
 
@@ -205,15 +206,17 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
 
         final List<AnalyzerJob> jobs = new ArrayList<AnalyzerJob>();
         final Set<Entry<Table, List<InputColumn<?>>>> entrySet = originatingTables.entrySet();
+        int partitionIndex = 0;
         for (Entry<Table, List<InputColumn<?>>> entry : entrySet) {
             final List<InputColumn<?>> columnsOfTable = entry.getValue();
             if (_escalatingInputProperty == null || _escalatingInputProperty.isArray()) {
                 // escalation will happen only for multi-table input
-                jobs.add(createPartitionedJob(null, columnsOfTable, configuredProperties));
+                jobs.add(createPartitionedJob(null, columnsOfTable, configuredProperties, partitionIndex++));
             } else {
                 for (InputColumn<?> escalatingColumn : columnsOfTable) {
                     // escalation happens for each column
-                    jobs.add(createPartitionedJob(escalatingColumn, columnsOfTable, configuredProperties));
+                    jobs.add(createPartitionedJob(escalatingColumn, columnsOfTable, configuredProperties,
+                            partitionIndex++));
                 }
             }
         }
@@ -278,8 +281,8 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
     }
 
     private AnalyzerJob createPartitionedJob(InputColumn<?> escalatingColumnValue, Collection<InputColumn<?>> availableColumns,
-            Map<ConfiguredPropertyDescriptor, Object> configuredProperties) {
-        final Map<ConfiguredPropertyDescriptor, Object> jobProperties = new HashMap<ConfiguredPropertyDescriptor, Object>(
+            Map<ConfiguredPropertyDescriptor, Object> configuredProperties, int partitionIndex) {
+        final Map<ConfiguredPropertyDescriptor, Object> jobProperties = new HashMap<>(
                 configuredProperties);
         for (Entry<ConfiguredPropertyDescriptor, Object> jobProperty : jobProperties.entrySet()) {
             final ConfiguredPropertyDescriptor propertyDescriptor = jobProperty.getKey();
@@ -299,6 +302,7 @@ public final class AnalyzerComponentBuilder<A extends Analyzer<?>> extends
         // jobs back to their builder
         final Map<String, String> metadataProperties = new LinkedHashMap<>(getMetadataProperties());
         metadataProperties.put(METADATA_PROPERTY_BUILDER_ID, "" + System.identityHashCode(this));
+        metadataProperties.put(METADATA_PROPERTY_BUILDER_PARTITION_INDEX, "" + partitionIndex);
 
         // we do not currently support this combination of multiple analyzer
         // jobs and having output data streams

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -73,7 +73,6 @@ public class SparkJobContext implements Serializable {
     // cached/transient state
     private transient DataCleanerConfiguration _dataCleanerConfiguration;
     private transient AnalysisJobBuilder _analysisJobBuilder;
-    private AnalysisJobBuilder _analysisJobBuilder1;
 
     public SparkJobContext(final URI dataCleanerConfigurationPath, final URI analysisJobXmlPath,
             final URI customPropertiesPath, final JavaSparkContext sparkContext) {

--- a/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/SparkJobContext.java
@@ -41,6 +41,7 @@ import org.datacleaner.job.ComponentJob;
 import org.datacleaner.job.JaxbJobReader;
 import org.datacleaner.job.OutputDataStreamJob;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.spark.utils.HdfsHelper;
 import org.datacleaner.util.InputStreamToPropertiesMapFunc;
@@ -72,6 +73,7 @@ public class SparkJobContext implements Serializable {
     // cached/transient state
     private transient DataCleanerConfiguration _dataCleanerConfiguration;
     private transient AnalysisJobBuilder _analysisJobBuilder;
+    private AnalysisJobBuilder _analysisJobBuilder1;
 
     public SparkJobContext(final URI dataCleanerConfigurationPath, final URI analysisJobXmlPath,
             final URI customPropertiesPath, final JavaSparkContext sparkContext) {
@@ -182,9 +184,14 @@ public class SparkJobContext implements Serializable {
     public String getComponentKey(ComponentJob componentJob) {
         final String key = componentJob.getMetadataProperties().get(METADATA_PROPERTY_COMPONENT_INDEX);
         if (key == null) {
-            throw new IllegalArgumentException("Cannot find component in job: " + componentJob);
+            throw new IllegalStateException("No key registered for component: " + componentJob);        }
+
+        final String partitionKey = componentJob.getMetadataProperties().get(AnalyzerComponentBuilder.METADATA_PROPERTY_BUILDER_PARTITION_INDEX);
+        if (partitionKey != null) {
+            return key + "." + partitionKey;
+        } else {
+            return key;
         }
-        return key;
     }
 
     public ComponentJob getComponentByKey(final String key) {
@@ -200,10 +207,7 @@ public class SparkJobContext implements Serializable {
         final List<ComponentJob> componentJobs = CollectionUtils.<ComponentJob> concat(false, job.getTransformerJobs(),
                 job.getTransformerJobs(), job.getAnalyzerJobs());
         for (ComponentJob componentJob : componentJobs) {
-            final String componentKey = componentJob.getMetadataProperties().get(METADATA_PROPERTY_COMPONENT_INDEX);
-            if (componentKey == null) {
-                throw new IllegalStateException("No key registered for component: " + componentJob);
-            }
+            final String componentKey = getComponentKey(componentJob);
             if (queriedKey.equals(componentKey)) {
                 return componentJob;
             }

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/SparkAnalysisRunnerTest.java
@@ -51,9 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SparkAnalysisRunnerTest {
     private static class TestSparkJobLifeCycleListener implements SparkJobLifeCycleListener {
@@ -118,6 +116,30 @@ public class SparkAnalysisRunnerTest {
         final int upperCaseChars = stringAnalyzerResult.getEntirelyUpperCaseCount(stringAnalyzerResult.getColumns()[0]);
         assertEquals(7, upperCaseChars);
     }
+
+    @Test
+    public void testEscalatedValueDistributionScenario() throws Exception {
+        final AnalysisResultFuture result = runAnalysisJob("DCTest - " + getName(), URI.create(
+                "src/test/resources/escalated-job.analysis.xml"), "escalated-job", false);
+
+        if (result.isErrornous()) {
+            throw (Exception) result.getErrors().get(0);
+        }
+
+        assertEquals(3, result.getResultMap().size());
+        final List<AnalyzerResult> results = result.getResults();
+        assertEquals(3, results.size());
+
+        final List<? extends ValueDistributionAnalyzerResult> valueDistributionAnalyzerResults =
+                result.getResults(ValueDistributionAnalyzerResult.class);
+        assertEquals(2,valueDistributionAnalyzerResults.size());
+
+        final ValueDistributionAnalyzerResult
+                vdAnalyzerResult = valueDistributionAnalyzerResults.get(0);
+        assertEquals(7, vdAnalyzerResult
+                .getTotalCount());
+    }
+
 
     @Test
     public void testWriteDataScenarioNoResult() throws Exception {

--- a/engine/env/spark/src/test/resources/escalated-job.analysis.xml
+++ b/engine/env/spark/src/test/resources/escalated-job.analysis.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+
+	<source>
+		<data-context ref="person_names" />
+		<columns>
+			<column id="col_country" path="country" />
+			<column id="col_company" path="company" />
+		</columns>
+	</source>
+
+	<analysis>
+		<analyzer>
+			<descriptor ref="String analyzer" />
+			<input ref="col_company" />
+		</analyzer>
+		
+		<analyzer>
+			<descriptor ref="Value distribution" />
+			<input ref="col_country" />
+			<input ref="col_company" />
+		</analyzer>
+	</analysis>
+
+</job>

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
@@ -347,6 +347,9 @@ public class JaxbJobWriter implements JobWriter<OutputStream> {
             if (key.equals(AnalyzerComponentBuilder.METADATA_PROPERTY_BUILDER_ID)) {
                 continue;
             }
+            if (key.equals(AnalyzerComponentBuilder.METADATA_PROPERTY_BUILDER_PARTITION_INDEX)) {
+                continue;
+            }
             final org.datacleaner.job.jaxb.MetadataProperties.Property property = new org.datacleaner.job.jaxb.MetadataProperties.Property();
             property.setName(key);
             property.setValue(entry.getValue());


### PR DESCRIPTION
To avoid escalated component jobs being sent to a single reducer, a new partition index is introduced, which makes it possible to see that the partitions are not the same job.

Fixes #1242