### PR TITLE
Hot folder monitoring

### DIFF
--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
@@ -43,7 +43,8 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
     private boolean _distributedExecution;
     private String _dateForOneTimeSchedule;
 	private Map<String,String> _jobMetadataProperties;
-    private boolean _runOnHadoop; 
+    private boolean _runOnHadoop;
+    private String _hotFolder;
 
     // no-args constructor
     public ScheduleDefinition() {
@@ -138,8 +139,9 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
             return TriggerType.PERIODIC;
         } else if(_dateForOneTimeSchedule!= null){
         	return TriggerType.ONETIME;
-        }
-        else {
+        } else if (_hotFolder != null) {
+            return TriggerType.HOTFOLDER;
+        } else {
             return TriggerType.MANUAL;
         }
     }
@@ -159,7 +161,15 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
 	public Map<String,String> getJobMetadataProperties(){
 		return _jobMetadataProperties;
 	}
-    
+
+    public String getHotFolder() {
+        return _hotFolder;
+    }
+
+    public void setHotFolder(String hotFolder) {
+        _hotFolder = hotFolder;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/TriggerType.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/TriggerType.java
@@ -25,5 +25,5 @@ package org.datacleaner.monitor.scheduling.model;
  */
 public enum TriggerType {
 
-    MANUAL, PERIODIC, DEPENDENT, ONETIME
+    MANUAL, PERIODIC, DEPENDENT, ONETIME, HOTFOLDER
 }

--- a/monitor/api/src/main/resources/execution-log.xsd
+++ b/monitor/api/src/main/resources/execution-log.xsd
@@ -34,6 +34,7 @@
 			<enumeration value="DEPENDENT" />
 			<enumeration value="MANUAL" />
 			<enumeration value="ONETIME" />
+			<enumeration value="HOTFOLDER" />
 		</restriction>
 	</simpleType>
 

--- a/monitor/api/src/main/resources/schedule.xsd
+++ b/monitor/api/src/main/resources/schedule.xsd
@@ -15,6 +15,7 @@
 					<element name="cron-expression" type="string" />
 					<element name="one-time" type="string" />
 					<element name="dependent-job" type="string" />
+					<element name="hot-folder" type="string" />
 				</choice>
 				<element name="distributed-execution" type="boolean" minOccurs="0" maxOccurs="1" />
 				<element name="run-on-hadoop" type="boolean" minOccurs="0" maxOccurs="1" />

--- a/monitor/services/pom.xml
+++ b/monitor/services/pom.xml
@@ -145,6 +145,10 @@
 			<artifactId>commons-fileupload</artifactId>
 			<version>1.2.2</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
 		<!-- Servlet+JSP dependencies -->
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -390,7 +390,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                         _scheduler.scheduleJob(jobDetail, trigger);
                     }
                 } else if (triggerType == TriggerType.HOTFOLDER) {
-                    String hotFolder = schedule.getHotFolder();
+                    final String hotFolder = schedule.getHotFolder();
                     
                     if (hotFolder != null) {
                         FileAlterationObserver observer = createObserver(hotFolder);
@@ -420,7 +420,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     private FileAlterationObserver createObserver(String fileName) {
-        File file = new File(fileName);
+        final File file = new File(fileName);
 
         if (file.isDirectory()) {
             return new FileAlterationObserver(file);
@@ -716,7 +716,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     void removeHotFolder(String jobIdentifier) {
-        FileAlterationObserver observer = _registeredHotFolders.get(jobIdentifier);
+        final FileAlterationObserver observer = _registeredHotFolders.get(jobIdentifier);
         _hotFolderMonitor.removeObserver(observer);
         try {
             observer.destroy();

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -510,10 +510,13 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
 
     @Override
     public ExecutionLog triggerExecution(TenantIdentifier tenant, JobIdentifier job) {
+        return triggerExecution(tenant, job, TriggerType.MANUAL);
+    }
 
+    private ExecutionLog triggerExecution(TenantIdentifier tenant, JobIdentifier job, final TriggerType manual) {
         final String jobNameToBeTriggered = job.getName();
         final ScheduleDefinition schedule = getSchedule(tenant, job);
-        final ExecutionLog execution = new ExecutionLog(schedule, TriggerType.MANUAL);
+        final ExecutionLog execution = new ExecutionLog(schedule, manual);
         execution.setJobBeginDate(new Date());
 
         try {
@@ -736,14 +739,14 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
             logger.info("file {} created in hot folder, triggering execution of job {}.", file.getName(), job
                     .getName());
 
-            triggerExecution(tenant, job);
+            triggerExecution(tenant, job, TriggerType.HOTFOLDER);
         }
 
         public void onFileChange(File file) {
             logger.info("file {} changed in hot folder, triggering execution of job {}.", file.getName(), job
                     .getName());
 
-            triggerExecution(tenant, job);
+            triggerExecution(tenant, job, TriggerType.HOTFOLDER);
         }
 
         public void onDirectoryDelete(File directory) {

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbExecutionLogWriter.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbExecutionLogWriter.java
@@ -72,6 +72,8 @@ public class JaxbExecutionLogWriter extends AbstractJaxbAdaptor<org.datacleaner.
             return TriggerType.MANUAL;
         case ONETIME :
         	return TriggerType.ONETIME; 
+        case HOTFOLDER:
+            return TriggerType.HOTFOLDER; 
         default:
             throw new UnsupportedOperationException("Unknown trigger type: " + triggerType);
         }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbScheduleReader.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbScheduleReader.java
@@ -98,6 +98,8 @@ public class JaxbScheduleReader extends AbstractJaxbAdaptor<Schedule> {
                 scheduleDefinition.setVariableProvider(variableProviderDef);
             }
 
+            scheduleDefinition.setHotFolder(schedule.getHotFolder());
+
             final Boolean runOnHadoop = schedule.isRunOnHadoop();
             if (runOnHadoop != null && runOnHadoop.booleanValue()){
                 scheduleDefinition.setRunOnHadoop(runOnHadoop);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbScheduleWriter.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/jaxb/JaxbScheduleWriter.java
@@ -64,8 +64,9 @@ public class JaxbScheduleWriter extends AbstractJaxbAdaptor<Schedule> {
             schedule.setCronExpression(scheduleDefinition.getCronExpression());
         }else if (scheduleDefinition.getTriggerType() == TriggerType.ONETIME) {
             schedule.setOneTime(scheduleDefinition.getDateForOneTimeSchedule());
-        }
-        else {
+        } else if (scheduleDefinition.getTriggerType() == TriggerType.HOTFOLDER) {
+            schedule.setHotFolder(scheduleDefinition.getHotFolder());
+        } else {
             schedule.setManualTrigger(true);
         }
 

--- a/monitor/ui/src/main/java/org/datacleaner/monitor/resources/scheduling.css
+++ b/monitor/ui/src/main/java/org/datacleaner/monitor/resources/scheduling.css
@@ -157,7 +157,7 @@
 
 .JobHistoryPanel .ExecutionCellList {
 	float: left;
-	width: 20%;
+	width: 25%;
 	overflow: auto;
 }
 
@@ -172,7 +172,7 @@
 }
 
 .JobHistoryPanel .ExecutionLogPanelTarget {
-	width: 70%;
+	width: 65%;
 	float: right;
 	margin-left: 15px;
 }

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/CustomizeSchedulePanel.ui.xml
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/CustomizeSchedulePanel.ui.xml
@@ -44,9 +44,9 @@
 			</p>
 			<p>
 				Either you can select to only allow
-				<i>manuel triggering</i>
+				<i>manual triggering</i>
 				of the job. In that case your job will not be automatically invoked,
-				but you can invoke it manually using this web application, ur using
+				but you can invoke it manually using this web application, or using
 				a web service invocation.
 			</p>
 		</div>
@@ -91,6 +91,14 @@
 					<g:ListBox ui:field="dependentTriggerJobListBox" styleName="form-control" />
 				</div>
 			</div>
+			<div class="triggerPanel">
+				<g:RadioButton ui:field="hotFolderTriggerRadio" text="Hot Folder trigger"
+					name="triggerTypeRadio" />
+				<div class="configurationPanel">
+					<p>Please provide a folder or file on which a change will trigger a run of this job:</p>
+					<g:TextBox ui:field="hotFolderTriggerLocation" styleName="form-control" />
+				</div>
+			</div>
 			</div>
 			<div class="triggerPanel">
 				<g:RadioButton ui:field="manualTriggerRadio" text="Manual trigger"
@@ -101,7 +109,7 @@
 				</div>
 			</div>
 			
-				<div class="triggerPanel">
+			<div class="triggerPanel">
 				<g:CheckBox ui:field="runOnHadoop" text="Run on Hadoop cluster"
 					name="runOnHadoop" />
 				

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ExecutionLogPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ExecutionLogPanel.java
@@ -147,7 +147,7 @@ public class ExecutionLogPanel extends Composite {
                 	triggerLabel.setText("Scheduled: OneTime '" + executionLog.getSchedule().getDateForOneTimeSchedule() + "'");
                 	break;
                 case HOTFOLDER:
-                    triggerLabel.setText("Triggered: Hot folder '" + executionLog.getSchedule().getHotFolder() + "'");
+                    triggerLabel.setText("Hot folder '" + executionLog.getSchedule().getHotFolder() + "' triggered");
                 }
             }
 

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ExecutionLogPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ExecutionLogPanel.java
@@ -146,6 +146,8 @@ public class ExecutionLogPanel extends Composite {
                 case ONETIME:
                 	triggerLabel.setText("Scheduled: OneTime '" + executionLog.getSchedule().getDateForOneTimeSchedule() + "'");
                 	break;
+                case HOTFOLDER:
+                    triggerLabel.setText("Triggered: Hot folder '" + executionLog.getSchedule().getHotFolder() + "'");
                 }
             }
 

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/JobHistoryPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/JobHistoryPanel.java
@@ -98,7 +98,7 @@ public class JobHistoryPanel extends Composite {
         });
         executionList.setSelectionModel(selectionModel);
 
-        executionList.setPixelSize(200, 400);
+        executionList.setPixelSize(250, 400);
         executionList.addStyleName("ExecutionCellList");
 
         initWidget(uiBinder.createAndBindUi(this));

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulePanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulePanel.java
@@ -181,6 +181,10 @@ public class SchedulePanel extends Composite {
         case ONETIME :
         	scheduleAnchor.setText(_schedule.getDateForOneTimeSchedule());
         	scheduleAnchor.removeStyleName("discrete");
+        	break;
+        case HOTFOLDER:
+            scheduleAnchor.setText(_schedule.getHotFolder());
+            scheduleAnchor.removeStyleName("discrete");
         }
     }
 


### PR DESCRIPTION
Fixes #1329.

Some things which may need special attention when reviewing this pull request:

- The ScheduleServiceImpl now spawns a `org.apache.commons.io.monitor.FileAlterationMonitor` instance on construction, which spawns a monitoring thread in the initialize method. Please check if the implementation doesn't introduce memory leaks or keeps unwanted references to objects.
- The hot folder monitor is quite trigger happy, when a hot folder trigger is added to as a schedule to a job it instantly starts the job for all initial changes it detects, which may be more than one initially. Please test this and provide some feedback whether or not we want to suppress these first time triggers.
- The Customize schedule dialog in DataCleaner monitor starts with a blue paragraph which describes some of different ways in which you can configure the schedule. It may be desirable to also add the hot folder trigger to this paragraph, which as yet has not been done.
