### PR TITLE
Specify replacement datastore from commandline

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
@@ -122,7 +122,7 @@ public class CliArguments {
     @Option(name = "-list", usage = "Used to print a list of various elements available in the configuration")
     private CliListType listType;
 
-    @Option(name = "-ds", aliases = { "-datastore", "--datastore-name" }, usage = "Name of datastore when printing a list of schemas, tables or columns")
+    @Option(name = "-ds", aliases = { "-datastore", "--datastore-name" }, usage = "Name of datastore when printing a list of schemas, tables or columns. Overrides datastore used when used with -job")
     private String datastoreName;
 
     @Option(name = "-s", aliases = { "-schema", "--schema-name" }, usage = "Name of schema when printing a list of tables or columns")

--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliRunner.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliRunner.java
@@ -83,7 +83,7 @@ public final class CliRunner implements Closeable {
      * Alternative constructor that will specifically specifies the output
      * writer. Should be used only for testing, since normally the CliArguments
      * should be used to decide which outputwriter to use
-     * 
+     *
      * @param arguments
      * @param writer
      * @param outputStream
@@ -101,7 +101,7 @@ public final class CliRunner implements Closeable {
                     }
                 };
             } else {
-                if(_arguments.getRunType() == CliRunType.SPARK){
+                if (_arguments.getRunType() == CliRunType.SPARK) {
                     _writerRef = null;
                     _outputStreamRef = null;
                 } else {
@@ -213,7 +213,7 @@ public final class CliRunner implements Closeable {
             System.err.println("Error:");
             e.printStackTrace(System.err);
         } finally {
-            if(configuration != null) {
+            if (configuration != null) {
                 configuration.getEnvironment().getTaskRunner().shutdown();
             }
         }
@@ -353,7 +353,17 @@ public final class CliRunner implements Closeable {
             final AnalysisJobBuilder analysisJobBuilder;
             final InputStream inputStream = jobResource.read();
             try {
-                analysisJobBuilder = jobReader.create(inputStream, variableOverrides);
+                if (_arguments.getDatastoreName() != null) {
+                    final Datastore datastore =
+                            configuration.getDatastoreCatalog().getDatastore(_arguments.getDatastoreName());
+                    if(datastore == null) {
+                        throw new IllegalArgumentException("No such datastore: " + _arguments.getDatastoreName());
+                    }
+                    analysisJobBuilder = jobReader.create(inputStream, variableOverrides,
+                            datastore);
+                } else {
+                    analysisJobBuilder = jobReader.create(inputStream, variableOverrides);
+                }
             } finally {
                 FileHelper.safeClose(inputStream);
             }

--- a/desktop/ui/src/test/java/org/datacleaner/cli/MainTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/cli/MainTest.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import junit.framework.TestCase;
-import nu.validator.htmlparser.common.XmlViolationPolicy;
-import nu.validator.htmlparser.sax.HtmlParser;
 
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.log4j.PropertyConfigurator;
@@ -46,6 +44,9 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import com.google.common.base.Splitter;
+
+import nu.validator.htmlparser.common.XmlViolationPolicy;
+import nu.validator.htmlparser.sax.HtmlParser;
 
 public class MainTest extends TestCase {
 
@@ -93,7 +94,7 @@ public class MainTest extends TestCase {
         assertEquals(
                 "-ds (-datastore, --datastore-name) VAL                     : Name of datastore when printing a list of schemas, tables",
                 lines[2].trim());
-        assertEquals("or columns", lines[3].trim());
+        assertEquals("or columns. Overrides datastore used when used with -job", lines[3].trim());
         assertEquals(
                 "-job (--job-file) PATH                                     : Path to an analysis job XML file to execute",
                 lines[4].trim());

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -344,6 +344,13 @@ public class JaxbJobReader implements JobReader<InputStream> {
         return create(unmarshallJob(inputStream), null, variableOverrides);
     }
 
+    public AnalysisJobBuilder create(InputStream inputStream, Map<String, String> variableOverrides, Datastore datastore) {
+        final JobType jobType = unmarshallJob(inputStream);
+        SourceColumnMapping sourceColumnMapping = new SourceColumnMapping(readMetadata(jobType));
+        sourceColumnMapping.autoMap(datastore);
+        return create(jobType, sourceColumnMapping, variableOverrides);
+    }
+
     private JobType unmarshallJob(InputStream inputStream) {
         try {
             Unmarshaller unmarshaller = _jaxbContext.createUnmarshaller();

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import junit.framework.TestCase;
+
 import org.apache.metamodel.util.ToStringComparator;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.InputColumn;
@@ -73,8 +75,6 @@ import org.datacleaner.result.CrosstabResult;
 import org.datacleaner.result.renderer.CrosstabTextRenderer;
 import org.datacleaner.test.TestHelper;
 
-import junit.framework.TestCase;
-
 public class JaxbJobReaderTest extends TestCase {
 
     private final DescriptorProvider descriptorProvider = new ClasspathScanDescriptorProvider().scanPackage(
@@ -89,7 +89,7 @@ public class JaxbJobReaderTest extends TestCase {
     // see #1196 - Synonym lookup changes has broken old jobs
     public void testReadJobWhereOutputColumnsHasBeenAddedToComponent() throws Exception {
         SynonymCatalog synonymCatalog = new SimpleSynonymCatalog("Job titles");
-        Collection<SynonymCatalog> synonyms = Arrays.asList(synonymCatalog);
+        Collection<SynonymCatalog> synonyms = Collections.singletonList(synonymCatalog);
         ReferenceDataCatalog referenceDataCatalog = new ReferenceDataCatalogImpl(Collections.emptyList(), synonyms, Collections.emptyList());
         DataCleanerConfigurationImpl conf = this.conf.withReferenceDataCatalog(referenceDataCatalog);
         
@@ -251,8 +251,8 @@ public class JaxbJobReaderTest extends TestCase {
             final String message = e.getMessage();
             assertTrue(message, message.startsWith("javax.xml.bind.UnmarshalException"));
             assertTrue(message,
-                    message.toLowerCase().indexOf("uri:\"http://eobjects.org/analyzerbeans/job/1.0\"") != -1);
-            assertTrue(message, message.indexOf("\"datacontext\"") != -1);
+                    message.toLowerCase().contains("uri:\"http://eobjects.org/analyzerbeans/job/1.0\""));
+            assertTrue(message, message.contains("\"datacontext\""));
         }
     }
 
@@ -309,6 +309,16 @@ public class JaxbJobReaderTest extends TestCase {
         assertEquals("FIRSTNAME,Blank count: 0", resultLines[3]);
         assertEquals("FIRSTNAME,Diacritic chars: 0", resultLines[4]);
         assertEquals("FIRSTNAME,Digit chars: 0", resultLines[5]);
+    }
+
+    public void testUsingSourceAlternateDatastore() throws Throwable {
+        Datastore datastore = TestHelper.createSampleDatabaseDatastore("another datastore name");
+        JaxbJobReader reader = new JaxbJobReader(conf);
+        final AnalysisJobBuilder analysisJobBuilder = reader.create(new FileInputStream(new File(
+                "src/test/resources/example-job-valid.xml")), null, datastore);
+
+        final AnalysisJob analysisJob = analysisJobBuilder.toAnalysisJob();
+        assertEquals("another datastore name", analysisJob.getDatastore().getName());
     }
 
     public void testUsingSourceColumnMapping() throws Throwable {
@@ -494,8 +504,8 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("EQ name", units[0].getInputColumnNames()[0].toString());
-        assertEquals("NEQ name", units[0].getInputColumnNames()[1].toString());
+        assertEquals("EQ name", units[0].getInputColumnNames()[0]);
+        assertEquals("NEQ name", units[0].getInputColumnNames()[1]);
     }
 
     public void testCoalesceJobWithCombinedTranformerColumns() throws Exception {
@@ -514,8 +524,8 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0].toString());
-        assertEquals("CONTACTLASTNAME (Upper case)", units[0].getInputColumnNames()[1].toString());
+        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("CONTACTLASTNAME (Upper case)", units[0].getInputColumnNames()[1]);
     }
 
     public void testCoalesceJobWithInputColumns() throws Exception {
@@ -534,10 +544,10 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0].toString());
-        assertEquals("CONTACTFIRSTNAME", units[0].getInputColumnNames()[1].toString());
-        assertEquals("PHONE", units[1].getInputColumnNames()[0].toString());
-        assertEquals("CITY", units[1].getInputColumnNames()[1].toString());
+        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("CONTACTFIRSTNAME", units[0].getInputColumnNames()[1]);
+        assertEquals("PHONE", units[1].getInputColumnNames()[0]);
+        assertEquals("CITY", units[1].getInputColumnNames()[1]);
     }
 
     public void testUnionJob() throws Exception {
@@ -557,11 +567,11 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0].toString());
-        assertEquals("LASTNAME", units[0].getInputColumnNames()[1].toString());
+        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("LASTNAME", units[0].getInputColumnNames()[1]);
         assertEquals("CONTACTLASTNAME", units[0].getSuggestedOutputColumnName());
-        assertEquals("CONTACTFIRSTNAME", units[1].getInputColumnNames()[0].toString());
-        assertEquals("FIRSTNAME", units[1].getInputColumnNames()[1].toString());
+        assertEquals("CONTACTFIRSTNAME", units[1].getInputColumnNames()[0]);
+        assertEquals("FIRSTNAME", units[1].getInputColumnNames()[1]);
         assertEquals("CONTACTFIRSTNAME", units[1].getSuggestedOutputColumnName());
 
         final List<OutputDataStream> outputDataStreams = componentBuilder.getOutputDataStreams();


### PR DESCRIPTION
This makes it possible to override the datastore to a job with by using -ds on the command line.

Fixes #565