### PR TITLE
#1456 Tokenizer disregards number of tokens when target is ROWS

### DIFF
--- a/components/basic-transformers/src/test/java/org/datacleaner/beans/transform/TokenizerTransformerTest.java
+++ b/components/basic-transformers/src/test/java/org/datacleaner/beans/transform/TokenizerTransformerTest.java
@@ -100,7 +100,7 @@ public class TokenizerTransformerTest extends TestCase {
 		InputColumn<?> col = new MetaModelInputColumn(new MutableColumn("name"));
 
 		@SuppressWarnings("unchecked")
-		TokenizerTransformer transformer = new TokenizerTransformer((InputColumn<String>) col, 2);
+		TokenizerTransformer transformer = new TokenizerTransformer((InputColumn<String>) col, 1);
 		transformer.tokenTarget = TokenTarget.ROWS;
 		OutputRowCollector collectorMock = EasyMock.createMock(OutputRowCollector.class);
 		transformer.outputRowCollector = collectorMock;

--- a/desktop/ui/src/main/java/org/datacleaner/panels/tokenizer/TokenizerJobBuilderPresenter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/tokenizer/TokenizerJobBuilderPresenter.java
@@ -81,6 +81,10 @@ class TokenizerJobBuilderPresenter extends TransformerComponentBuilderPanel {
                     }
                 }
             });
+            
+            if (_numTokensPropertyWidget != null && _tokenTargetPropertyWidget.getValue() == TokenTarget.ROWS) {
+                _numTokensPropertyWidget.setEnabled(false);
+            }
         } else if ("Number of tokens".equals(propertyName)) {
             _numTokensPropertyWidget = (SingleNumberPropertyWidget) propertyWidget;
         }


### PR DESCRIPTION
Fixes #1456 

In Tokenizer dialog, when "token target" is ROWS then "number of tokens" field should be disabled. This worked fine while changing "token target" (onChange event) but after the dialog window was reopened it was enabled again. This is now fixed. 

![tokenizer-cols](https://cloud.githubusercontent.com/assets/13213915/17522267/a77ea5a6-5e56-11e6-80f0-e0668148660c.png)
![tokenizer-rows](https://cloud.githubusercontent.com/assets/13213915/17522268/a7963c7a-5e56-11e6-9b40-0ffec38827df.png)
