### PR TITLE
Read replacement properties file in hot folder

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -20,6 +20,7 @@
 package org.datacleaner.monitor.server;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.ParseException;
@@ -31,6 +32,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
@@ -43,6 +45,7 @@ import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
 import org.apache.metamodel.util.Action;
 import org.apache.metamodel.util.CollectionUtils;
+import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Func;
 import org.datacleaner.monitor.configuration.TenantContext;
 import org.datacleaner.monitor.configuration.TenantContextFactory;
@@ -94,6 +97,8 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+
+import com.google.common.collect.Maps;
 
 /**
  * Main implementation of the {@link SchedulingService} interface.
@@ -401,7 +406,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                     if (hotFolder != null) {
                         FileAlterationObserver observer = createObserver(hotFolder);
                     
-                        observer.addListener(new HotFolderAlterationListener(job, schedule.getTenant()));
+                        observer.addListener(new HotFolderAlterationListener(job, schedule));
                     
                         _hotFolderMonitor.addObserver(observer);
                         
@@ -743,10 +748,20 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     private final class HotFolderAlterationListener extends FileAlterationListenerAdaptor {
         private final JobIdentifier job;
         private final TenantIdentifier tenant;
+        private final String overridePropertiesFilePath;
 
-        private HotFolderAlterationListener(final JobIdentifier job, final TenantIdentifier tenant) {
+        private HotFolderAlterationListener(final JobIdentifier job, final ScheduleDefinition schedule) {
             this.job = job;
-            this.tenant = tenant;
+            this.tenant = schedule.getTenant();
+
+            final String hotFolderPath = schedule.getHotFolder();
+            final File hotFolder = new File(hotFolderPath);
+            final String overridePropertiesFileName = job.getName() + ".properties";
+            if (hotFolder.isDirectory()) {
+                overridePropertiesFilePath = new File(hotFolder, overridePropertiesFileName).getAbsolutePath();
+            } else {
+                overridePropertiesFilePath = FilenameUtils.getFullPath(hotFolderPath) + overridePropertiesFileName;
+            }
         }
 
         @Override
@@ -754,7 +769,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
             logger.info("file {} created in hot folder, triggering execution of job {}.", file.getName(), job
                     .getName());
 
-            triggerExecution(tenant, job, null, TriggerType.HOTFOLDER);
+            triggerJobExecution();
         }
 
         @Override
@@ -762,7 +777,26 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
             logger.info("file {} changed in hot folder, triggering execution of job {}.", file.getName(), job
                     .getName());
 
-            triggerExecution(tenant, job, null, TriggerType.HOTFOLDER);
+            triggerJobExecution();
+        }
+
+        private void triggerJobExecution() {
+            final FileResource overrideProperties = new FileResource(overridePropertiesFilePath);
+            Map<String, String> propertiesMap = null;
+            
+            if (overrideProperties.isExists()) {
+                try {
+                    Properties properties = new Properties();
+                    properties.load(overrideProperties.read());
+                    
+                    propertiesMap = Maps.fromProperties(properties);
+                } catch (IOException e) {
+                    logger.warn("Exception occurred when loading properties file {} for hot folder trigger of job {}.",
+                            overridePropertiesFilePath, job.getName());
+                }
+            }
+            
+            triggerExecution(tenant, job, propertiesMap, TriggerType.HOTFOLDER);
         }
     }
 }


### PR DESCRIPTION
Fixes #1362.

Made it possible to add a properties file in the hot folder (or the folder in which the hot file is located), which is used to override properties in the default configuration to run the job with. By convention the properties file has to have the same name as the job and the .properties extension. So if you have a job named "Analyze customers" the properties files has to be named "Analyze customers.properties".