### PR TITLE
Upgrade jackson and spark libraries versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<slf4j.version>1.7.10</slf4j.version>
 		<junit.version>4.12</junit.version>
 		<hadoop.version>2.7.1</hadoop.version>
-		<spark.version>1.4.1</spark.version>
+		<spark.version>1.6.1</spark.version>
 		<easymock.version>3.4</easymock.version>
 		<httpcomponents.version>4.4.1</httpcomponents.version>
 		<guava.version>16.0.1</guava.version>
@@ -25,7 +25,7 @@
 		<quartz.version>2.1.7</quartz.version>
 		<freemarker.version>2.3.22</freemarker.version>
 		<icu4j.version>55.1</icu4j.version>
-		<jackson.version>2.4.6</jackson.version>
+		<jackson.version>2.7.3</jackson.version>
 		<javax.servlet.version>3.0.1</javax.servlet.version>
 		<javax.jsp.version>2.3.1</javax.jsp.version>
 		<javax.el.version>2.2.5</javax.el.version>
@@ -1268,6 +1268,11 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.module</groupId>
 				<artifactId>jackson-module-jsonSchema</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-scala_2.11</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
DataCleaner still uses an older version of the com.fasterxml.jackson libraries than metamodel, which can cause problems when testing custom components for DataCleaner during the development process directly from your IDE. Upgrading these libraries to the latest version remedies these problems. By upgrading to the newest version we can also remove a workaround implemented in the org.datacleaner.restclient.Serializator class.

Because the current version of the spark libraries don't work with the newer com.fasterxml.jackson libraries, the spark version also has to be updated.