### PR TITLE
Lower verbosity of log message for displaying text using other font

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
@@ -670,7 +670,7 @@ public final class WidgetUtils {
         Font font = label.getFont();
         int canDisplay = font.canDisplayUpTo(text);
         if (canDisplay != -1) {
-            logger.warn("Default font ('{}') was unable to display text ('{}'), searching for alternative.",
+            logger.info("Default font ('{}') was unable to display text ('{}'), searching for alternative.",
                     font.getName(), text);
 
             // if the label contains undisplayable characters, look for a


### PR DESCRIPTION
When DataCleaner desktop is unable to display a text using the default font, it falls back to a custom font and logs a message at warning level, which can flood the logs, but isn't really a problem, because it is handled nicely. Therefore lowering verbosity of log message.