### PR TITLE
#1306 Datacloud status icon improvements.

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
@@ -23,7 +23,6 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import javax.inject.Provider;
 import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -33,14 +32,18 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 
 import org.datacleaner.actions.MoveComponentTimerActionListener;
+import org.datacleaner.bootstrap.WindowContext;
+import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.RemoteServerState;
+import org.datacleaner.user.UserPreferences;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.DCHtmlBox;
 import org.datacleaner.widgets.DCLabel;
-import org.datacleaner.windows.OptionsDialog;
+import org.datacleaner.windows.AbstractWindow;
+import org.datacleaner.windows.DataCloudLogInWindow;
 import org.jdesktop.swingx.VerticalLayout;
 
 /**
@@ -54,7 +57,6 @@ public class DataCloudInformationPanel extends JPanel {
     private static final int POSITION_Y = 130;
 
     private final DCGlassPane _glassPane;
-    private final Provider<OptionsDialog> _optionsDialogProvider;
     private final Color _background = WidgetUtils.BG_COLOR_BRIGHTEST;
     private final Color _foreground = WidgetUtils.BG_COLOR_DARKEST;
     private final Color _borderColor = WidgetUtils.BG_COLOR_MEDIUM;
@@ -64,18 +66,25 @@ public class DataCloudInformationPanel extends JPanel {
     final private DCHtmlBox htmlBoxDataCloud =
             new DCHtmlBox("More information on <a href=\"http://datacleaner.org\">datacleaner.org</a>");
 
-    public DataCloudInformationPanel(DCGlassPane glassPane, Provider<OptionsDialog> optionsDialogProvider) {
+    public DataCloudInformationPanel(DCGlassPane glassPane, final DataCleanerConfiguration configuration,
+            final UserPreferences userPreferences, WindowContext windowContext, AbstractWindow owner) {
         super();
         _glassPane = glassPane;
-        _optionsDialogProvider = optionsDialogProvider;
-        optionButton = WidgetFactory.createDefaultButton("Option", IconUtils.MENU_OPTIONS);
+        optionButton = WidgetFactory.createDefaultButton("Sign in to DataCloud", IconUtils.MENU_OPTIONS);
         optionButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(final ActionEvent e) {
                 moveOut(0);
-                final OptionsDialog optionsDialog = _optionsDialogProvider.get();
-                optionsDialog.getTabbedPane().setSelectedIndex(1);
-                optionsDialog.open();
+                WidgetUtils.invokeSwingAction(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (DataCloudLogInWindow.isRelevantToShow(userPreferences, configuration)) {
+                            final DataCloudLogInWindow dataCloudLogInWindow = new DataCloudLogInWindow(configuration,
+                                    userPreferences, windowContext, owner);
+                            dataCloudLogInWindow.open();
+                        }
+                    }
+                });
             }
         });
         setBorder(new CompoundBorder(new LineBorder(_borderColor, 1), new EmptyBorder(20, 20, 20, 30)));

--- a/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
@@ -73,7 +73,7 @@ public class DataCloudInformationPanel extends JPanel {
             @Override
             public void actionPerformed(final ActionEvent e) {
                 moveOut(0);
-                OptionsDialog optionsDialog = _optionsDialogProvider.get();
+                final OptionsDialog optionsDialog = _optionsDialogProvider.get();
                 optionsDialog.getTabbedPane().setSelectedIndex(1);
                 optionsDialog.open();
             }

--- a/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
@@ -20,8 +20,12 @@
 package org.datacleaner.panels;
 
 import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
+import javax.inject.Provider;
 import javax.swing.Box;
+import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.Timer;
 import javax.swing.border.CompoundBorder;
@@ -30,10 +34,13 @@ import javax.swing.border.LineBorder;
 
 import org.datacleaner.actions.MoveComponentTimerActionListener;
 import org.datacleaner.configuration.RemoteServerState;
+import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
+import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.DCHtmlBox;
 import org.datacleaner.widgets.DCLabel;
+import org.datacleaner.windows.OptionsDialog;
 import org.jdesktop.swingx.VerticalLayout;
 
 /**
@@ -47,17 +54,30 @@ public class DataCloudInformationPanel extends JPanel {
     private static final int POSITION_Y = 130;
 
     private final DCGlassPane _glassPane;
+    private final Provider<OptionsDialog> _optionsDialogProvider;
     private final Color _background = WidgetUtils.BG_COLOR_BRIGHTEST;
     private final Color _foreground = WidgetUtils.BG_COLOR_DARKEST;
     private final Color _borderColor = WidgetUtils.BG_COLOR_MEDIUM;
 
     private DCLabel text;
-    final DCHtmlBox htmlBoxDataCloud =
+    private JButton optionButton;
+    final private DCHtmlBox htmlBoxDataCloud =
             new DCHtmlBox("More information on <a href=\"http://datacleaner.org\">datacleaner.org</a>");
 
-    public DataCloudInformationPanel(DCGlassPane glassPane) {
+    public DataCloudInformationPanel(DCGlassPane glassPane, Provider<OptionsDialog> optionsDialogProvider) {
         super();
         _glassPane = glassPane;
+        _optionsDialogProvider = optionsDialogProvider;
+        optionButton = WidgetFactory.createDefaultButton("Option", IconUtils.MENU_OPTIONS);
+        optionButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(final ActionEvent e) {
+                moveOut(0);
+                OptionsDialog optionsDialog = _optionsDialogProvider.get();
+                optionsDialog.getTabbedPane().setSelectedIndex(1);
+                optionsDialog.open();
+            }
+        });
         setBorder(new CompoundBorder(new LineBorder(_borderColor, 1), new EmptyBorder(20, 20, 20, 30)));
         setVisible(false);
         setSize(WIDTH, 400);
@@ -73,6 +93,8 @@ public class DataCloudInformationPanel extends JPanel {
         text = DCLabel.darkMultiLine("");
         add(text);
         add(Box.createVerticalBox());
+        add(optionButton);
+        add(Box.createVerticalBox());
         add(htmlBoxDataCloud);
     }
 
@@ -85,6 +107,7 @@ public class DataCloudInformationPanel extends JPanel {
     }
 
     public void setInformationStatus(RemoteServerState remoteServerState) {
+        optionButton.setVisible(false);
         text.setText("");
         String panelContent = "";
         if (remoteServerState.getActualState() == RemoteServerState.State.OK ||
@@ -108,8 +131,8 @@ public class DataCloudInformationPanel extends JPanel {
 
         if (remoteServerState.getActualState() == RemoteServerState.State.NOT_CONNECTED) {
             panelContent = addLine(panelContent, "Datacloud is not configured.");
-            panelContent = addLine(panelContent, "You can set your credentials in");
-            panelContent = addLine(panelContent, "<b>Options dialog - DataCloud</b>");
+            panelContent = addLine(panelContent, "You can set your credentials here.");
+            optionButton.setVisible(true);
         }
 
         if (remoteServerState.getActualState() == RemoteServerState.State.ERROR) {

--- a/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DataCloudInformationPanel.java
@@ -59,8 +59,8 @@ public class DataCloudInformationPanel extends JPanel {
     private final Color _foreground = WidgetUtils.BG_COLOR_DARKEST;
     private final Color _borderColor = WidgetUtils.BG_COLOR_MEDIUM;
 
-    private DCLabel text;
-    private JButton optionButton;
+    private final DCLabel text;
+    private final JButton optionButton;
     final private DCHtmlBox htmlBoxDataCloud =
             new DCHtmlBox("More information on <a href=\"http://datacleaner.org\">datacleaner.org</a>");
 

--- a/desktop/ui/src/main/java/org/datacleaner/util/MutableRemoteServerConfigurationImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/MutableRemoteServerConfigurationImpl.java
@@ -38,7 +38,7 @@ public class MutableRemoteServerConfigurationImpl extends RemoteServerConfigurat
     }
 
     public void addServer(String serverName, String url, String username, String password) {
-        RemoteServerData serverData = new RemoteServerDataImpl(url, serverName, username, password);
+        final RemoteServerData serverData = new RemoteServerDataImpl(url, serverName, username, password);
         addRemoteData(serverData);
         if(RemoteDescriptorProvider.DATACLOUD_SERVER_NAME.equals(serverName)){
             configWriter.addRemoteServer(serverName, null, username, password);

--- a/desktop/ui/src/main/java/org/datacleaner/util/MutableRemoteServerConfigurationImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/MutableRemoteServerConfigurationImpl.java
@@ -25,6 +25,7 @@ import org.datacleaner.configuration.DomConfigurationWriter;
 import org.datacleaner.configuration.RemoteServerConfigurationImpl;
 import org.datacleaner.configuration.RemoteServerData;
 import org.datacleaner.configuration.RemoteServerDataImpl;
+import org.datacleaner.descriptors.RemoteDescriptorProvider;
 import org.datacleaner.job.concurrent.TaskRunner;
 
 public class MutableRemoteServerConfigurationImpl extends RemoteServerConfigurationImpl {
@@ -38,8 +39,13 @@ public class MutableRemoteServerConfigurationImpl extends RemoteServerConfigurat
 
     public void addServer(String serverName, String url, String username, String password) {
         RemoteServerData serverData = new RemoteServerDataImpl(url, serverName, username, password);
-        remoteServerDataList.add(serverData);
-        configWriter.addRemoteServer(serverName, url, username, password);
+        addRemoteData(serverData);
+        if(RemoteDescriptorProvider.DATACLOUD_SERVER_NAME.equals(serverName)){
+            configWriter.addRemoteServer(serverName, null, username, password);
+        }else{
+            configWriter.addRemoteServer(serverName, url, username, password);
+        }
+
     }
 
     public void updateServerCredentials(String serverName, String userName, String password) {

--- a/desktop/ui/src/main/java/org/datacleaner/util/RemoteServersUtils.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/RemoteServersUtils.java
@@ -45,18 +45,18 @@ public class RemoteServersUtils {
             DataCleanerEnvironment env, String serverName, String serverUrl, String userName, String password) {
         if (RemoteDescriptorProvider.DATACLOUD_SERVER_NAME.equals(serverName)) {
             serverUrl = RemoteDescriptorProvider.DATACLOUD_URL;
-            getMutableServerConfig(env).addServer(serverName, null, userName, password);
-        } else {
-            getMutableServerConfig(env).addServer(serverName, serverUrl, userName, password);
         }
+        getMutableServerConfig(env).addServer(serverName, serverUrl, userName, password);
 
         RemoteServerData remoteServerData = new RemoteServerDataImpl(serverUrl, serverName, userName, password);
 
-        if(!(env.getDescriptorProvider() instanceof CompositeDescriptorProvider)){
+        if (!(env.getDescriptorProvider() instanceof CompositeDescriptorProvider)) {
             throw new IllegalStateException("DescriptorProvider is not instance of CompositeDescriptorProvider class.");
         }
-        final CompositeDescriptorProvider descriptorProvider = (CompositeDescriptorProvider) env.getDescriptorProvider();
-        descriptorProvider.addDelegate(new RemoteDescriptorProviderImpl(remoteServerData, env.getRemoteServerConfiguration()));
+        final CompositeDescriptorProvider descriptorProvider =
+                (CompositeDescriptorProvider) env.getDescriptorProvider();
+        descriptorProvider
+                .addDelegate(new RemoteDescriptorProviderImpl(remoteServerData, env.getRemoteServerConfiguration()));
         descriptorProvider.refresh();
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/util/RemoteServersUtils.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/RemoteServersUtils.java
@@ -48,7 +48,7 @@ public class RemoteServersUtils {
         }
         getMutableServerConfig(env).addServer(serverName, serverUrl, userName, password);
 
-        RemoteServerData remoteServerData = new RemoteServerDataImpl(serverUrl, serverName, userName, password);
+        final RemoteServerData remoteServerData = new RemoteServerDataImpl(serverUrl, serverName, userName, password);
 
         if (!(env.getDescriptorProvider() instanceof CompositeDescriptorProvider)) {
             throw new IllegalStateException("DescriptorProvider is not instance of CompositeDescriptorProvider class.");

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/DataCloudStatusLabel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/DataCloudStatusLabel.java
@@ -23,19 +23,21 @@ import java.awt.Cursor;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
-import javax.inject.Provider;
 import javax.swing.JLabel;
 
+import org.datacleaner.bootstrap.WindowContext;
+import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.RemoteServerConfiguration;
 import org.datacleaner.configuration.RemoteServerState;
 import org.datacleaner.configuration.RemoteServerStateListener;
 import org.datacleaner.descriptors.RemoteDescriptorProvider;
 import org.datacleaner.panels.DCGlassPane;
 import org.datacleaner.panels.DataCloudInformationPanel;
+import org.datacleaner.user.UserPreferences;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.WidgetUtils;
-import org.datacleaner.windows.OptionsDialog;
+import org.datacleaner.windows.AbstractWindow;
 
 /**
  * Status Label for DataCloud
@@ -44,12 +46,12 @@ public class DataCloudStatusLabel extends JLabel {
     private RemoteServerConfiguration _remoteServerConfiguration;
     private DataCloudInformationPanel _dataCloudInformationPanel;
 
-    public DataCloudStatusLabel(final RemoteServerConfiguration remoteServerConfiguration, DCGlassPane glassPane,
-            Provider<OptionsDialog> optionsDialogProvider) {
+    public DataCloudStatusLabel(DCGlassPane glassPane,final DataCleanerConfiguration configuration,
+            final UserPreferences userPreferences, WindowContext windowContext, AbstractWindow owner) {
         super("DataCloud");
         setForeground(WidgetUtils.BG_COLOR_BRIGHTEST);
-        _remoteServerConfiguration = remoteServerConfiguration;
-        _dataCloudInformationPanel = new DataCloudInformationPanel(glassPane, optionsDialogProvider);
+        _remoteServerConfiguration = configuration.getEnvironment().getRemoteServerConfiguration();
+        _dataCloudInformationPanel = new DataCloudInformationPanel(glassPane, configuration, userPreferences, windowContext, owner);
 
         _remoteServerConfiguration.addListener(new RemoteServerStateListenerImpl());
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/DataCloudStatusLabel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/DataCloudStatusLabel.java
@@ -23,6 +23,7 @@ import java.awt.Cursor;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
+import javax.inject.Provider;
 import javax.swing.JLabel;
 
 import org.datacleaner.configuration.RemoteServerConfiguration;
@@ -34,6 +35,7 @@ import org.datacleaner.panels.DataCloudInformationPanel;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.WidgetUtils;
+import org.datacleaner.windows.OptionsDialog;
 
 /**
  * Status Label for DataCloud
@@ -42,16 +44,18 @@ public class DataCloudStatusLabel extends JLabel {
     private RemoteServerConfiguration _remoteServerConfiguration;
     private DataCloudInformationPanel _dataCloudInformationPanel;
 
-    public DataCloudStatusLabel(final RemoteServerConfiguration remoteServerConfiguration, DCGlassPane glassPane) {
+    public DataCloudStatusLabel(final RemoteServerConfiguration remoteServerConfiguration, DCGlassPane glassPane,
+            Provider<OptionsDialog> optionsDialogProvider) {
         super("DataCloud");
         setForeground(WidgetUtils.BG_COLOR_BRIGHTEST);
         _remoteServerConfiguration = remoteServerConfiguration;
-        _dataCloudInformationPanel = new DataCloudInformationPanel(glassPane);
+        _dataCloudInformationPanel = new DataCloudInformationPanel(glassPane, optionsDialogProvider);
 
         _remoteServerConfiguration.addListener(new RemoteServerStateListenerImpl());
 
         setIcon(RemoteServerState.State.NOT_CONNECTED);
-        _dataCloudInformationPanel.setInformationStatus(new RemoteServerState(RemoteServerState.State.NOT_CONNECTED, null, null));
+        _dataCloudInformationPanel
+                .setInformationStatus(new RemoteServerState(RemoteServerState.State.NOT_CONNECTED, null, null));
 
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         addMouseListener(new MouseAdapter() {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -769,8 +769,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         final JXStatusBar statusBar = WidgetFactory.createStatusBar(_statusLabel);
 
         final DataCloudStatusLabel dataCloudStatusLabel =
-                new DataCloudStatusLabel(_configuration.getEnvironment().getRemoteServerConfiguration(), _glassPane,
-                        _optionsDialogProvider);
+                new DataCloudStatusLabel( _glassPane, _configuration, _userPreferences, getWindowContext(), this);
         statusBar.add(dataCloudStatusLabel);
         statusBar.add(Box.createHorizontalStrut(20));
 

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -768,7 +768,9 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
 
         final JXStatusBar statusBar = WidgetFactory.createStatusBar(_statusLabel);
 
-        final DataCloudStatusLabel dataCloudStatusLabel = new DataCloudStatusLabel(_configuration.getEnvironment().getRemoteServerConfiguration(),  _glassPane);
+        final DataCloudStatusLabel dataCloudStatusLabel =
+                new DataCloudStatusLabel(_configuration.getEnvironment().getRemoteServerConfiguration(), _glassPane,
+                        _optionsDialogProvider);
         statusBar.add(dataCloudStatusLabel);
         statusBar.add(Box.createHorizontalStrut(20));
 
@@ -801,6 +803,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         final JMenuItem optionsMenuItem = WidgetFactory.createMenuItem("Options", IconUtils.MENU_OPTIONS);
         optionsMenuItem.addActionListener(e -> {
             OptionsDialog optionsDialog = _optionsDialogProvider.get();
+            optionsDialog.getTabbedPane().setSelectedIndex(0);
             optionsDialog.open();
         });
         

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -802,7 +802,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     private JToggleButton createMoreMenuButton() {
         final JMenuItem optionsMenuItem = WidgetFactory.createMenuItem("Options", IconUtils.MENU_OPTIONS);
         optionsMenuItem.addActionListener(e -> {
-            OptionsDialog optionsDialog = _optionsDialogProvider.get();
+            final OptionsDialog optionsDialog = _optionsDialogProvider.get();
             optionsDialog.getTabbedPane().setSelectedIndex(0);
             optionsDialog.open();
         });

--- a/engine/remote-components/src/main/java/org/datacleaner/configuration/RemoteServerConfigurationImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/configuration/RemoteServerConfigurationImpl.java
@@ -183,7 +183,7 @@ public class RemoteServerConfigurationImpl implements RemoteServerConfiguration 
     }
 
     private void notifyAllListeners(String remoteServerName){
-        RemoteServerState remoteServerState = actualStateMap.get(remoteServerName);
+        final RemoteServerState remoteServerState = actualStateMap.get(remoteServerName);
         for (RemoteServerStateListener listener : listeners) {
             logger.info("Remote server {} has new state {}", remoteServerName, remoteServerState);
             listener.onRemoteServerStateChange(remoteServerName, remoteServerState);

--- a/engine/remote-components/src/main/java/org/datacleaner/configuration/RemoteServerConfigurationImpl.java
+++ b/engine/remote-components/src/main/java/org/datacleaner/configuration/RemoteServerConfigurationImpl.java
@@ -173,10 +173,10 @@ public class RemoteServerConfigurationImpl implements RemoteServerConfiguration 
     }
 
     protected synchronized void addRemoteData(RemoteServerData remoteServerData){
-        String serverName = remoteServerData.getServerName();
+        final String serverName = remoteServerData.getServerName();
         remoteServerDataList.add(remoteServerData);
         if(RemoteDescriptorProvider.DATACLOUD_SERVER_NAME.equals(serverName)){
-            RemoteServerState remoteServerState = checkDataCloudServerAvailability(remoteServerData);
+            final RemoteServerState remoteServerState = checkDataCloudServerAvailability(remoteServerData);
             actualStateMap.put(serverName, remoteServerState);
             notifyAllListeners(serverName);
         }


### PR DESCRIPTION
#1306 
1) Class name won't be contained in error messages.
2) Add button into panel to show option dialog with datacloud credentials.
![option button](https://cloud.githubusercontent.com/assets/13237018/14630271/ba1dfac4-060c-11e6-9ddc-f4244a4ff63c.png)

3) DataCloud Icon must be green immediately after login to datacloud.
