### PR TITLE
#552 JavaScriptAdvancedTransformer -- default code was unrunnable at Monitor

### DIFF
--- a/components/data-structures/src/main/java/org/datacleaner/beans/datastructures/BuildListTransformer.java
+++ b/components/data-structures/src/main/java/org/datacleaner/beans/datastructures/BuildListTransformer.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 @Categorized(DataStructuresCategory.class)
 public class BuildListTransformer implements Transformer {
 
-    private static final Logger logger = LoggerFactory.getLogger(BuildMapTransformer.class);
+    private static final Logger logger = LoggerFactory.getLogger(BuildListTransformer.class);
 
     @Inject
     @Configured

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
@@ -66,7 +66,7 @@ public class JavaScriptAdvancedTransformer implements Transformer {
     @StringProperty(multiline = true, mimeType = { "text/javascript", "application/x-javascript" })
     String sourceCode = "var transformerObj = {\n"
             + "\tinitialize: function() {\n\t\tlogger.info('Initializing advanced JavaScript transformer...');\n\t},\n\n"
-            + "\ttransform: function(columns,values,outputCollector) {\n\t\tlogger.debug('transform({},{}) invoked', columns, values);\n\t\tfor (var i=0;i<columns.length;i++) {\n\t\t\toutputCollector.putValues(columns[i],values[i])\n\t\t}\n\t},\n\n"
+            + "\ttransform: function(columns,values,outputCollector) {\n\t\tlogger.debug('transform({},{},{}) invoked', columns, values, outputCollector);\n\t\tfor (var i=0;i<columns.length;i++) {\n\t\t\toutputCollector.putValues(columns[i],values[i])\n\t\t}\n\t},\n\n"
             + "\tclose: function() {\n\t\tlogger.info('Closing advanced JavaScript transformer...');\n\t}\n}";
 
     @Inject

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
@@ -42,8 +42,6 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptableObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A transformer that uses userwritten JavaScript to generate a transformer
@@ -54,8 +52,6 @@ import org.slf4j.LoggerFactory;
 @Categorized(ScriptingCategory.class)
 @Concurrent(false)
 public class JavaScriptAdvancedTransformer implements Transformer {
-
-    private static final Logger logger = LoggerFactory.getLogger(JavaScriptAdvancedTransformer.class);
 
     @Inject
     @Configured
@@ -107,7 +103,7 @@ public class JavaScriptAdvancedTransformer implements Transformer {
             _script = context.compileString(sourceCode, this.getClass().getSimpleName(), 1, null);
             _sharedScope = context.initStandardObjects();
 
-            JavaScriptUtils.addToScope(_sharedScope, logger, "logger", "log");
+            JavaScriptUtils.addToScope(_sharedScope, new JavaScriptLogger(), "logger", "log");
             JavaScriptUtils.addToScope(_sharedScope, System.out, "out");
 
             _script.exec(context, _sharedScope);

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptAdvancedTransformer.java
@@ -70,7 +70,7 @@ public class JavaScriptAdvancedTransformer implements Transformer {
     @StringProperty(multiline = true, mimeType = { "text/javascript", "application/x-javascript" })
     String sourceCode = "var transformerObj = {\n"
             + "\tinitialize: function() {\n\t\tlogger.info('Initializing advanced JavaScript transformer...');\n\t},\n\n"
-            + "\ttransform: function(columns,values,outputCollector) {\n\t\tlogger.debug('transform({},{},{}) invoked', columns, values, outputCollector);\n\t\tfor (var i=0;i<columns.length;i++) {\n\t\t\toutputCollector.putValues(columns[i],values[i])\n\t\t}\n\t},\n\n"
+            + "\ttransform: function(columns,values,outputCollector) {\n\t\tlogger.debug('transform({},{}) invoked', columns, values);\n\t\tfor (var i=0;i<columns.length;i++) {\n\t\t\toutputCollector.putValues(columns[i],values[i])\n\t\t}\n\t},\n\n"
             + "\tclose: function() {\n\t\tlogger.info('Closing advanced JavaScript transformer...');\n\t}\n}";
 
     @Inject

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptFilter.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptFilter.java
@@ -35,8 +35,6 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Named("JavaScript filter")
 @Description("Supply your own piece of JavaScript that evaluates whether rows should be included or excluded from processing.")
@@ -46,8 +44,6 @@ public class JavaScriptFilter implements Filter<JavaScriptFilter.Category> {
     public static enum Category {
         VALID, INVALID;
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(JavaScriptFilter.class);
 
     @Configured
     InputColumn<?>[] columns;
@@ -72,7 +68,7 @@ public class JavaScriptFilter implements Filter<JavaScriptFilter.Category> {
             _script = context.compileString(sourceCode, this.getClass().getSimpleName(), 1, null);
             _sharedScope = context.initStandardObjects();
 
-            JavaScriptUtils.addToScope(_sharedScope, logger, "logger", "log");
+            JavaScriptUtils.addToScope(_sharedScope, new JavaScriptLogger(), "logger", "log");
             JavaScriptUtils.addToScope(_sharedScope, System.out, "out");
         } finally {
             Context.exit();

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptLogger.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptLogger.java
@@ -1,0 +1,67 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.beans.script;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JavaScriptLogger {
+    private static final Logger logger = LoggerFactory.getLogger(JavaScriptLogger.class);
+            
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+    
+    public void trace(String format, Object... argv) {
+        logger.trace(format, argv);
+    }
+    
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+ 
+    public void debug(String format, Object... argv) {
+        logger.debug(format, argv);
+    }
+    
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+ 
+    public void info(String format, Object... argv) {
+        logger.info(format, argv);
+    }
+    
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+    
+    public void warn(String format, Object... argv) {
+        logger.warn(format, argv);
+    }
+    
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+    
+    public void error(String format, Object... argv) {
+        logger.error(format, argv);
+    }
+}

--- a/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
+++ b/components/javascript/src/main/java/org/datacleaner/beans/script/JavaScriptTransformer.java
@@ -37,8 +37,6 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A transformer that uses userwritten JavaScript to generate a value
@@ -48,9 +46,6 @@ import org.slf4j.LoggerFactory;
 @Description("Supply your own piece of JavaScript to do a custom transformation")
 @Categorized(ScriptingCategory.class)
 public class JavaScriptTransformer implements Transformer {
-
-	private static final Logger logger = LoggerFactory
-			.getLogger(JavaScriptTransformer.class);
 
 	public static enum ReturnType {
 		STRING, NUMBER, BOOLEAN;
@@ -93,11 +88,10 @@ public class JavaScriptTransformer implements Transformer {
 		Context context = _contextFactory.enterContext();
 
 		try {
-			_script = context.compileString(sourceCode, this.getClass()
-					.getSimpleName(), 1, null);
+			_script = context.compileString(sourceCode, this.getClass().getSimpleName(), 1, null);
 			_sharedScope = context.initStandardObjects();
 
-			JavaScriptUtils.addToScope(_sharedScope, logger, "logger", "log");
+			JavaScriptUtils.addToScope(_sharedScope, new JavaScriptLogger(), "logger", "log");
 			JavaScriptUtils.addToScope(_sharedScope, System.out, "out");
 		} finally {
 			Context.exit();

--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -268,6 +268,12 @@
 			<artifactId>hive-jdbc</artifactId>
 		</dependency>
 
+		<!-- Logging -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+	
 		<!-- JSF -->
 		<dependency>
 			<groupId>org.glassfish</groupId>

--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -273,7 +273,7 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 		</dependency>
-	
+
 		<!-- JSF -->
 		<dependency>
 			<groupId>org.glassfish</groupId>

--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -268,12 +268,6 @@
 			<artifactId>hive-jdbc</artifactId>
 		</dependency>
 
-		<!-- Logging -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-		</dependency>
-
 		<!-- JSF -->
 		<dependency>
 			<groupId>org.glassfish</groupId>


### PR DESCRIPTION
Fixes #552 

In JavaScriptAdvancedTransformer default code there was ```logger.debug(String, String[], String[], String)``` used. The last item was outputCollector which actually provided it's Object.toString() output (not so useful for users anyway). So, it was removed from the debug output and now ```logger.debug(String, String[], String[])``` is used which works fine. 