### PR TITLE
Bug/1424 null check filter considers empty strings as null

### DIFF
--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
@@ -132,7 +132,7 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
                 }
                 q.where(column, OperatorType.DIFFERENT_FROM, null);
                 if (considerEmptyStringAsNull && col.getDataType() == String.class) {
-                    q.where(column, OperatorType.LIKE, "%");
+                    q.where(column, OperatorType.DIFFERENT_FROM, "");
                 }
             }
         } else {

--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.inject.Named;
 
 import org.apache.metamodel.query.FilterItem;
-import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.OperatorType;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
@@ -133,7 +132,7 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
                 }
                 q.where(column, OperatorType.DIFFERENT_FROM, null);
                 if (considerEmptyStringAsNull && col.getDataType() == String.class) {
-                    q.having(FunctionType.TO_BOOLEAN, column, OperatorType.EQUALS_TO, "TRUE");
+                    q.where(column, OperatorType.LIKE, "%");
                 }
             }
         } else {

--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
@@ -48,21 +48,21 @@ import org.datacleaner.components.categories.FilterCategory;
 @Distributed(true)
 public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.NullCheckCategory>, HasLabelAdvice {
 
-    public static enum NullCheckCategory {
+    public enum NullCheckCategory {
         @Alias("INVALID")
         NULL,
 
         @Alias("VALID")
-        NOT_NULL;
+        NOT_NULL
     }
 
-    public static enum EvaluationMode implements HasName {
-        ALL_FIELDS("When all fields are NULL, the record is considered NULL"), ANY_FIELD(
-                "When any field is NULL, the record is considered NULL");
+    public enum EvaluationMode implements HasName {
+        ALL_FIELDS("When all fields are NULL, the record is considered NULL"),
+        ANY_FIELD("When any field is NULL, the record is considered NULL");
 
         private final String _name;
 
-        private EvaluationMode(String name) {
+        EvaluationMode(String name) {
             _name = name;
         }
 
@@ -82,7 +82,7 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
     boolean considerEmptyStringAsNull = false;
 
     @Configured("Evaluation mode")
-    EvaluationMode evaluationMode = EvaluationMode.ANY_FIELD;;
+    EvaluationMode evaluationMode = EvaluationMode.ANY_FIELD;
 
     public NullCheckFilter() {
     }
@@ -132,12 +132,12 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
                 }
                 q.where(column, OperatorType.DIFFERENT_FROM, null);
                 if (considerEmptyStringAsNull && col.getDataType() == String.class) {
-                    q.where(column, OperatorType.DIFFERENT_FROM, "");
+                    q.where(column, OperatorType.LIKE, "%");
                 }
             }
         } else {
             // if NULL all filter items will be OR'ed.
-            List<FilterItem> filterItems = new ArrayList<FilterItem>();
+            List<FilterItem> filterItems = new ArrayList<>();
             for (InputColumn<?> col : columns) {
                 Column column = col.getPhysicalColumn();
                 if (column == null) {
@@ -195,7 +195,6 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
                     break;
                 }
             }
-            
         }
         return result;
     }

--- a/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
+++ b/components/basic-filters/src/main/java/org/datacleaner/beans/filter/NullCheckFilter.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.inject.Named;
 
 import org.apache.metamodel.query.FilterItem;
+import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.OperatorType;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
@@ -132,7 +133,7 @@ public class NullCheckFilter implements QueryOptimizedFilter<NullCheckFilter.Nul
                 }
                 q.where(column, OperatorType.DIFFERENT_FROM, null);
                 if (considerEmptyStringAsNull && col.getDataType() == String.class) {
-                    q.where(column, OperatorType.LIKE, "%");
+                    q.having(FunctionType.TO_BOOLEAN, column, OperatorType.EQUALS_TO, "TRUE");
                 }
             }
         } else {

--- a/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
+++ b/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
@@ -132,8 +132,8 @@ public class NullCheckFilterTest extends TestCase {
 		Query optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NOT_NULL);
 
 		assertEquals("SELECT \"EMPLOYEES\".\"EMAIL\", \"EMPLOYEES\".\"EMPLOYEENUMBER\" FROM "
-				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMPLOYEENUMBER\" "
-				+ "IS NOT NULL HAVING TO_BOOLEAN(\"EMPLOYEES\".\"EMAIL\") = TRUE", optimizedQuery.toSql());
+				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMAIL\" "
+				+ "LIKE '%' AND \"EMPLOYEES\".\"EMPLOYEENUMBER\" IS NOT NULL", optimizedQuery.toSql());
 
 		optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NULL);
 

