### PR TITLE
Fix adding of timelines with pattern finder analyzer

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
@@ -35,6 +35,7 @@ import org.apache.metamodel.util.Predicate;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.AnalyzerResultFuture;
 import org.datacleaner.api.InputColumn;
+import org.datacleaner.beans.stringpattern.PatternFinderAnalyzer;
 import org.datacleaner.descriptors.ComponentDescriptor;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.descriptors.Descriptors;
@@ -481,6 +482,14 @@ public class MetricValueUtils {
         if (metricDescriptors == null || metricDescriptors.isEmpty()) {
             return null;
         }
+
+        if (componentJob.getDescriptor().getComponentClass() == PatternFinderAnalyzer.class && !(componentJob
+                .getConfiguration().getProperty(componentJob.getDescriptor().getConfiguredProperty(
+                        "Group column")) == null)) {
+            logger.warn("Pattern finder analyzer doesn't support metrics if it has a Group column configured.");
+            return null;
+        }
+
         final String label = LabelUtils.getLabel(componentJob);
         final InputColumn<?> identifyingInputColumn = AnalyzerJobHelper.getIdentifyingInputColumn(componentJob);
 


### PR DESCRIPTION
Fixes #1477.

If a Pattern finder analyzer has a Group column configured the getMatchCount() and getPatternCount() methods on the PatternFinderResult class propage an exception because they both invoke the getSingleCrosstab() which is programmed to throw an exception in case a Group column has been configured.

So, do not return metric groups for Patter finder analyzer for which a Group column has been configured. Just log a message that the Pattern finder analyzer doesn't support this.

It would be better if instead of just logging a message we would provide direct feedback to the user in the user interface, but this would require some more refactoring (and time).