### PR TITLE
Preventing "ordering" in MaxRowsFilter when "Running on N rows"

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/ExecuteButtonOptions.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/ExecuteButtonOptions.java
@@ -165,6 +165,7 @@ public class ExecuteButtonOptions {
                     final FilterComponentBuilder<MaxRowsFilter, Category> maxRowsFilter = jobBuilderCopy
                             .addFilter(MaxRowsFilter.class);
                     maxRowsFilter.getComponentInstance().setMaxRows(maxRows.intValue());
+                    maxRowsFilter.getComponentInstance().setApplyOrdering(false);
                     maxRowsFilter.addInputColumn(jobBuilderCopy.getSourceColumns().get(0));
                     final FilterOutcome filterOutcome = maxRowsFilter.getFilterOutcome(MaxRowsFilter.Category.VALID);
                     final Collection<ComponentBuilder> componentBuilders = jobBuilderCopy.getComponentBuilders();


### PR DESCRIPTION
A small (but important) fix to the "Preview N rows" functionality on the execute button. This ensures that ordering is not applied by the "Max rows" filter - which means that on the query execution plan, nothing is done to apply an "ORDER BY" clause.

(I just ran out of memory due to this - because I was previewing a job based on a very big CSV file ... DOH!)