### PR TITLE
Allow POST for jobs without specific content type

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobTriggeringController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/JobTriggeringController.java
@@ -58,8 +58,7 @@ public class JobTriggeringController {
     @Autowired
     SchedulingService _schedulingService;
 
-    @RequestMapping(method = { RequestMethod.DELETE, RequestMethod.GET, RequestMethod.HEAD, RequestMethod.OPTIONS,
-            RequestMethod.PATCH, RequestMethod.PUT, RequestMethod.TRACE }, produces = "application/json")
+    @RequestMapping(produces = "application/json")
     @ResponseBody
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     public Map<String, String> invokeJob(@PathVariable("tenant") final String tenant,
@@ -68,7 +67,7 @@ public class JobTriggeringController {
         return handleJob(tenant, jobName, block, timeoutMillis, null);
     }
 
-    @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, 
+    @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.TEXT_PLAIN_VALUE)
     @ResponseBody
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
@@ -108,7 +107,7 @@ public class JobTriggeringController {
             @PathVariable("job") String jobName, @RequestParam(value = "block", required = false) Boolean block,
             @RequestParam(value = "timeoutMillis", required = false) Integer timeoutMillis,
             @RequestBody final Properties overrideProperties) throws Throwable {
-        final boolean blocking = block != null && block.booleanValue();
+        final boolean blocking = block != null && block;
 
         jobName = jobName.replaceAll("\\+", " ");
 
@@ -129,7 +128,7 @@ public class JobTriggeringController {
             }
         }
 
-        final Map<String, String> result = new HashMap<String, String>();
+        final Map<String, String> result = new HashMap<>();
         result.put("status", toString(executionLog.getExecutionStatus()));
         result.put("logOutput", executionLog.getLogOutput());
         result.put("resultId", executionLog.getResultId());
@@ -150,10 +149,7 @@ public class JobTriggeringController {
         if (timeoutMillis == null) {
             return false;
         }
-        if (millisWaited > timeoutMillis.intValue()) {
-            return true;
-        }
-        return false;
+        return millisWaited > timeoutMillis;
     }
 
     private String toString(Object obj) {


### PR DESCRIPTION
This makes sure that jobs without a content type and/or body can still use POST to trigger a job execution.

Fixes #1425

We'd probably like this to be tested pretty thoroughly, since it has already slipped through the cracks once.