### PR TITLE
bug/1423 ValueDistributionAnalyzer, unconfigured output, execution enabled

### DIFF
--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzer.java
@@ -94,11 +94,9 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
 
     /**
      * Constructor used for testing and ad-hoc purposes
-     * 
+     *
      * @param column
      * @param recordUniqueValues
-     * @param topFrequentValues
-     * @param bottomFrequentValues
      */
     public ValueDistributionAnalyzer(InputColumn<?> column, boolean recordUniqueValues) {
         this(column, null, recordUniqueValues);
@@ -106,12 +104,10 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
 
     /**
      * Constructor used for testing and ad-hoc purposes
-     * 
+     *
      * @param column
      * @param groupColumn
      * @param recordUniqueValues
-     * @param topFrequentValues
-     * @param bottomFrequentValues
      */
     public ValueDistributionAnalyzer(InputColumn<?> column, InputColumn<String> groupColumn, boolean recordUniqueValues) {
         this();
@@ -125,7 +121,7 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
      * Main constructor
      */
     public ValueDistributionAnalyzer() {
-        _valueDistributionGroups = new TreeMap<String, ValueDistributionGroup>(
+        _valueDistributionGroups = new TreeMap<>(
                 NullTolerableComparator.get(String.class));
     }
 
@@ -182,13 +178,12 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
         if (_groupColumn == null) {
             logger.info("getResult() invoked, processing single group");
             final ValueDistributionGroup valueDistributionGroup = getValueDistributionGroup(_column.getName());
-            final SingleValueDistributionResult ungroupedResult = valueDistributionGroup
-                    .createResult(_recordUniqueValues);
-            return ungroupedResult;
+
+            return valueDistributionGroup.createResult(_recordUniqueValues);
         } else {
             logger.info("getResult() invoked, processing {} groups", _valueDistributionGroups.size());
 
-            final SortedSet<SingleValueDistributionResult> groupedResults = new TreeSet<SingleValueDistributionResult>();
+            final SortedSet<SingleValueDistributionResult> groupedResults = new TreeSet<>();
             for (String group : _valueDistributionGroups.keySet()) {
                 final ValueDistributionGroup valueDistributibutionGroup = getValueDistributionGroup(group);
                 final SingleValueDistributionResult result = valueDistributibutionGroup
@@ -204,7 +199,7 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
     }
 
     /**
-     * 
+     *
      * @param collectionFactory
      * @deprecated use of this property is no longer adviced. It will be phased
      *             out in later versions of DataCleaner

--- a/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzer.java
+++ b/components/value-distribution/src/main/java/org/datacleaner/beans/valuedist/ValueDistributionAnalyzer.java
@@ -94,7 +94,7 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
 
     /**
      * Constructor used for testing and ad-hoc purposes
-     *
+     * 
      * @param column
      * @param recordUniqueValues
      */
@@ -104,7 +104,7 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
 
     /**
      * Constructor used for testing and ad-hoc purposes
-     *
+     * 
      * @param column
      * @param groupColumn
      * @param recordUniqueValues
@@ -199,7 +199,7 @@ public class ValueDistributionAnalyzer implements Analyzer<ValueDistributionAnal
     }
 
     /**
-     *
+     * 
      * @param collectionFactory
      * @deprecated use of this property is no longer adviced. It will be phased
      *             out in later versions of DataCleaner

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -370,7 +370,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     public void open() {
         super.open();
     }
-
+    
     @Override
     public void changePanel(AnalysisWindowPanelType panel) {
         if (_datastore == null) {
@@ -391,7 +391,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     /**
      * Gets whether or not the datastore has been set in this window (ie. if the
      * tree is showing a datastore).
-     *
+     * 
      * @return true if a datastore is set.
      */
     @Override
@@ -401,7 +401,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
 
     /**
      * Initializes the window to use a particular datastore in the schema tree.
-     *
+     * 
      * @param datastore
      */
     @Override
@@ -411,7 +411,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
 
     /**
      * Initializes the window to use a particular datastore in the schema tree.
-     *
+     * 
      * @param datastore
      * @param expandTree
      *            true if the datastore tree should be initially expanded.
@@ -798,7 +798,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
             optionsDialog.getTabbedPane().setSelectedIndex(0);
             optionsDialog.open();
         });
-
+        
         final JMenuItem monitorMenuItem = WidgetFactory.createMenuItem("DataCleaner monitor",
                 IconUtils.MENU_DQ_MONITOR);
         monitorMenuItem.addActionListener(e -> {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -23,6 +23,7 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Cursor;
 import java.awt.Image;
+import java.awt.event.ActionListener;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.ByteArrayOutputStream;
@@ -860,12 +861,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
                 final ImageIcon icon = new ImageIcon(windowIcon.getScaledInstance(IconUtils.ICON_SIZE_SMALL,
                         IconUtils.ICON_SIZE_SMALL, Image.SCALE_DEFAULT));
                 final JMenuItem switchToWindowItem = WidgetFactory.createMenuItem(titleText, icon);
-                switchToWindowItem.addActionListener(new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        window.toFront();
-                    }
-                });
+                switchToWindowItem.addActionListener(e1 -> window.toFront());
                 windowsMenuItem.add(switchToWindowItem);
             }
 


### PR DESCRIPTION
Fixes #1423  

Original reason for this fix was an exception while running job with unconfigured input columns in ValueDistributionAnalyzer. The fix is general, though. Every exception in AnalysisJobBuilderWindowImpl.updateStatusLabel() makes the job un-executable now. 