### PR TITLE
Fix reference to Salesforce duplicate detection job

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/user/DemoConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/DemoConfiguration.java
@@ -43,7 +43,8 @@ public class DemoConfiguration {
     public static final String JOB_CUSTOMER_JOB_TITLE_ANALYTICS = addFile("jobs/Job title analytics.analysis.xml");
     public static final String JOB_CUSTOMER_DEDUP_TRAINING = addFile("jobs/dedup_customers_training.analysis.xml");
     public static final String JOB_CUSTOMER_DEDUP_DETECTION = addFile("jobs/dedup_customers_detection.analysis.xml");
-    public static final String JOB_SFDC_DUPLICATE_TRAINING = addFile("jobs/Salesforce dedup training.analysis.xml");
+    public static final String JOB_SFDC_DUPLICATE_TRAINING = addFile(
+            "jobs/Salesforce duplicate detection.analysis.xml");
     public static final String JOB_EXPORT_ORDERS_DATA = addFile("jobs/Export of Orders data mart.analysis.xml");
     public static final String JOB_COPY_EMPLOYEES_TO_CUSTOMERS = addFile("jobs/Copy employees to customer table.analysis.xml");
     public static final String JOB_ORDERDB_DUPLICATE_DETECTION = addFile("jobs/OrderDB Customers Duplicate detection.analysis.xml");


### PR DESCRIPTION
Fixes #1269.

Replaced reference to non existent "Salesforce dedup training" job with one to the existent "Salesforce duplicate detection" job.