### PR TITLE
Fix backwards compatibility issue in plain search/replace transformer

### DIFF
--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -48,6 +48,7 @@ import org.apache.metamodel.util.FileHelper;
 import org.datacleaner.api.Converter;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.OutputDataStream;
+import org.datacleaner.beans.transform.PlainSearchReplaceTransformer;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.SourceColumnMapping;
 import org.datacleaner.connection.Datastore;
@@ -878,38 +879,49 @@ public class JaxbJobReader implements JobReader<InputStream> {
         if (configuredPropertiesType != null) {
             final List<Property> properties = configuredPropertiesType.getProperty();
             final ComponentDescriptor<?> descriptor = builder.getDescriptor();
+
+            Map<String, String> removedProperties = new HashMap<>();
+            
             for (Property property : properties) {
                 final String name = property.getName();
-                final ConfiguredPropertyDescriptor configuredProperty = descriptor.getConfiguredProperty(name);
+                
+                if (isRemovedProperty(descriptor, name)) {
+                    removedProperties.put(name, getValue(property));
+                } else {
+                    final ConfiguredPropertyDescriptor configuredProperty = descriptor.getConfiguredProperty(name);
 
-                if (configuredProperty == null) {
-                    throw new ComponentConfigurationException("No such property: " + name);
-                }
-
-                String stringValue = getValue(property);
-                if (stringValue == null) {
-                    String variableRef = property.getRef();
-                    if (variableRef == null) {
-                        throw new IllegalStateException("Neither value nor ref was specified for property: " + name);
+                    if (configuredProperty == null) {
+                        throw new ComponentConfigurationException("No such property: " + name);
                     }
 
-                    stringValue = variables.get(variableRef);
-
+                    String stringValue = getValue(property);
                     if (stringValue == null) {
-                        throw new ComponentConfigurationException("No such variable: " + variableRef);
+                        String variableRef = property.getRef();
+                        if (variableRef == null) {
+                            throw new IllegalStateException("Neither value nor ref was specified for property: "
+                                    + name);
+                        }
+
+                        stringValue = variables.get(variableRef);
+
+                        if (stringValue == null) {
+                            throw new ComponentConfigurationException("No such variable: " + variableRef);
+                        }
+
+                        builder.getMetadataProperties().put(DATACLEANER_JAXB_VARIABLE_PREFIX + configuredProperty
+                                .getName(), variableRef);
                     }
 
-                    builder.getMetadataProperties().put(
-                            DATACLEANER_JAXB_VARIABLE_PREFIX + configuredProperty.getName(), variableRef);
+                    final Converter<?> customConverter = configuredProperty.createCustomConverter();
+                    final Object value = stringConverter.deserialize(stringValue, configuredProperty.getType(),
+                            customConverter);
+
+                    logger.debug("Setting property '{}' to {}", name, value);
+                    builder.setConfiguredProperty(configuredProperty, value);
                 }
-
-                final Converter<?> customConverter = configuredProperty.createCustomConverter();
-                final Object value = stringConverter.deserialize(stringValue, configuredProperty.getType(),
-                        customConverter);
-
-                logger.debug("Setting property '{}' to {}", name, value);
-                builder.setConfiguredProperty(configuredProperty, value);
             }
+            
+            processRemovedProperties(builder, stringConverter, descriptor, removedProperties);
         }
         if (metadataPropertiesType != null) {
             final List<org.datacleaner.job.jaxb.MetadataProperties.Property> propertyList = metadataPropertiesType
@@ -920,6 +932,18 @@ public class JaxbJobReader implements JobReader<InputStream> {
                 builder.setMetadataProperty(name, value);
             }
         }
+    }
+
+    private static void processRemovedProperties(final ComponentBuilder builder, final StringConverter stringConverter,
+            final ComponentDescriptor<?> descriptor, Map<String, String> removedProperties) {
+        if (descriptor.getComponentClass() == PlainSearchReplaceTransformer.class) {
+            PlainSearchReplaceTransformer.processRemovedProperties(builder, stringConverter, descriptor,
+                    removedProperties);
+        }
+    }
+
+    private static boolean isRemovedProperty(final ComponentDescriptor<?> descriptor, final String name) {
+        return PlainSearchReplaceTransformer.isRemovedProperty(descriptor, name); 
     }
 
     private String getValue(Property property) {

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -880,7 +880,7 @@ public class JaxbJobReader implements JobReader<InputStream> {
             final List<Property> properties = configuredPropertiesType.getProperty();
             final ComponentDescriptor<?> descriptor = builder.getDescriptor();
 
-            Map<String, String> removedProperties = new HashMap<>();
+            final Map<String, String> removedProperties = new HashMap<>();
             
             for (Property property : properties) {
                 final String name = property.getName();

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -464,4 +464,11 @@ public class JaxbJobReaderTest extends TestCase {
         assertNotNull(result3);
         assertEquals(0, result3.getRowCount(result3.getColumns()[0]));
     }
+
+    public void testPlainSearchReplaceJobUpgrade() throws Exception {
+        JaxbJobReader reader = new JaxbJobReader(conf);
+        AnalysisJobBuilder jobBuilder = reader.create(new File(
+                "src/test/resources/version_4_5_3_plain_search_replace.analysis.xml"));
+        assertTrue(jobBuilder.isConfigured());
+    }
 }

--- a/engine/xml-config/src/test/resources/version_4_5_3_plain_search_replace.analysis.xml
+++ b/engine/xml-config/src/test/resources/version_4_5_3_plain_search_replace.analysis.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <job-description>Created with DataCleaner Enterprise edition 4.5.3</job-description>
+        <author>arjans</author>
+        <updated-date>2016-04-12+02:00</updated-date>
+        <metadata-properties>
+            <property name="CoordinatesX.PUBLIC.CUSTOMERS">144</property>
+            <property name="CoordinatesY.PUBLIC.CUSTOMERS">80</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="my database"/>
+        <columns>
+            <column id="col_country" path="CUSTOMERS.COUNTRY" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation>
+        <transformer>
+            <descriptor ref="Plain search/replace"/>
+            <metadata-properties>
+                <property name="CoordinatesX">326</property>
+                <property name="CoordinatesY">178</property>
+            </metadata-properties>
+            <properties>
+                <property name="Search string" value="Espana"/>
+                <property name="Replacement string" value="Spain"/>
+                <property name="Replace entire string" value="true"/>
+            </properties>
+            <input ref="col_country"/>
+            <output id="col_countryreplacedespana" name="COUNTRY (replaced 'Espana')"/>
+        </transformer>
+    </transformation>
+    <analysis>
+        <analyzer>
+            <descriptor ref="Value distribution"/>
+            <metadata-properties>
+                <property name="CoordinatesX">532</property>
+                <property name="CoordinatesY">234</property>
+            </metadata-properties>
+            <properties>
+                <property name="Record unique values" value="true"/>
+                <property name="Record drill-down information" value="true"/>
+                <property name="Top n most frequent values" value="&lt;null&gt;"/>
+                <property name="Bottom n most frequent values" value="&lt;null&gt;"/>
+            </properties>
+            <input ref="col_countryreplacedespana" name="Column"/>
+        </analyzer>
+    </analysis>
+</job>


### PR DESCRIPTION
Fixes #1284.

Added some logic to the JaxbJobReader#applyProperties method which checks if a property has been removed from the component which is being read, stores these values and uses these to process the removed properties, i.e. assign their values to another newly introduced property if necessary.

Implemented this logic specifically for the PlainSearchReplaceTransformer from which the "Search string" and "Replacement string" properties have been removed in favor of a "Replacements" property.