### PR TITLE
ElasticSearch: Remember connection type and don't use cluster name

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/ElasticSearchDatastoreDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ElasticSearchDatastoreDialog.java
@@ -220,7 +220,7 @@ public class ElasticSearchDatastoreDialog extends AbstractDatastoreDialog<Elasti
         if (originalDatastore == null) {
             _hostnameTextField.setText("localhost");
             _portTextField.setText(""+ElasticSearchDatastore.DEFAULT_PORT);
-            _clientTypeComboBox.setSelectedItem(ClientType.REST);
+            _clientTypeComboBox.setSelectedItem(DEFAULT_CLIENT_TYPE);
         } else {
             _clientTypeComboBox.setSelectedItem(originalDatastore.getClientType());
             _datastoreNameTextField.setText(originalDatastore.getName());

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
@@ -19,14 +19,12 @@
  */
 package org.datacleaner.configuration;
 
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Set;
 
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.schema.TableType;
 import org.apache.metamodel.util.FileResource;
-import org.apache.metamodel.util.Func;
 import org.apache.metamodel.util.HdfsResource;
 import org.apache.metamodel.util.Resource;
 import org.apache.metamodel.util.SimpleTableDef;
@@ -86,12 +84,7 @@ public class DomConfigurationWriter {
     }
 
     public DomConfigurationWriter(Resource resource) {
-        _document = resource.read(new Func<InputStream, Document>() {
-            @Override
-            public Document eval(InputStream in) {
-                return XmlUtils.parseDocument(in);
-            }
-        });
+        _document = resource.read(XmlUtils::parseDocument);
 
     }
 
@@ -663,9 +656,11 @@ public class DomConfigurationWriter {
         appendElement(ds, "port", datastore.getPort());
         appendElement(ds, "cluster-name", datastore.getClusterName());
         appendElement(ds, "index-name", datastore.getIndexName());
+        appendElement(ds, "client-type", datastore.getClientType().name());
         appendElement(ds, "username", datastore.getUsername());
         appendElement(ds, "password", encodePassword(datastore.getPassword()));
         appendElement(ds, "ssl", datastore.getSsl());
+
         if (datastore.getSsl()) {
             appendElement(ds, "keystore-path", datastore.getKeystorePath());
             appendElement(ds, "keystore-password", encodePassword(datastore.getKeystorePassword()));


### PR DESCRIPTION
This will store client connection types (none was remembered, but only REST was affected). Will also disable cluster name for REST clients, as it is not used.

 Fixes #1331
 Fixes #1311