### PR TITLE
Qualified autowire for remote component config 

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/components/ComponentHandlerFactory.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/components/ComponentHandlerFactory.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,7 @@ public class ComponentHandlerFactory {
     private ApplicationContext appCtx;
 
     @Autowired
-    public ComponentHandlerFactory(RemoteComponentsConfiguration remoteComponentsConfiguration) {
+    public ComponentHandlerFactory(@Qualifier("published-components") RemoteComponentsConfiguration remoteComponentsConfiguration) {
         this._remoteComponentsConfiguration = remoteComponentsConfiguration;
     }
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1.java
@@ -80,6 +80,7 @@ import org.datacleaner.util.IconUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -138,6 +139,7 @@ public class ComponentControllerV1 {
     TenantContextFactory _tenantContextFactory;
     
     @Autowired
+    @Qualifier(value="published-components")
     RemoteComponentsConfiguration _remoteComponentsConfiguration;
 
     @Autowired


### PR DESCRIPTION
Remote component config has now qualified autowire. Needed by DataCloud so that a "composite" config bean can be defined in application context, refering to other component config beans.

BTW, the default "empty" config already has a name "published-components", this is why I picked the qualifier of that name - to be backward compatible with the current bean name.