### PR TITLE
Increase height of Simple dictionary dialog

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
@@ -156,7 +156,7 @@ public final class SimpleDictionaryDialog extends AbstractDialog {
         mainPanel.add(formPanel, BorderLayout.CENTER);
         mainPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        mainPanel.setPreferredSize(getDialogWidth(), 400);
+        mainPanel.setPreferredSize(getDialogWidth(), 430);
 
         return mainPanel;
     }


### PR DESCRIPTION
Fixes #1316.

Increase height of Simple dictionary dialog, so it looks as expected when opening it.