### PR TITLE
Refresh graph when changing datastore

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -442,6 +442,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
 
         setSchemaTree(datastore, expandTree, con);
         updateStatusLabel();
+        _graph.refresh();
     }
 
     private void setSchemaTree(final Datastore datastore, boolean expandTree, final DatastoreConnection con) {


### PR DESCRIPTION
A refresh will make sure that the correct datastore is always shown.

Fixes #1262