### PR TITLE
Feature/1170 replace inlined synonyms

### DIFF
--- a/components/reference-data/src/main/java/org/datacleaner/beans/transform/SynonymLookupTransformer.java
+++ b/components/reference-data/src/main/java/org/datacleaner/beans/transform/SynonymLookupTransformer.java
@@ -82,12 +82,13 @@ public class SynonymLookupTransformer implements Transformer, HasLabelAdvice {
     SynonymCatalog synonymCatalog;
 
     @Configured
-    @Description("Retain original value in case no synonym is found (otherwise null)")
+    @Description("Retain original value when no synonyms are found. If turned off, <null> will be returned when no synonyms are found.")
     boolean retainOriginalValue = true;
 
     @Configured
-    @Description("Tokenize and look up every token of the input, rather than looking up the complete input string?")
-    boolean lookUpEveryToken = false;
+    @Alias("Look up every token")
+    @Description("Replace synonyms that occur as a substring within the complete text? If turned off, only synonyms that match the complete text value will be replaced.")
+    boolean replaceInlinedSynonyms = true;
 
     @Inject
     @Configured
@@ -154,7 +155,7 @@ public class SynonymLookupTransformer implements Transformer, HasLabelAdvice {
             return new String[3];
         }
 
-        if (lookUpEveryToken) {
+        if (replaceInlinedSynonyms) {
             final SynonymCatalogConnection.Replacement replacement = synonymCatalogConnection.replaceInline(
                     originalValue);
             if (replacedSynonymsType == ReplacedSynonymsType.STRING) {

--- a/components/reference-data/src/test/java/org/datacleaner/beans/transform/SynonymLookupTransformerTest.java
+++ b/components/reference-data/src/test/java/org/datacleaner/beans/transform/SynonymLookupTransformerTest.java
@@ -45,7 +45,7 @@ public class SynonymLookupTransformerTest {
         MockInputColumn<String> col = new MockInputColumn<>("my col", String.class);
 
         SynonymLookupTransformer transformer = new SynonymLookupTransformer(col, sc, true, configuration);
-        transformer.lookUpEveryToken = true;
+        transformer.replaceInlinedSynonyms = true;
         transformer.init();
 
         assertEquals("Hello DNK DNK DNK!", transformer.transform(new MockInputRow().put(col,
@@ -65,7 +65,7 @@ public class SynonymLookupTransformerTest {
         MockInputColumn<String> col = new MockInputColumn<>("my col", String.class);
 
         SynonymLookupTransformer transformer = new SynonymLookupTransformer(col, sc, true, configuration);
-        transformer.lookUpEveryToken = false;
+        transformer.replaceInlinedSynonyms = false;
         transformer.init();
 
         assertEquals("Hello denmark dnk dk!", transformer.transform(new MockInputRow().put(col,
@@ -89,6 +89,7 @@ public class SynonymLookupTransformerTest {
 
         // with retain original value
         SynonymLookupTransformer transformer = new SynonymLookupTransformer(col, sc, true, configuration);
+        transformer.replaceInlinedSynonyms = false;
         assertEquals(3, transformer.getOutputColumns().getColumnCount());
         assertEquals("my col (synonyms replaced)", transformer.getOutputColumns().getColumnName(0));
 
@@ -103,6 +104,7 @@ public class SynonymLookupTransformerTest {
 
         // without retain original value
         transformer = new SynonymLookupTransformer(col, sc, false, configuration);
+        transformer.replaceInlinedSynonyms = false;
         assertEquals(3, transformer.getOutputColumns().getColumnCount());
         assertEquals("my col (synonyms replaced)", transformer.getOutputColumns().getColumnName(0));
         assertEquals("my col (synonyms found)", transformer.getOutputColumns().getColumnName(1));
@@ -128,7 +130,7 @@ public class SynonymLookupTransformerTest {
 
         // with retain original value
         SynonymLookupTransformer transformer = new SynonymLookupTransformer(col, sc, true, configuration);
-        transformer.lookUpEveryToken = true;
+        transformer.replaceInlinedSynonyms = true;
         transformer.replacedSynonymsType = SynonymLookupTransformer.ReplacedSynonymsType.LIST;
         transformer.init();
         assertEquals(3, transformer.getOutputColumns().getColumnCount());
@@ -159,6 +161,7 @@ public class SynonymLookupTransformerTest {
 
         // without retain original value
         transformer = new SynonymLookupTransformer(col, sc, false, configuration);
+        transformer.replaceInlinedSynonyms = false;
         transformer.init();
         assertEquals(3, transformer.getOutputColumns().getColumnCount());
         assertEquals("my col (synonyms replaced)", transformer.getOutputColumns().getColumnName(0));

--- a/desktop/ui/src/test/resources/documentation/synonym_lookup.html
+++ b/desktop/ui/src/test/resources/documentation/synonym_lookup.html
@@ -136,8 +136,8 @@ h3 {
 					</li> 					<li class="list-group-item">
 						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-							 Look up every token
-						</h3> <p>Tokenize and look up every token of the input, rather than looking up the complete input string?</p> <!-- type --> <span
+							 Replace inlined synonyms
+						</h3> <p>Replace synonyms that occur as a substring within the complete text? If turned off, only synonyms that match the complete text value will be replaced.</p> <!-- type --> <span
 						class="label label-primary">boolean</span>  
 
 						<!-- required/optional -->  <span
@@ -157,7 +157,7 @@ h3 {
 						<h3>
 							 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
 							 Retain original value
-						</h3> <p>Retain original value in case no synonym is found (otherwise null)</p> <!-- type --> <span
+						</h3> <p>Retain original value when no synonyms are found. If turned off, <null> will be returned when no synonyms are found.</p> <!-- type --> <span
 						class="label label-primary">boolean</span>  
 
 						<!-- required/optional -->  <span

--- a/engine/core/src/test/java/org/datacleaner/components/convert/ConvertToDateTransformerTest.java
+++ b/engine/core/src/test/java/org/datacleaner/components/convert/ConvertToDateTransformerTest.java
@@ -37,11 +37,19 @@ public class ConvertToDateTransformerTest extends TestCase {
     private static final String TEST_TIMEZONE = "CET";
 
     private SimpleDateFormat dateFormat;
+    private TimeZone realTimeZone;
 
+    @Override
     protected void setUp() throws Exception {
+        realTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone(TEST_TIMEZONE));
         dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
-        dateFormat.setTimeZone(TimeZone.getTimeZone(TEST_TIMEZONE));
     };
+    
+    @Override
+    protected void tearDown() throws Exception {
+        TimeZone.setDefault(realTimeZone);
+    }
 
     public void testConvertWithNumberOnlyDateMask() throws Exception {
         ConvertToDateTransformer transformer = new ConvertToDateTransformer();


### PR DESCRIPTION
Fixes #1170 

 * Rename and convention change for strange property "Look up every token"
 * Fixed an unrelated unittests which is only visible if you're on a timezone (and time of day) when your time offset from CET is sufficient to provoke another date when applying a timeless date format.