### PR TITLE
Reinstates edition display

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/LicenceAndEditionStatusLabel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/LicenceAndEditionStatusLabel.java
@@ -43,7 +43,7 @@ public class LicenceAndEditionStatusLabel extends JLabel {
     private final RightInformationPanel _rightPanel;
 
     public LicenceAndEditionStatusLabel(RightInformationPanel rightPanel) {
-        super(PANEL_NAME);
+        super(Version.getEdition());
         _rightPanel = rightPanel;
         setForeground(WidgetUtils.BG_COLOR_BRIGHTEST);
 

--- a/desktop/ui/src/test/java/org/datacleaner/widgets/LicenceAndEditionStatusLabelTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/widgets/LicenceAndEditionStatusLabelTest.java
@@ -1,0 +1,44 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.widgets;
+
+import org.datacleaner.Version;
+import org.datacleaner.panels.RightInformationPanel;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class LicenceAndEditionStatusLabelTest {
+    LicenceAndEditionStatusLabel _label;
+
+    @Before
+    public void setup() {
+        RightInformationPanel rightInformationPanel = mock(RightInformationPanel.class);
+
+        _label = new LicenceAndEditionStatusLabel(rightInformationPanel);
+    }
+
+    @Test
+    public void testLabelTitle() {
+        assertEquals("Should always show edition", _label.getText(), Version.getEdition());
+    }
+}


### PR DESCRIPTION
This reinstates the edition display that was broken by a refactoring of the right-side panel.

Also makes a (very simple) test to ensure it doesn't get broken again by mistake.

Fixes #1463