### PR TITLE
Make use of MetaModel's new custom column naming feature

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
@@ -20,22 +20,24 @@
 package org.datacleaner.widgets;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.swing.JButton;
+import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
-import org.jdesktop.swingx.JXTextField;
 import org.jdesktop.swingx.VerticalLayout;
 
 public class CustomColumnNamesWidget {
     private final DCPanel _innerPanel;
     private final DCPanel _outerPanel;
+    private final List<JButton> _buttons;
 
     public CustomColumnNamesWidget(List<String> columnNames) {
         _innerPanel = new DCPanel();
@@ -59,6 +61,8 @@ public class CustomColumnNamesWidget {
         buttonPanel.add(addButton);
         buttonPanel.add(removeButton);
 
+        _buttons = Arrays.asList(addButton, removeButton);
+
         if (columnNames != null) {
             columnNames.forEach(columnName -> addColumnName(columnName, false));
         }
@@ -71,7 +75,7 @@ public class CustomColumnNamesWidget {
     }
 
     private void addColumnName(String columnName, boolean updateUI) {
-        JXTextField columnNameField = WidgetFactory.createTextField();
+        JTextField columnNameField = WidgetFactory.createTextField();
         if (columnName != null) {
             columnNameField.setText(columnName);
         }
@@ -90,14 +94,17 @@ public class CustomColumnNamesWidget {
     }
 
     public List<String> getColumnNames() {
-        List<String> columnNames = new ArrayList<String>();
-        for (Component component : _innerPanel.getComponents()) {
-            final String columnName = ((JXTextField) component).getText();
-            if (columnName.length() != 0) {
-                columnNames.add(columnName);
-            }
-        }
-        return columnNames;
+        return getColumnNameFields().stream().filter(field -> field.getText().length() > 0).map(JTextField::getText)
+                .collect(Collectors.toList());
+    }
+
+    public List<JTextField> getColumnNameFields() {
+        return Stream.of(_innerPanel.getComponents()).map(component -> (JTextField) component).collect(Collectors
+                .toList());
+    }
+
+    public List<JButton> getButtons() {
+        return _buttons;
     }
 
     public DCPanel getPanel() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
@@ -48,8 +48,7 @@ public class CustomColumnNamesWidget {
 
         final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE_DARK);
         removeButton.addActionListener(e -> {
-            int componentCount = _innerPanel.getComponentCount();
-            if (componentCount > 0) {
+            if (_innerPanel.getComponentCount() > 0) {
                 removeColumnName();
                 _innerPanel.updateUI();
             }
@@ -75,7 +74,7 @@ public class CustomColumnNamesWidget {
     }
 
     private void addColumnName(String columnName, boolean updateUI) {
-        JTextField columnNameField = WidgetFactory.createTextField();
+        final JTextField columnNameField = WidgetFactory.createTextField();
         if (columnName != null) {
             columnNameField.setText(columnName);
         }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/CustomColumnNamesWidget.java
@@ -1,0 +1,106 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.widgets;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.border.EmptyBorder;
+
+import org.datacleaner.panels.DCPanel;
+import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.WidgetFactory;
+import org.jdesktop.swingx.JXTextField;
+import org.jdesktop.swingx.VerticalLayout;
+
+public class CustomColumnNamesWidget {
+    private final DCPanel _innerPanel;
+    private final DCPanel _outerPanel;
+
+    public CustomColumnNamesWidget(List<String> columnNames) {
+        _innerPanel = new DCPanel();
+        _innerPanel.setLayout(new VerticalLayout(2));
+
+        final JButton addButton = WidgetFactory.createSmallButton(IconUtils.ACTION_ADD_DARK);
+        addButton.addActionListener(e -> addColumnName("", true));
+
+        final JButton removeButton = WidgetFactory.createSmallButton(IconUtils.ACTION_REMOVE_DARK);
+        removeButton.addActionListener(e -> {
+            int componentCount = _innerPanel.getComponentCount();
+            if (componentCount > 0) {
+                removeColumnName();
+                _innerPanel.updateUI();
+            }
+        });
+
+        final DCPanel buttonPanel = new DCPanel();
+        buttonPanel.setBorder(new EmptyBorder(0, 4, 0, 0));
+        buttonPanel.setLayout(new VerticalLayout(2));
+        buttonPanel.add(addButton);
+        buttonPanel.add(removeButton);
+
+        if (columnNames != null) {
+            columnNames.forEach(columnName -> addColumnName(columnName, false));
+        }
+
+        _outerPanel = new DCPanel();
+        _outerPanel.setLayout(new BorderLayout());
+
+        _outerPanel.add(_innerPanel, BorderLayout.CENTER);
+        _outerPanel.add(buttonPanel, BorderLayout.EAST);
+    }
+
+    private void addColumnName(String columnName, boolean updateUI) {
+        JXTextField columnNameField = WidgetFactory.createTextField();
+        if (columnName != null) {
+            columnNameField.setText(columnName);
+        }
+
+        _innerPanel.add(columnNameField);
+        if (updateUI) {
+            _innerPanel.updateUI();
+        }
+    }
+
+    private void removeColumnName() {
+        int componentCount = _innerPanel.getComponentCount();
+        if (componentCount > 0) {
+            _innerPanel.remove(componentCount - 1);
+        }
+    }
+
+    public List<String> getColumnNames() {
+        List<String> columnNames = new ArrayList<String>();
+        for (Component component : _innerPanel.getComponents()) {
+            final String columnName = ((JXTextField) component).getText();
+            if (columnName.length() != 0) {
+                columnNames.add(columnName);
+            }
+        }
+        return columnNames;
+    }
+
+    public DCPanel getPanel() {
+        return _outerPanel;
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/windows/CsvDatastoreDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/CsvDatastoreDialog.java
@@ -488,17 +488,16 @@ public final class CsvDatastoreDialog extends AbstractResourceBasedDatastoreDial
     }
 
     private void registerColumnNameFields() {
-        _columnNamesWidget.getColumnNameFields().forEach(field -> {
-            if (!_columnNameFields.contains(field)) {
-                field.addKeyListener(new KeyAdapter() {
-                    @Override
-                    public void keyTyped(KeyEvent e) {
-                        onSettingsUpdated(false, false, getResource());
-                    }
-                });
+        _columnNamesWidget.getColumnNameFields().stream().filter(field -> !_columnNameFields.contains(field)).forEach(
+                field -> {
+                    field.addKeyListener(new KeyAdapter() {
+                        @Override
+                        public void keyTyped(KeyEvent e) {
+                            onSettingsUpdated(false, false, getResource());
+                        }
+                    });
 
-                _columnNameFields.add(field);
-            }
-        });
+                    _columnNameFields.add(field);
+                });
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
@@ -49,11 +49,11 @@ public final class ExcelDatastoreDialog extends AbstractFileBasedDatastoreDialog
 			MutableDatastoreCatalog mutableDatastoreCatalog, WindowContext windowContext, UserPreferences userPreferences) {
 		super(originalDatastore, mutableDatastoreCatalog, windowContext, userPreferences);
 
-		if (originalDatastore != null){
-		    _columnNamesWidget = new CustomColumnNamesWidget(originalDatastore.getCustomColumnNames());
-		} else{
-		    _columnNamesWidget = new CustomColumnNamesWidget(null); 
-		}
+        if (originalDatastore != null) {
+            _columnNamesWidget = new CustomColumnNamesWidget(originalDatastore.getCustomColumnNames());
+        } else {
+            _columnNamesWidget = new CustomColumnNamesWidget(null);
+        }
 	}
 
     protected List<Entry<String, JComponent>> getFormElements() {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
@@ -19,28 +19,44 @@
  */
 package org.datacleaner.windows;
 
+import java.util.List;
+import java.util.Map.Entry;
+
 import javax.inject.Inject;
+import javax.swing.JComponent;
 import javax.swing.filechooser.FileFilter;
 
-import org.datacleaner.connection.ExcelDatastore;
+import org.apache.metamodel.util.FileResource;
 import org.datacleaner.bootstrap.WindowContext;
+import org.datacleaner.connection.ExcelDatastore;
 import org.datacleaner.guice.Nullable;
 import org.datacleaner.user.MutableDatastoreCatalog;
 import org.datacleaner.user.UserPreferences;
 import org.datacleaner.util.FileFilters;
 import org.datacleaner.util.IconUtils;
+import org.datacleaner.util.ImmutableEntry;
 import org.datacleaner.widgets.AbstractResourceTextField;
-import org.apache.metamodel.util.FileResource;
+import org.datacleaner.widgets.CustomColumnNamesWidget;
 
 public final class ExcelDatastoreDialog extends AbstractFileBasedDatastoreDialog<ExcelDatastore> {
 
 	private static final long serialVersionUID = 1L;
 
+    private final CustomColumnNamesWidget _columnNamesWidget;
+
 	@Inject
 	protected ExcelDatastoreDialog(@Nullable ExcelDatastore originalDatastore,
 			MutableDatastoreCatalog mutableDatastoreCatalog, WindowContext windowContext, UserPreferences userPreferences) {
 		super(originalDatastore, mutableDatastoreCatalog, windowContext, userPreferences);
+
+		_columnNamesWidget = new CustomColumnNamesWidget(originalDatastore.getCustomColumnNames());
 	}
+
+    protected List<Entry<String, JComponent>> getFormElements() {
+        List<Entry<String, JComponent>> res = super.getFormElements();
+        res.add(new ImmutableEntry<>("Column Names", _columnNamesWidget.getPanel()));
+        return res;
+    }
 
 	@Override
 	protected void setFileFilters(AbstractResourceTextField<?> filenameField) {
@@ -65,7 +81,7 @@ public final class ExcelDatastoreDialog extends AbstractFileBasedDatastoreDialog
 
 	@Override
 	protected ExcelDatastore createDatastore(String name, String filename) {
-		return new ExcelDatastore(name, new FileResource(filename), filename);
+		return new ExcelDatastore(name, new FileResource(filename), filename, _columnNamesWidget.getColumnNames());
 	}
 
 	@Override

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ExcelDatastoreDialog.java
@@ -49,7 +49,11 @@ public final class ExcelDatastoreDialog extends AbstractFileBasedDatastoreDialog
 			MutableDatastoreCatalog mutableDatastoreCatalog, WindowContext windowContext, UserPreferences userPreferences) {
 		super(originalDatastore, mutableDatastoreCatalog, windowContext, userPreferences);
 
-		_columnNamesWidget = new CustomColumnNamesWidget(originalDatastore.getCustomColumnNames());
+		if (originalDatastore != null){
+		    _columnNamesWidget = new CustomColumnNamesWidget(originalDatastore.getCustomColumnNames());
+		} else{
+		    _columnNamesWidget = new CustomColumnNamesWidget(null); 
+		}
 	}
 
     protected List<Entry<String, JComponent>> getFormElements() {

--- a/engine/core/src/main/java/org/datacleaner/connection/CsvDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/CsvDatastore.java
@@ -28,6 +28,7 @@ import org.datacleaner.util.ReadObjectBuilder;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.csv.CsvDataContext;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Resource;
@@ -63,6 +64,7 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
     private final boolean _failOnInconsistencies;
     private final boolean _multilineValues;
     private final int _headerLineNumber;
+    private final List<String> _customColumnNames;
 
     public CsvDatastore(String name, Resource resource) {
         this(name, resource, resource.getName(), CsvConfiguration.DEFAULT_QUOTE_CHAR,
@@ -105,6 +107,13 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
     public CsvDatastore(String name, Resource resource, String filename, Character quoteChar, Character separatorChar,
             Character escapeChar, String encoding, boolean failOnInconsistencies, boolean multilineValues,
             int headerLineNumber) {
+        this(name, resource, filename, quoteChar, separatorChar, escapeChar, encoding, failOnInconsistencies,
+                multilineValues, headerLineNumber, null);
+    }
+
+    public CsvDatastore(String name, Resource resource, String filename, Character quoteChar, Character separatorChar,
+            Character escapeChar, String encoding, boolean failOnInconsistencies, boolean multilineValues,
+            int headerLineNumber, List<String> customColumnNames) {
         super(name);
         _filename = filename;
         if (resource == null) {
@@ -121,6 +130,7 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
             headerLineNumber = CsvConfiguration.NO_COLUMN_NAME_LINE;
         }
         _headerLineNumber = headerLineNumber;
+        _customColumnNames = customColumnNames;
 
     }
 
@@ -157,6 +167,10 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
         return _resourceRef.get();
     }
 
+    public List<String> getCustomColumnNames() {
+        return _customColumnNames;
+    }
+
     @Override
     protected UsageAwareDatastoreConnection<UpdateableDataContext> createDatastoreConnection() {
         final UpdateableDataContext dataContext;
@@ -176,9 +190,14 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
         final char quoteChar = _quoteChar == null ? DEFAULT_QUOTE_CHAR : _quoteChar;
         final char escapeChar = _escapeChar == null ? CsvConfiguration.DEFAULT_ESCAPE_CHAR : _escapeChar;
         final String encoding = _encoding == null ? FileHelper.UTF_8_ENCODING : _encoding;
-        final CsvConfiguration configuration = new CsvConfiguration(_headerLineNumber, encoding, separatorChar,
-                quoteChar, escapeChar, _failOnInconsistencies, _multilineValues);
-        return configuration;
+
+        if (_customColumnNames == null || _customColumnNames.size() == 0) {
+            return new CsvConfiguration(_headerLineNumber, encoding, separatorChar, quoteChar, escapeChar,
+                    _failOnInconsistencies, _multilineValues);
+        } else {
+            return new CsvConfiguration(_headerLineNumber, new CustomColumnNamingStrategy(_customColumnNames), encoding,
+                    separatorChar, quoteChar, escapeChar, _failOnInconsistencies, _multilineValues);
+        }
     }
 
     @Override
@@ -195,7 +214,7 @@ public final class CsvDatastore extends UsageAwareDatastore<UpdateableDataContex
     public boolean isFailOnInconsistencies() {
         return _failOnInconsistencies;
     }
-    
+
     public boolean isMultilineValues() {
         return _multilineValues;
     }

--- a/engine/core/src/test/java/org/datacleaner/connection/ExcelDatastoreTest.java
+++ b/engine/core/src/test/java/org/datacleaner/connection/ExcelDatastoreTest.java
@@ -19,12 +19,16 @@
  */
 package org.datacleaner.connection;
 
+import java.util.Arrays;
+
 import org.apache.metamodel.schema.Column;
 import junit.framework.TestCase;
 
 public class ExcelDatastoreTest extends TestCase {
 
-	public void testOpenSpreadsheetXls() throws Exception {
+	private static final String NR_ENTRIES_IN_SPREADSHEET2007 = "4";
+
+    public void testOpenSpreadsheetXls() throws Exception {
 		Datastore datastore = new ExcelDatastore("foobar", null, "src/test/resources/Spreadsheet2003.xls");
 		assertEquals("foobar", datastore.getName());
 		DatastoreConnection con = datastore.openConnection();
@@ -60,7 +64,27 @@ public class ExcelDatastoreTest extends TestCase {
 		assertEquals(
 				"Column[name=date,columnNumber=2,type=STRING,nullable=true,nativeType=null,columnSize=null]",
 				col3.toString());
+
+        assertEquals(NR_ENTRIES_IN_SPREADSHEET2007, con.getDataContext().executeQuery(
+                "select count(string) from Sheet1").toRows().get(0).getValue(0).toString());
 	}
+
+    public void testCustomColumnNaming() throws Exception {
+        final DatastoreConnection con = new ExcelDatastore("foobar", null, "src/test/resources/Spreadsheet2007.xlsx",
+                Arrays.asList("first", "second", "third")).openConnection();
+
+        assertNotNull(con.getSchemaNavigator().convertToColumn("first"));
+        assertNotNull(con.getSchemaNavigator().convertToColumn("second"));
+
+        final Column col3 = con.getSchemaNavigator().convertToColumn("third");
+        assertNotNull(col3);
+        assertEquals(
+                "Column[name=third,columnNumber=2,type=STRING,nullable=true,nativeType=null,columnSize=null]",
+                col3.toString());
+
+        assertEquals(NR_ENTRIES_IN_SPREADSHEET2007, con.getDataContext().executeQuery("select count(third) from Sheet1")
+                .toRows().get(0).getValue(0).toString());
+    }
 
 	public void testToString() throws Exception {
 		Datastore datastore = new ExcelDatastore("foobar", null, "src/test/resources/Spreadsheet2007.xlsx");

--- a/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
+++ b/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
@@ -128,6 +128,10 @@ public class CsvConfigurationDetection {
      * @throws IllegalStateException
      *             if an error occurs during auto-detection
      */
+    public CsvConfiguration suggestCsvConfiguration() throws IllegalStateException {
+        return suggestCsvConfiguration(null); 
+    }
+    
     public CsvConfiguration suggestCsvConfiguration(List<String> columnNames) throws IllegalStateException {
         final byte[] sample = getSampleBuffer();
         final String encoding = suggestEncoding(sample);

--- a/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
+++ b/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
@@ -116,7 +116,8 @@ public class CsvConfigurationDetection {
      * @throws IllegalStateException
      *             if an error occurs during auto-detection
      */
-    public CsvConfiguration suggestCsvConfiguration(String encoding, List<String> columnNames) throws IllegalStateException {
+    public CsvConfiguration suggestCsvConfiguration(String encoding, List<String> columnNames)
+            throws IllegalStateException {
         final byte[] sample = getSampleBuffer();
         return suggestCsvConfiguration(sample, encoding, columnNames);
     }
@@ -129,9 +130,9 @@ public class CsvConfigurationDetection {
      *             if an error occurs during auto-detection
      */
     public CsvConfiguration suggestCsvConfiguration() throws IllegalStateException {
-        return suggestCsvConfiguration(null); 
+        return suggestCsvConfiguration(null);
     }
-    
+
     public CsvConfiguration suggestCsvConfiguration(List<String> columnNames) throws IllegalStateException {
         final byte[] sample = getSampleBuffer();
         final String encoding = suggestEncoding(sample);
@@ -139,7 +140,8 @@ public class CsvConfigurationDetection {
         return suggestCsvConfiguration(sample, encoding, columnNames);
     }
 
-    private CsvConfiguration suggestCsvConfiguration(byte[] sample, String encoding, List<String> columnNames) throws IllegalStateException {
+    private CsvConfiguration suggestCsvConfiguration(byte[] sample, String encoding, List<String> columnNames)
+            throws IllegalStateException {
 
         char[] sampleChars = readSampleBuffer(sample, encoding);
 
@@ -218,19 +220,19 @@ public class CsvConfigurationDetection {
                 quoteChar = '"';
             }
         }
-        final ColumnNamingStrategy columnNamingStategy;  
-        if (columnNames != null && columnNames.size() > 0){
-            columnNamingStategy =  new CustomColumnNamingStrategy(columnNames); 
-        }else{
-            columnNamingStategy = null; 
+        final ColumnNamingStrategy columnNamingStategy;
+        if (columnNames != null && columnNames.size() > 0) {
+            columnNamingStategy = new CustomColumnNamingStrategy(columnNames);
+        } else {
+            columnNamingStategy = null;
         }
         // detect if multi line values occur
         boolean multiline = false;
         final CsvConfiguration multiLineConfiguration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
                 columnNamingStategy, encoding, separatorChar, quoteChar, escapeChar, false, true);
         try {
-            final CsvDataContext testDataContext = new CsvDataContext(new InMemoryResource("foo.txt", sample,
-                    System.currentTimeMillis()), multiLineConfiguration);
+            final CsvDataContext testDataContext = new CsvDataContext(new InMemoryResource("foo.txt", sample, System
+                    .currentTimeMillis()), multiLineConfiguration);
             final Table table = testDataContext.getDefaultSchema().getTable(0);
             try (final DataSet dataSet = testDataContext.query().from(table).select(table.getColumns()).execute()) {
                 while (dataSet.next()) {
@@ -252,8 +254,8 @@ public class CsvConfigurationDetection {
             return multiLineConfiguration;
         }
 
-        return new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE, columnNamingStategy, encoding, separatorChar, quoteChar,
-                escapeChar, false, multiline);
+        return new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE, columnNamingStategy, encoding,
+                separatorChar, quoteChar, escapeChar, false, multiline);
     }
 
     private int indexOf(char c, char[] sampleChars) {

--- a/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
+++ b/engine/utils/src/main/java/org/datacleaner/util/CsvConfigurationDetection.java
@@ -26,12 +26,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.csv.CsvDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.InMemoryResource;
@@ -113,9 +116,9 @@ public class CsvConfigurationDetection {
      * @throws IllegalStateException
      *             if an error occurs during auto-detection
      */
-    public CsvConfiguration suggestCsvConfiguration(String encoding) throws IllegalStateException {
+    public CsvConfiguration suggestCsvConfiguration(String encoding, List<String> columnNames) throws IllegalStateException {
         final byte[] sample = getSampleBuffer();
-        return suggestCsvConfiguration(sample, encoding);
+        return suggestCsvConfiguration(sample, encoding, columnNames);
     }
 
     /**
@@ -125,14 +128,14 @@ public class CsvConfigurationDetection {
      * @throws IllegalStateException
      *             if an error occurs during auto-detection
      */
-    public CsvConfiguration suggestCsvConfiguration() throws IllegalStateException {
+    public CsvConfiguration suggestCsvConfiguration(List<String> columnNames) throws IllegalStateException {
         final byte[] sample = getSampleBuffer();
         final String encoding = suggestEncoding(sample);
 
-        return suggestCsvConfiguration(sample, encoding);
+        return suggestCsvConfiguration(sample, encoding, columnNames);
     }
 
-    private CsvConfiguration suggestCsvConfiguration(byte[] sample, String encoding) throws IllegalStateException {
+    private CsvConfiguration suggestCsvConfiguration(byte[] sample, String encoding, List<String> columnNames) throws IllegalStateException {
 
         char[] sampleChars = readSampleBuffer(sample, encoding);
 
@@ -211,11 +214,16 @@ public class CsvConfigurationDetection {
                 quoteChar = '"';
             }
         }
-
+        final ColumnNamingStrategy columnNamingStategy;  
+        if (columnNames != null && columnNames.size() > 0){
+            columnNamingStategy =  new CustomColumnNamingStrategy(columnNames); 
+        }else{
+            columnNamingStategy = null; 
+        }
         // detect if multi line values occur
         boolean multiline = false;
         final CsvConfiguration multiLineConfiguration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
-                encoding, separatorChar, quoteChar, escapeChar, false, true);
+                columnNamingStategy, encoding, separatorChar, quoteChar, escapeChar, false, true);
         try {
             final CsvDataContext testDataContext = new CsvDataContext(new InMemoryResource("foo.txt", sample,
                     System.currentTimeMillis()), multiLineConfiguration);
@@ -240,7 +248,7 @@ public class CsvConfigurationDetection {
             return multiLineConfiguration;
         }
 
-        return new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE, encoding, separatorChar, quoteChar,
+        return new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE, columnNamingStategy, encoding, separatorChar, quoteChar,
                 escapeChar, false, multiline);
     }
 

--- a/engine/utils/src/test/java/org/datacleaner/util/CsvConfigurationDetectionTest.java
+++ b/engine/utils/src/test/java/org/datacleaner/util/CsvConfigurationDetectionTest.java
@@ -20,6 +20,8 @@
 package org.datacleaner.util;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.metamodel.csv.CsvConfiguration;
 
@@ -30,15 +32,27 @@ public class CsvConfigurationDetectionTest extends TestCase {
     public void testDetectMultiLine() throws Exception {
         CsvConfigurationDetection detection = new CsvConfigurationDetection(new File(
                 "src/test/resources/csv-detect/csv_multi_line.csv"));
-        CsvConfiguration configuration = detection.suggestCsvConfiguration();
+        CsvConfiguration configuration = detection.suggestCsvConfiguration(null);
         assertTrue(configuration.isMultilineValues());
     }
 
     public void testDetectSingleLine() throws Exception {
         CsvConfigurationDetection detection = new CsvConfigurationDetection(new File(
                 "src/test/resources/csv-detect/csv_single_line.csv"));
-        CsvConfiguration configuration = detection.suggestCsvConfiguration();
+        CsvConfiguration configuration = detection.suggestCsvConfiguration(null);
         assertFalse(configuration.isMultilineValues());
+    }
+
+    public void testColumnNames() throws Exception {
+        CsvConfigurationDetection detection = new CsvConfigurationDetection(new File(
+                "src/test/resources/csv-detect/csv_single_line.csv"));
+        final List<String> list = new ArrayList<>();
+        list.add("myId"); 
+        list.add("MyName"); 
+        
+        CsvConfiguration configuration = detection.suggestCsvConfiguration(list);
+        assertFalse(configuration.isMultilineValues());
+        assertNotNull(configuration.getColumnNamingStrategy()); 
     }
 
 }

--- a/engine/utils/src/test/java/org/datacleaner/util/CsvConfigurationDetectionTest.java
+++ b/engine/utils/src/test/java/org/datacleaner/util/CsvConfigurationDetectionTest.java
@@ -32,14 +32,14 @@ public class CsvConfigurationDetectionTest extends TestCase {
     public void testDetectMultiLine() throws Exception {
         CsvConfigurationDetection detection = new CsvConfigurationDetection(new File(
                 "src/test/resources/csv-detect/csv_multi_line.csv"));
-        CsvConfiguration configuration = detection.suggestCsvConfiguration(null);
+        CsvConfiguration configuration = detection.suggestCsvConfiguration();
         assertTrue(configuration.isMultilineValues());
     }
 
     public void testDetectSingleLine() throws Exception {
         CsvConfigurationDetection detection = new CsvConfigurationDetection(new File(
                 "src/test/resources/csv-detect/csv_single_line.csv"));
-        CsvConfiguration configuration = detection.suggestCsvConfiguration(null);
+        CsvConfiguration configuration = detection.suggestCsvConfiguration();
         assertFalse(configuration.isMultilineValues());
     }
 

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
@@ -792,6 +792,10 @@ public class DomConfigurationWriter {
 
         appendElement(ds, "filename", filename);
 
+        if (datastore.getCustomColumnNames() != null && datastore.getCustomColumnNames().size() > 0) {
+            datastore.getCustomColumnNames().forEach(columnName -> appendElement(ds, "custom-column-name", columnName));
+        }
+
         return ds;
     }
 

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/DomConfigurationWriter.java
@@ -793,7 +793,11 @@ public class DomConfigurationWriter {
         appendElement(ds, "filename", filename);
 
         if (datastore.getCustomColumnNames() != null && datastore.getCustomColumnNames().size() > 0) {
-            datastore.getCustomColumnNames().forEach(columnName -> appendElement(ds, "custom-column-name", columnName));
+            final Element customColumnNamesElement = getDocument().createElement("custom-column-names");
+            ds.appendChild(customColumnNamesElement);
+
+            datastore.getCustomColumnNames().forEach(columnName -> appendElement(customColumnNamesElement,
+                    "column-name", columnName));
         }
 
         return ds;
@@ -828,6 +832,14 @@ public class DomConfigurationWriter {
         appendElement(datastoreElement, "fail-on-inconsistencies", datastore.isFailOnInconsistencies());
         appendElement(datastoreElement, "multiline-values", datastore.isMultilineValues());
         appendElement(datastoreElement, "header-line-number", datastore.getHeaderLineNumber());
+
+        if (datastore.getCustomColumnNames() != null && datastore.getCustomColumnNames().size() > 0) {
+            final Element customColumnNamesElement = getDocument().createElement("custom-column-names");
+            datastoreElement.appendChild(customColumnNamesElement);
+
+            datastore.getCustomColumnNames().forEach(columnName -> appendElement(customColumnNamesElement,
+                    "column-name", columnName));
+        }
 
         return datastoreElement;
     }

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -1143,7 +1143,8 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
             DataCleanerConfiguration configuration) {
         final String filename = getStringVariable("filename", excelDatastoreType.getFilename());
         final Resource resource = _interceptor.createResource(filename, configuration);
-        return new ExcelDatastore(name, resource, filename);
+        final List<String> customeColumnNames = excelDatastoreType.getCustomColumnName();
+        return new ExcelDatastore(name, resource, filename, customeColumnNames);
     }
 
     private Datastore createDatastore(String name, XmlDatastoreType xmlDatastoreType) {

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -1143,8 +1143,12 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
             DataCleanerConfiguration configuration) {
         final String filename = getStringVariable("filename", excelDatastoreType.getFilename());
         final Resource resource = _interceptor.createResource(filename, configuration);
-        final List<String> customeColumnNames = excelDatastoreType.getCustomColumnName();
-        return new ExcelDatastore(name, resource, filename, customeColumnNames);
+
+        List<String> customColumnNames = null;
+        if (excelDatastoreType.getCustomColumnNames() != null) {
+            customColumnNames = excelDatastoreType.getCustomColumnNames().getColumnName();
+        }
+        return new ExcelDatastore(name, resource, filename, customColumnNames);
     }
 
     private Datastore createDatastore(String name, XmlDatastoreType xmlDatastoreType) {
@@ -1284,8 +1288,13 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
             headerLineNumber = CsvConfiguration.DEFAULT_COLUMN_NAME_LINE;
         }
 
+        List<String> customColumnNames = null;
+        if (csvDatastoreType.getCustomColumnNames() != null) {
+            customColumnNames = csvDatastoreType.getCustomColumnNames().getColumnName();
+        }
+
         return new CsvDatastore(name, resource, filename, quoteChar, separatorChar, escapeChar, encoding,
-                failOnInconsistencies, multilineValues, headerLineNumber);
+                failOnInconsistencies, multilineValues, headerLineNumber, customColumnNames);
     }
 
     private char getChar(String charString, char ifNull, char ifBlank) {

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -1212,8 +1212,14 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
             for (int i = 0; i < valueWidths.length; i++) {
                 valueWidths[i] = valueWidthsBoxed.get(i);
             }
+
+            List<String> customColumnNames = null;
+            if (fixedWidthDatastore.getCustomColumnNames() != null) {
+                customColumnNames = fixedWidthDatastore.getCustomColumnNames().getColumnName();
+            }
+
             ds = new FixedWidthDatastore(name, filename, encoding, valueWidths, failOnInconsistencies, skipEbcdicHeader,
-                    eolPresent, headerLineNumber);
+                    eolPresent, headerLineNumber, customColumnNames);
         } else {
             ds = new FixedWidthDatastore(name, filename, encoding, fixedValueWidth, failOnInconsistencies,
                     skipEbcdicHeader, eolPresent, headerLineNumber);

--- a/engine/xml-config/src/main/resources/configuration.xsd
+++ b/engine/xml-config/src/main/resources/configuration.xsd
@@ -798,6 +798,13 @@
 					<element name="fail-on-inconsistencies" type="boolean" minOccurs="0" />
 					<element name="skip-ebcdic-header" type="boolean" minOccurs="0" />
 					<element name="eol-present" type="boolean" minOccurs="0" />
+					<element name="custom-column-names" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<sequence>
+								<element name="column-name" minOccurs="0" maxOccurs="unbounded" type="string" />
+							</sequence>
+						</complexType>
+					</element>
 				</all>
 			</extension>
 		</complexContent>

--- a/engine/xml-config/src/main/resources/configuration.xsd
+++ b/engine/xml-config/src/main/resources/configuration.xsd
@@ -811,6 +811,7 @@
 			<extension base="ab:abstractDatastoreType">
 				<sequence>
 					<element name="filename" minOccurs="1" maxOccurs="1" type="string" />
+					<element name="custom-column-name" minOccurs="0" maxOccurs="unbounded" type="string" />
 				</sequence>
 			</extension>
 		</complexContent>

--- a/engine/xml-config/src/main/resources/configuration.xsd
+++ b/engine/xml-config/src/main/resources/configuration.xsd
@@ -461,6 +461,13 @@
 							</documentation>
 						</annotation>
 					</element>
+					<element name="custom-column-names" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<sequence>
+								<element name="column-name" minOccurs="0" maxOccurs="unbounded" type="string" />
+							</sequence>
+						</complexType>
+					</element>
 				</all>
 			</extension>
 		</complexContent>
@@ -811,7 +818,13 @@
 			<extension base="ab:abstractDatastoreType">
 				<sequence>
 					<element name="filename" minOccurs="1" maxOccurs="1" type="string" />
-					<element name="custom-column-name" minOccurs="0" maxOccurs="unbounded" type="string" />
+					<element name="custom-column-names" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<sequence>
+								<element name="column-name" minOccurs="0" maxOccurs="unbounded" type="string" />
+							</sequence>
+						</complexType>
+					</element>
 				</sequence>
 			</extension>
 		</complexContent>


### PR DESCRIPTION
MetaModel now provides the option to pass a ColumnNamingStrategy when constructing a CsvConfiguration, ExcelConfiguration or FixedWidthConfiguration. We can use this to configure custom column names for datastores in DataCleaner.

This pull request adds this functionality to the engine and DataCleaner desktop. It is now possible to add column names in the Datastore configuration dialog. It still look pretty rough, so this may need some further enhancing.

Notes:
- Right now it only fully works for Excel datastores because of https://issues.apache.org/jira/browse/METAMODEL-1113 and https://issues.apache.org/jira/browse/METAMODEL-1114. To make it work for Csv datastores we just need to wait for a MetaModel release which includes the fix for METAMODEL-1113. To make it work for Fixed-width datastores we both need to wait for a MetaModel release which includes the fix for METAMODEL-1114 and comment in one line of out commented code in the FixedWidthDatastore class.
- This pull request only add the functionality to configure custom column names to DataCleaner desktop, not to DataCleaner monitor. Right now, to be able to use it in DataCleaner monitor, you have to configure it in the conf.xml used by DataCleaner monitor.