--- a/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
+++ b/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
@@ -132,8 +132,8 @@ public class NullCheckFilterTest extends TestCase {
 		Query optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NOT_NULL);
 
 		assertEquals("SELECT \"EMPLOYEES\".\"EMAIL\", \"EMPLOYEES\".\"EMPLOYEENUMBER\" FROM "
-				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMAIL\" LIKE '%' "
-				+ "AND \"EMPLOYEES\".\"EMPLOYEENUMBER\" IS NOT NULL", optimizedQuery.toSql());
+				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMPLOYEENUMBER\" "
+				+ "IS NOT NULL HAVING TO_BOOLEAN(\"EMPLOYEES\".\"EMAIL\") = TRUE", optimizedQuery.toSql());
 
 		optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NULL);
 

--- a/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
+++ b/components/basic-filters/src/test/java/org/datacleaner/beans/filter/NullCheckFilterTest.java
@@ -59,9 +59,9 @@ public class NullCheckFilterTest extends TestCase {
 	}
 
 	public void testCategorize() throws Exception {
-		InputColumn<Integer> col1 = new MockInputColumn<Integer>("col1", Integer.class);
-		InputColumn<Boolean> col2 = new MockInputColumn<Boolean>("col2", Boolean.class);
-		InputColumn<String> col3 = new MockInputColumn<String>("col3", String.class);
+		InputColumn<Integer> col1 = new MockInputColumn<>("col1", Integer.class);
+		InputColumn<Boolean> col2 = new MockInputColumn<>("col2", Boolean.class);
+		InputColumn<String> col3 = new MockInputColumn<>("col3", String.class);
 		InputColumn<?>[] columns = new InputColumn[] { col1, col2, col3 };
 
 		NullCheckFilter filter = new NullCheckFilter(columns, true);
@@ -82,9 +82,9 @@ public class NullCheckFilterTest extends TestCase {
 	}
 	
 	public void testCategorizeAllFieldsMode() throws Exception {
-        InputColumn<Integer> col1 = new MockInputColumn<Integer>("col1", Integer.class);
-        InputColumn<Boolean> col2 = new MockInputColumn<Boolean>("col2", Boolean.class);
-        InputColumn<String> col3 = new MockInputColumn<String>("col3", String.class);
+        InputColumn<Integer> col1 = new MockInputColumn<>("col1", Integer.class);
+        InputColumn<Boolean> col2 = new MockInputColumn<>("col2", Boolean.class);
+        InputColumn<String> col3 = new MockInputColumn<>("col3", String.class);
         InputColumn<?>[] columns = new InputColumn[] { col1, col2, col3 };
 
         NullCheckFilter filter = new NullCheckFilter(columns, true, EvaluationMode.ALL_FIELDS);
@@ -132,8 +132,8 @@ public class NullCheckFilterTest extends TestCase {
 		Query optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NOT_NULL);
 
 		assertEquals("SELECT \"EMPLOYEES\".\"EMAIL\", \"EMPLOYEES\".\"EMPLOYEENUMBER\" FROM "
-				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMAIL\" <> '' AND "
-				+ "\"EMPLOYEES\".\"EMPLOYEENUMBER\" IS NOT NULL", optimizedQuery.toSql());
+				+ "PUBLIC.\"EMPLOYEES\" WHERE \"EMPLOYEES\".\"EMAIL\" IS NOT NULL AND \"EMPLOYEES\".\"EMAIL\" LIKE '%' "
+				+ "AND \"EMPLOYEES\".\"EMPLOYEENUMBER\" IS NOT NULL", optimizedQuery.toSql());
 
 		optimizedQuery = filter.optimizeQuery(baseQuery.clone(), NullCheckFilter.NullCheckCategory.NULL);
 


### PR DESCRIPTION
Fixes #1424. 

Problem with "optimized sql condition" in NullCheckFilter with "Consider empty strings as null" checked. 

Condition ```<Operator.DIFFERENT_FROM, "">``` was replaced by ```<Operator.LIKE, "%">```. 
