### PR TITLE
Added API for filtering the jobs based on metadata property

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobsFolderController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobsFolderController.java
@@ -58,7 +58,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.UrlEscapers;
 
 @Controller
@@ -94,14 +93,13 @@ public class JobsFolderController {
         return result;
     }
 
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(value="/filter", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public String getFolderJobsByMetadataProperty(@PathVariable("tenant") String tenant,
+    public List<Map<String, Object>> getFolderJobsByMetadataProperty(@PathVariable("tenant") String tenant,
             @RequestParam(value = "property", required = true) String metadataProperty,
             @RequestParam(value = "value", required = true) String metadataPropertyValue)
             throws JsonProcessingException {
         final TenantContext tenantContext = _contextFactory.getContext(tenant);
-        final ObjectMapper objectMapper = new ObjectMapper();
         final List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
         {
             final List<JobIdentifier> jobs = tenantContext.getJobs();
@@ -127,6 +125,7 @@ public class JobsFolderController {
                             final List<AnalyzerJob> analyzerJobs = analysisJob.getAnalyzerJobs();
                             for (AnalyzerJob analyzerJob : analyzerJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
+                                jobComponent.put("name", analyzerJob.getName()); 
                                 jobComponent.put("type", "analyzer");
                                 jobComponent.put("descriptor", analyzerJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", analyzerJob.getMetadataProperties());
@@ -136,6 +135,7 @@ public class JobsFolderController {
                             List<TransformerJob> transformerJobs = analysisJob.getTransformerJobs();
                             for (TransformerJob transformerJob : transformerJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
+                                jobComponent.put("name", transformerJob.getName()); 
                                 jobComponent.put("type", "transformer");
                                 jobComponent.put("descriptor", transformerJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", transformerJob.getMetadataProperties());
@@ -145,6 +145,7 @@ public class JobsFolderController {
                             List<FilterJob> filterJobs = analysisJob.getFilterJobs();
                             for (FilterJob filterJob : filterJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
+                                jobComponent.put("name", filterJob.getName()); 
                                 jobComponent.put("type", "filter");
                                 jobComponent.put("descriptor", filterJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", filterJob.getMetadataProperties());
@@ -157,7 +158,7 @@ public class JobsFolderController {
                 }
             }
         }
-        return objectMapper.writeValueAsString(result);
+        return result; 
     }
 
     @RolesAllowed(SecurityRoles.JOB_EDITOR)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobsFolderController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobsFolderController.java
@@ -57,7 +57,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.net.UrlEscapers;
 
 @Controller
@@ -93,12 +92,11 @@ public class JobsFolderController {
         return result;
     }
 
-    @RequestMapping(value="/filter", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/filter", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public List<Map<String, Object>> getFolderJobsByMetadataProperty(@PathVariable("tenant") String tenant,
             @RequestParam(value = "property", required = true) String metadataProperty,
-            @RequestParam(value = "value", required = true) String metadataPropertyValue)
-            throws JsonProcessingException {
+            @RequestParam(value = "value", required = true) String metadataPropertyValue) {
         final TenantContext tenantContext = _contextFactory.getContext(tenant);
         final List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
         {
@@ -125,7 +123,7 @@ public class JobsFolderController {
                             final List<AnalyzerJob> analyzerJobs = analysisJob.getAnalyzerJobs();
                             for (AnalyzerJob analyzerJob : analyzerJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
-                                jobComponent.put("name", analyzerJob.getName()); 
+                                jobComponent.put("name", analyzerJob.getName());
                                 jobComponent.put("type", "analyzer");
                                 jobComponent.put("descriptor", analyzerJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", analyzerJob.getMetadataProperties());
@@ -135,7 +133,7 @@ public class JobsFolderController {
                             List<TransformerJob> transformerJobs = analysisJob.getTransformerJobs();
                             for (TransformerJob transformerJob : transformerJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
-                                jobComponent.put("name", transformerJob.getName()); 
+                                jobComponent.put("name", transformerJob.getName());
                                 jobComponent.put("type", "transformer");
                                 jobComponent.put("descriptor", transformerJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", transformerJob.getMetadataProperties());
@@ -145,7 +143,7 @@ public class JobsFolderController {
                             List<FilterJob> filterJobs = analysisJob.getFilterJobs();
                             for (FilterJob filterJob : filterJobs) {
                                 final Map<String, Object> jobComponent = new HashMap<String, Object>();
-                                jobComponent.put("name", filterJob.getName()); 
+                                jobComponent.put("name", filterJob.getName());
                                 jobComponent.put("type", "filter");
                                 jobComponent.put("descriptor", filterJob.getDescriptor().getDisplayName());
                                 jobComponent.put("metadataProperties", filterJob.getMetadataProperties());
@@ -158,7 +156,7 @@ public class JobsFolderController {
                 }
             }
         }
-        return result; 
+        return result;
     }
 
     @RolesAllowed(SecurityRoles.JOB_EDITOR)

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
@@ -39,20 +39,18 @@ public class JobsFolderControllerTest {
 
         final JobsFolderController controller = new JobsFolderController();
         controller._contextFactory = contextFactory;
-        final String resultsMetadata1 = controller.getFolderJobsByMetadataProperty("tenant6", "Category", "Enrichment");
-        assertEquals(
-                "[{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_no_analyzers.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_no_analyzers.analysis.xml\",\"name\":\"concat_job_no_analyzers\",\"metadataProperties\":{\"Group\":\"Person Enrichment\",\"Category\":\"Enrichment\",\"CoordinatesX.GoldenRecords.person\":\"154\",\"CoordinatesY.GoldenRecords.person\":\"77\"}},{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_no_datastore.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_no_datastore.analysis.xml\",\"name\":\"concat_job_no_datastore\",\"metadataProperties\":{\"Group\":\"Person Enrichment\",\"Category\":\"Enrichment\",\"CoordinatesX.GoldenRecords.person\":\"154\",\"CoordinatesY.GoldenRecords.person\":\"77\"}}]",
-                resultsMetadata1);
+        final String resultsMetadata1 = controller.getFolderJobsByMetadataProperty("tenant6", "Category", "Enrichment").toString();
+        assertEquals("[{descriptors=[{name=null, metadataProperties={CoordinatesY=244, CoordinatesX=294}, descriptor=Concatenator, type=transformer}], filename=concat_job_no_analyzers.analysis.xml, repository_path=/tenant6/jobs/concat_job_no_analyzers.analysis.xml, name=concat_job_no_analyzers, metadataProperties={Group=Person Enrichment, Category=Enrichment, CoordinatesX.GoldenRecords.person=154, CoordinatesY.GoldenRecords.person=77}}, {descriptors=[{name=null, metadataProperties={CoordinatesY=244, CoordinatesX=294}, descriptor=Concatenator, type=transformer}], filename=concat_job_no_datastore.analysis.xml, repository_path=/tenant6/jobs/concat_job_no_datastore.analysis.xml, name=concat_job_no_datastore, metadataProperties={Group=Person Enrichment, Category=Enrichment, CoordinatesX.GoldenRecords.person=154, CoordinatesY.GoldenRecords.person=77}}]", resultsMetadata1);
 
-        final String resultsMetadata2 = controller.getFolderJobsByMetadataProperty("tenant6", "Group", "Person");
+        final String resultsMetadata2 = controller.getFolderJobsByMetadataProperty("tenant6", "Group", "Person").toString();
         assertEquals(
-                "[{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"289\",\"CoordinatesX\":\"487\"},\"descriptor\":\"String analyzer\",\"type\":\"analyzer\"},{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_short_column_paths.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_short_column_paths.analysis.xml\",\"name\":\"concat_job_short_column_paths\",\"metadataProperties\":{\"Group\":\"Person\"}}]",
+                "[{descriptors=[{name=null, metadataProperties={CoordinatesY=289, CoordinatesX=487}, descriptor=String analyzer, type=analyzer}, {name=null, metadataProperties={CoordinatesY=244, CoordinatesX=294}, descriptor=Concatenator, type=transformer}], filename=concat_job_short_column_paths.analysis.xml, repository_path=/tenant6/jobs/concat_job_short_column_paths.analysis.xml, name=concat_job_short_column_paths, metadataProperties={Group=Person}}]",
                 resultsMetadata2);
 
-        final String resultsMetadata3 = controller.getFolderJobsByMetadataProperty("tenant6", "test", "Person");
+        final String resultsMetadata3 = controller.getFolderJobsByMetadataProperty("tenant6", "test", "Person").toString();
         assertEquals("[]", resultsMetadata3);
 
-        final String resultsMetadata4 = controller.getFolderJobsByMetadataProperty("tenant6", "", "");
+        final String resultsMetadata4 = controller.getFolderJobsByMetadataProperty("tenant6", "", "").toString();
         assertEquals("[]", resultsMetadata4);
 
     }

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
@@ -1,0 +1,59 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.server.controllers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
+import org.datacleaner.monitor.configuration.TenantContextFactory;
+import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
+import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.repository.file.FileRepository;
+import org.junit.Test;
+
+public class JobsFolderControllerTest {
+
+    @Test
+    public void testResultsFolderJsonMetadata() throws Exception {
+
+        final FileRepository repository = new FileRepository("src/test/resources/example_repo/");
+        final TenantContextFactory contextFactory = new TenantContextFactoryImpl(repository,
+                new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
+
+        final JobsFolderController controller = new JobsFolderController();
+        controller._contextFactory = contextFactory;
+        final String resultsMetadata1 = controller.getFolderJobsByMetadataProperty("tenant6", "Category", "Enrichment");
+        assertEquals(
+                "[{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_no_analyzers.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_no_analyzers.analysis.xml\",\"name\":\"concat_job_no_analyzers\",\"metadataProperties\":{\"Group\":\"Person Enrichment\",\"Category\":\"Enrichment\",\"CoordinatesX.GoldenRecords.person\":\"154\",\"CoordinatesY.GoldenRecords.person\":\"77\"}},{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_no_datastore.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_no_datastore.analysis.xml\",\"name\":\"concat_job_no_datastore\",\"metadataProperties\":{\"Group\":\"Person Enrichment\",\"Category\":\"Enrichment\",\"CoordinatesX.GoldenRecords.person\":\"154\",\"CoordinatesY.GoldenRecords.person\":\"77\"}}]",
+                resultsMetadata1);
+
+        final String resultsMetadata2 = controller.getFolderJobsByMetadataProperty("tenant6", "Group", "Person");
+        assertEquals(
+                "[{\"descriptors\":[{\"metadataProperties\":{\"CoordinatesY\":\"289\",\"CoordinatesX\":\"487\"},\"descriptor\":\"String analyzer\",\"type\":\"analyzer\"},{\"metadataProperties\":{\"CoordinatesY\":\"244\",\"CoordinatesX\":\"294\"},\"descriptor\":\"Concatenator\",\"type\":\"transformer\"}],\"filename\":\"concat_job_short_column_paths.analysis.xml\",\"repository_path\":\"/tenant6/jobs/concat_job_short_column_paths.analysis.xml\",\"name\":\"concat_job_short_column_paths\",\"metadataProperties\":{\"Group\":\"Person\"}}]",
+                resultsMetadata2);
+
+        final String resultsMetadata3 = controller.getFolderJobsByMetadataProperty("tenant6", "test", "Person");
+        assertEquals("[]", resultsMetadata3);
+
+        final String resultsMetadata4 = controller.getFolderJobsByMetadataProperty("tenant6", "", "");
+        assertEquals("[]", resultsMetadata4);
+
+    }
+}

--- a/monitor/services/src/test/resources/example_repo/tenant6/conf.xml
+++ b/monitor/services/src/test/resources/example_repo/tenant6/conf.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns="http://eobjects.org/analyzerbeans/configuration/1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<datastore-catalog>
+	</datastore-catalog>
+
+	<reference-data-catalog>
+	</reference-data-catalog>
+
+</configuration>

--- a/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_no_analyzers.analysis.xml
+++ b/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_no_analyzers.analysis.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <author>DataCleaner.org</author>
+         <metadata-properties>
+            <property name="Group">Person Enrichment</property>
+            <property name="Category">Enrichment</property>
+            <property name="CoordinatesX.GoldenRecords.person">154</property>
+            <property name="CoordinatesY.GoldenRecords.person">77</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="orderdb"/>
+        <columns>
+            <column id="col_0" path="PUBLIC.CUSTOMERS.CONTACTLASTNAME" type="VARCHAR"/>
+            <column id="col_1" path="PUBLIC.CUSTOMERS.CONTACTFIRSTNAME" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation>
+        <transformer>
+            <descriptor ref="Concatenator"/>
+            <metadata-properties>
+                <property name="CoordinatesY">244</property>
+                <property name="CoordinatesX">294</property>
+            </metadata-properties>
+            <properties>
+                <property name="Separator" value=" "/>
+            </properties>
+            <input ref="col_1"/>
+            <input ref="col_0"/>
+            <output id="col_2" name="fullname"/>
+        </transformer>
+    </transformation>
+    <analysis />
+</job>

--- a/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_no_datastore.analysis.xml
+++ b/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_no_datastore.analysis.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+	<job-metadata>
+		<metadata-properties>
+			<property name="Group">Person Enrichment</property>
+			<property name="Category">Enrichment</property>
+			<property name="CoordinatesX.GoldenRecords.person">154</property>
+			<property name="CoordinatesY.GoldenRecords.person">77</property>
+		</metadata-properties>
+	</job-metadata>
+	<source>
+		<data-context ref="this is a datastore that does not exist" />
+		<columns>
+			<column id="col_0" path="lastname" type="VARCHAR" />
+			<column id="col_1" path="firstname" type="VARCHAR" />
+		</columns>
+	</source>
+	<transformation>
+		<transformer>
+			<descriptor ref="Concatenator" />
+			<metadata-properties>
+				<property name="CoordinatesY">244</property>
+				<property name="CoordinatesX">294</property>
+			</metadata-properties>
+			<properties>
+				<property name="Separator" value=" " />
+			</properties>
+			<input ref="col_1" />
+			<input ref="col_0" />
+			<output id="col_2" name="fullname" />
+		</transformer>
+	</transformation>
+	<analysis />
+</job>

--- a/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_short_column_paths.analysis.xml
+++ b/monitor/services/src/test/resources/example_repo/tenant6/jobs/concat_job_short_column_paths.analysis.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+   <job-metadata>
+         <metadata-properties>
+            <property name="Group">Person</property>
+         </metadata-properties>  
+    </job-metadata>
+    <source>
+        <data-context ref="orderdb"/>
+        <columns>
+            <column id="col_0" path="CUSTOMERS.CONTACTLASTNAME" type="VARCHAR"/>
+            <column id="col_1" path="CUSTOMERS.CONTACTFIRSTNAME" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation>
+        <transformer>
+            <descriptor ref="Concatenator"/>
+            <metadata-properties>
+                <property name="CoordinatesY">244</property>
+                <property name="CoordinatesX">294</property>
+            </metadata-properties>
+            <properties>
+                <property name="Separator" value=" "/>
+            </properties>
+            <input ref="col_1"/>
+            <input ref="col_0"/>
+            <output id="col_2" name="fullname"/>
+        </transformer>
+    </transformation>
+    <analysis>
+        <analyzer>
+            <descriptor ref="String analyzer"/>
+            <metadata-properties>
+                <property name="CoordinatesY">289</property>
+                <property name="CoordinatesX">487</property>
+            </metadata-properties>
+            <properties/>
+            <input ref="col_2"/>
+        </analyzer>
+    </analysis>
+</job>


### PR DESCRIPTION
Fixes #1391 

The API has been improved to filter jobs based on any job metadata property that have a specific value. 
Eg:
`repository/{tenant}/jobs?property=Category&value=enrichment`