### PR TITLE
Fix errors caused by missing .png files

### DIFF
--- a/desktop/ui/pom.xml
+++ b/desktop/ui/pom.xml
@@ -58,6 +58,35 @@
 					<source>${project.build.directory}/lib</source>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.8</version>
+				<executions>
+					<execution>
+						<id>copy-icons</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<target name="copyicons">
+						<copy file="${project.build.directory}/classes/images/actions/add_dark.png" 
+								tofile="${project.build.directory}/classes/images/actions/add.png" />
+						<copy file="${project.build.directory}/classes/images/actions/close_dark.png" 
+								tofile="${project.build.directory}/classes/images/actions/close.png" />
+						<copy file="${project.build.directory}/classes/images/actions/remove_dark.png" 
+								tofile="${project.build.directory}/classes/images/actions/remove.png" />
+						<copy file="${project.build.directory}/classes/images/actions/save_dark.png" 
+								tofile="${project.build.directory}/classes/images/actions/save.png" />
+						<copy file="${project.build.directory}/classes/images/actions/scrolldown_dark.png" 
+								tofile="${project.build.directory}/classes/images/actions/scrolldown.png" />
+					</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Fixes #1285.

Copy images/actions/*_dark.png to images/actions/*.png to make sure components compiled against older versions which use the .png files still work at run-time.