### PR TITLE
Hadoop direct namenode connection naming

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/util/convert/HadoopResourceBuilder.java
@@ -45,7 +45,7 @@ public class HadoopResourceBuilder {
      * <li>Group 3: The path (example '/foo/bar.txt')</li>
      * </ul>
      */
-    public static final Pattern RESOURCE_SCHEME_PATTERN = Pattern.compile("([\\w\\+\\-\\.]+)://\\{([\\w\\.]*)\\}(.*)");
+    public static final Pattern RESOURCE_SCHEME_PATTERN = Pattern.compile("([\\w\\+\\-\\.]+)://\\{([\\w\\.\\W\\s]*)\\}(.*)");
 
     public HadoopResourceBuilder(ServerInformationCatalog catalog, String templatedUri) {
         final Matcher matcher = RESOURCE_SCHEME_PATTERN.matcher(templatedUri);

--- a/engine/core/src/test/java/org/datacleaner/util/convert/HadoopResourceBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/util/convert/HadoopResourceBuilderTest.java
@@ -37,6 +37,16 @@ public class HadoopResourceBuilderTest {
     }
 
     @Test
+    public void testPatternGroupsWithSpaces() throws Exception {
+        final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher(
+                "hdfs://{my /-+\\|& server}/foo/bar.txt");
+        assertTrue(matcher.find());
+        assertEquals("hdfs", matcher.group(1));
+        assertEquals("my /-+\\|& server", matcher.group(2));
+        assertEquals("/foo/bar.txt", matcher.group(3));
+    }
+
+    @Test
     public void testPatternGroupsNoScheme() throws Exception {
         final Matcher matcher = HadoopResourceBuilder.RESOURCE_SCHEME_PATTERN.matcher("/foo/bar.txt");
         assertFalse(matcher.find());


### PR DESCRIPTION
Fixes #1259

Changed the regular expression so it is able to handle more kinds of names for direct namenode connections to Hadoop clusters.