### PR TITLE
Upgraded to Apache MetaModel 4.5.2 (using staged repo)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<httpcomponents.version>4.4.1</httpcomponents.version>
 		<guava.version>16.0.1</guava.version>
 		<curator.version>2.6.0</curator.version>
-		<metamodel.version>4.5.1</metamodel.version>
+		<metamodel.version>4.5.2</metamodel.version>
 		<metamodel.extras.version>4.4.0</metamodel.extras.version>
 		<gwt.version>2.7.0</gwt.version>
 		<spring.core.version>4.1.9.RELEASE</spring.core.version>
@@ -51,6 +51,19 @@
 		almost any kind of data, eg. CSV files, databases, Excel spreadsheets, NoSQL databases and more.</description>
 	<url>http://datacleaner.org</url>
 	<packaging>pom</packaging>
+	
+	<repositories>
+		<repository>
+        <id>metamodel-staging</id>
+        <url>https://repository.apache.org/content/repositories/orgapachemetamodel-1017</url>
+        <releases>
+           <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+     </repository>
+	</repositories>
 	
 	<profiles>
 		<profile>


### PR DESCRIPTION
A branch used to check that the (staged) Apache MetaModel 4.5.2 release will work with DataCleaner. Let's see how Travis CI runs with this ...

Please do not merge yet, since the MM release is still awaiting it's release VOTE.