### PR TITLE
Feature/add country names

### DIFF
--- a/components/standardizers/src/main/java/org/datacleaner/beans/standardize/Country.java
+++ b/components/standardizers/src/main/java/org/datacleaner/beans/standardize/Country.java
@@ -141,7 +141,7 @@ public enum Country implements HasName, HasAliases {
 
     CONGO_BRAZZAVILLE("CG", "COG", "Congo (Brazzaville)", "Congo", "Congo (the)", "the Republic of the Congo"),
 
-    CONGO_KINSHASA("CD", "COD", "Congo (Kinshasa)", "Congo, Democratic republic of the", "the Democratic Republic of the Congo", "Congo (the Democratic Republic of the)", "Zaire"),
+    CONGO_KINSHASA("CD", "COD", "Congo (Kinshasa)", "Congo, Democratic republic of the", "the Democratic Republic of the Congo", "Congo (the Democratic Republic of the)", "Zaire"), /* Former country name 'Zaire' */
     
     COOK_ISLANDS("CK", "COK", "Cook Islands"),
 
@@ -200,7 +200,7 @@ public enum Country implements HasName, HasAliases {
 
     GABON("GA", "GAB", "Gabon"),
 
-    GAMBIA("GM", "GMB", "Gambia", ""),
+    GAMBIA("GM", "GMB", "Gambia"),
 
     GEORGIA("GE", "GEO", "Georgia"),
 

--- a/components/standardizers/src/main/java/org/datacleaner/beans/standardize/Country.java
+++ b/components/standardizers/src/main/java/org/datacleaner/beans/standardize/Country.java
@@ -139,10 +139,10 @@ public enum Country implements HasName, HasAliases {
 
     COMOROS("KM", "COM", "Comoros"),
 
-    CONGO_BRAZZAVILLE("CG", "COG", "Congo (Brazzaville)"),
+    CONGO_BRAZZAVILLE("CG", "COG", "Congo (Brazzaville)", "Congo", "Congo (the)", "the Republic of the Congo"),
 
-    CONGO_KINSHASA("CD", "COD", "Congo (Kinshasa)"),
-
+    CONGO_KINSHASA("CD", "COD", "Congo (Kinshasa)", "Congo, Democratic republic of the", "the Democratic Republic of the Congo", "Congo (the Democratic Republic of the)", "Zaire"),
+    
     COOK_ISLANDS("CK", "COK", "Cook Islands"),
 
     COSTA_RICA("CR", "CRI", "Costa Rica"),
@@ -190,7 +190,7 @@ public enum Country implements HasName, HasAliases {
 
     FINLAND("FI", "FIN", "Finland"),
 
-    FRANCE("FR", "FRA", "France", "French Republic", "République Française", "Republique Francaise", "Frankrijk"),
+    FRANCE("FR", "FRA", "France", "French Republic", "République Française", "Republique Francaise", "Frankrijk", "Corsica"),
 
     FRENCH_GUIANA("GF", "GUF", "French Guiana"),
 
@@ -200,7 +200,7 @@ public enum Country implements HasName, HasAliases {
 
     GABON("GA", "GAB", "Gabon"),
 
-    GAMBIA("GM", "GMB", "Gambia"),
+    GAMBIA("GM", "GMB", "Gambia", ""),
 
     GEORGIA("GE", "GEO", "Georgia"),
 
@@ -300,7 +300,7 @@ public enum Country implements HasName, HasAliases {
 
     MACAU("MO", "MAC", "Macau", "China, Macao SAR", "Macao SAR"),
 
-    MACEDONIA("MK", "MKD", "Macedonia", "Macedonie", "Macedonië"),
+    MACEDONIA("MK", "MKD", "Macedonia", "Macedonie", "Macedonië", "Macedonia, the former Yugoslav republic of"),
 
     MADAGASCAR("MG", "MDG", "Madagascar"),
 
@@ -326,7 +326,7 @@ public enum Country implements HasName, HasAliases {
 
     MEXICO("MX", "MEX", "Mexico", "México", "United Mexican States"),
 
-    MICRONESIA("FM", "FSM", "Micronesia", "Micronesia (Federated States of)", "Federated States of Micronesia"),
+    MICRONESIA("FM", "FSM", "Micronesia", "Micronesia (Federated States of)", "Federated States of Micronesia", "Micronesia, Federated States of"),
 
     MOLDOVA("MD", "MDA", "Moldova"),
 
@@ -342,7 +342,7 @@ public enum Country implements HasName, HasAliases {
 
     MOZAMBIQUE("MZ", "MOZ", "Mozambique"),
 
-    MYANMAR("MM", "MMR", "Myanmar"),
+    MYANMAR("MM", "MMR", "Myanmar", "Burma"), /*country changed name from 'Burma'  to 'Maynmar' */
 
     NAMIBIA("NA", "NAM", "Namibia"),
 
@@ -438,7 +438,7 @@ public enum Country implements HasName, HasAliases {
 
     SINGAPORE("SG", "SGP", "Singapore"),
 
-    SINT_MAARTEN("SX", "SXM", "Sint Maarten"),
+    SINT_MAARTEN("SX", "SXM", "Sint Maarten", "St. Maarten", "Sint Maarten (Dutch part)"),
 
     SLOVAKIA("SK", "SVK", "Slovakia", "Slowakije"),
 
@@ -457,6 +457,8 @@ public enum Country implements HasName, HasAliases {
     SRI_LANKA("LK", "LKA", "Sri Lanka"),
 
     SUDAN("SD", "SDN", "Sudan"),
+    
+    SOUTH_SUDAN("SS", "SSD", "South Sudan"),
 
     SURINAME("SR", "SUR", "Suriname"),
 
@@ -478,7 +480,7 @@ public enum Country implements HasName, HasAliases {
 
     THAILAND("TH", "THA", "Thailand"),
 
-    TIMOR_LESTE("TL", "TLS", "Timor-Leste"),
+    TIMOR_LESTE("TL", "TLS", "Timor-Leste", "East Timor"), /*Former name: 'East Timor'*/
 
     TOGO("TG", "TGO", "Togo"),
 
@@ -519,17 +521,17 @@ public enum Country implements HasName, HasAliases {
 
     VANUATU("VU", "VUT", "Vanuatu"),
 
-    VATICAN_CITY("VA", "VAT", "Vatican City"),
+    VATICAN_CITY("VA", "VAT", "Vatican City", "Holy See"),
 
     VENEZUELA("VE", "VEN", "Venezuela", "Bolivarian Republic of Venezuela", "Venezuela (Bolivarian Republic of)"),
 
     VIETNAM("VN", "VNM", "Vietnam", "Viet nam"),
 
-    VIRGIN_ISLANDS_BRITISH("VG", "VGB", "Virgin Islands, British"),
+    VIRGIN_ISLANDS_BRITISH("VG", "VGB", "Virgin Islands, British", "British Virgin Islands"),
 
     VIRGIN_ISLANDS_US("VI", "VIR", "Virgin Islands, U.S.", "United States Virgin Islands"),
 
-    WALLIS_AND_FUTUNA_ISLANDS("WF", "WLF", "Wallis and Futuna Islands"),
+    WALLIS_AND_FUTUNA_ISLANDS("WF", "WLF", "Wallis and Futuna Islands", "Wallis and Futuna"),
 
     WESTERN_SAHARA("EH", "ESH", "Western Sahara"),
 
@@ -677,6 +679,7 @@ public enum Country implements HasName, HasAliases {
         country = replaceAll(country, "STATES ", " ");
         country = replaceAll(country, "STATE ", " ");
         country = replaceAll(country, "OF ", " ");
+        country = country.replaceFirst("THE", " "); 
 
         // remove spaces
         country = replaceAll(country, " ", "");

--- a/components/standardizers/src/test/java/org/datacleaner/beans/standardize/CountryTest.java
+++ b/components/standardizers/src/test/java/org/datacleaner/beans/standardize/CountryTest.java
@@ -77,5 +77,39 @@ public class CountryTest extends TestCase {
         assertEquals(Country.UNITED_KINGDOM, Country.find("England"));
         assertEquals(Country.UNITED_KINGDOM, Country.find("Northern Ireland"));
         assertEquals(Country.UNITED_KINGDOM, Country.find(".uk"));
+        assertEquals(Country.UNITED_KINGDOM, Country.find("The United Kingdom"));
+        assertEquals(Country.UNITED_KINGDOM, Country.find("Northern Ireland")); 
+    }
+    
+    public void testFindKongoKinshasa() throws Exception {
+        assertEquals(Country.CONGO_KINSHASA, Country.find("Congo (the Democratic Republic of the)"));
+        assertEquals(Country.CONGO_KINSHASA, Country.find("Congo, Democratic Republic of the")); 
+        
+    }
+    
+    public void testFindCongoBrazzaville() throws Exception {
+        assertEquals(Country.CONGO_BRAZZAVILLE, Country.find("Congo, Republic of the")); 
+    }
+    
+    public void testFindCountriesWithTheInNames() throws Exception {
+        assertEquals(Country.GAMBIA, Country.find("Gambia, The"));
+        assertEquals(Country.CAYMAN_ISLANDS, Country.find("Cayman Islands, The"));
+        assertEquals(Country.BAHAMAS, Country.find("Bahamas, The")); 
+        assertEquals(Country.NETHERLANDS, Country.find("Netherlands")); 
+    }
+    
+    public void testRandomContries(){
+        assertEquals(Country.SOUTH_SUDAN, Country.find("South Sudan"));
+        assertEquals(Country.MACEDONIA, Country.find("Macedonia, The Former Yugoslav Republic of"));
+        assertEquals(Country.MYANMAR, Country.find("Burma"));
+        assertEquals(Country.MYANMAR, Country.find("Myanmar"));
+        assertEquals(Country.TIMOR_LESTE, Country.find("East Timor"));
+        assertEquals(Country.TIMOR_LESTE, Country.find("Timor-Leste")); 
+        assertEquals(Country.VIRGIN_ISLANDS_BRITISH, Country.find("British Virgin Islands"));
+        assertEquals(Country.MICRONESIA, Country.find("Micronesia, Federated States of"));
+        assertEquals(Country.SINT_MAARTEN, Country.find("St. Maarten"));
+        assertEquals(Country.WALLIS_AND_FUTUNA_ISLANDS, Country.find("Wallis and Futuna"));
+        assertEquals(Country.VATICAN_CITY, Country.find("Holy See"));    
+        assertEquals(Country.FRANCE, Country.find("Corsica"));
     }
 }


### PR DESCRIPTION
Fixes #1443 
- Added extra countries that we do not have and some other names they might have 
- Removed the <b> ", The" </b> where possible 
- The Provinces such as "Corsica" return that the countries they belong to. 
- Added the former names of some countries in the list. 
- I ignored the countries that do not exist anymore such as "Yougoslavia" and is heavily disputed such as "Gaza Strip". 