### PR TITLE
Remote component API - output columns info in processing response

### DIFF
--- a/engine/rest-client/src/main/java/org/datacleaner/restclient/ProcessStatelessOutput.java
+++ b/engine/rest-client/src/main/java/org/datacleaner/restclient/ProcessStatelessOutput.java
@@ -20,6 +20,7 @@
 package org.datacleaner.restclient;
 
 import java.io.Serializable;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,4 +38,6 @@ public class ProcessStatelessOutput implements Serializable {
     public JsonNode result;
     @JsonProperty
     public JsonNode rows;
+    @JsonProperty
+    public List<OutputColumns.OutputColumn> columns;
 }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1.java
@@ -241,8 +241,8 @@ public class ComponentControllerV1 {
     public ProcessStatelessOutput processStateless(
             @PathVariable(PARAMETER_NAME_TENANT) final String tenant,
             @PathVariable(PARAMETER_NAME_NAME) final String name,
-            @RequestParam(value = PARAMETER_NAME_OUTPUT_STYLE,required = false, defaultValue = PARAMETER_VALUE_OUTPUT_STYLE_TABULAR) String outputStyle,
-            @RequestParam(value = PARAMETER_NAME_COLUMNS,required = false, defaultValue = "false") boolean outputColumnsInfo,
+            @RequestParam(value = PARAMETER_NAME_OUTPUT_STYLE, required = false, defaultValue = PARAMETER_VALUE_OUTPUT_STYLE_TABULAR) String outputStyle,
+            @RequestParam(value = PARAMETER_NAME_COLUMNS, required = false, defaultValue = "false") boolean outputColumnsInfo,
             @RequestBody final ProcessStatelessInput processStatelessInput) {
         String decodedName = ComponentsRestClientUtils.unescapeComponentName(name);
 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1Test.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ComponentControllerV1Test.java
@@ -184,7 +184,7 @@ public class ComponentControllerV1Test {
     @Test
     public void testProcessStateless() throws Exception {
         ProcessStatelessInput input = createSampleInput();
-        ProcessStatelessOutput output = componentControllerV1.processStateless(tenant, componentName, null, input);
+        ProcessStatelessOutput output = componentControllerV1.processStateless(tenant, componentName, null, false, input);
         JsonNode rows = output.rows;
         Assert.assertEquals("Output should have one row group", 1, rows.size());
         Assert.assertEquals("Output should have one row", 1, rows.get(0).size());
@@ -197,7 +197,7 @@ public class ComponentControllerV1Test {
 
         ProcessStatelessInput input = createSampleInput();
 
-        ProcessStatelessOutput output = componentControllerV1.processStateless(tenant, componentName, "map", input);
+        ProcessStatelessOutput output = componentControllerV1.processStateless(tenant, componentName, "map", false, input);
         JsonNode rows = output.rows;
         Assert.assertEquals("Output should have one row group", 1, rows.size());
         Assert.assertEquals("Output should have one row", 1, rows.get(0).size());


### PR DESCRIPTION
Optional parameter now allows to obtain column info in the response of transformer result.

This PR solves this issue: the remote components API - the method to process rows - returns processed rows as a "table" of data. If called by DataCleaner engine, no problem since it uses another API method "getOutputColumns" to get info about output columns.

But when calling the API directly, it could be good to obtain the column info directly in the "processing" call response. This is why I made it possible through an optional request boolean flag. (Default is "false").

Example output with columns info: (BTW, the columns info format is reused from the existing "getOutputColumns" response)
```
{
  "rows": [ [ ["hello", "world"] ], [ ["Hi", "Jane"] ] ],
  "columns": [
    {
      "name": "Greeting",
      "type": "java.lang.String",
      "schema": {
        "type": "string"
      }
    },
    {
      "name": "Object name",
      "type": "java.lang.String",
      "schema": {
        "type": "string"
      }
    },
  ]
}
```