### PR TITLE
Use proper parsing instead of non-working homegrown solution

### DIFF
--- a/components/standardizers/src/main/java/org/datacleaner/beans/standardize/UrlStandardizerTransformer.java
+++ b/components/standardizers/src/main/java/org/datacleaner/beans/standardize/UrlStandardizerTransformer.java
@@ -19,100 +19,71 @@
  */
 package org.datacleaner.beans.standardize;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.inject.Named;
 
 import org.datacleaner.api.Categorized;
 import org.datacleaner.api.Configured;
 import org.datacleaner.api.Description;
-import org.datacleaner.api.Initialize;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.api.InputRow;
 import org.datacleaner.api.OutputColumns;
 import org.datacleaner.api.Transformer;
 import org.datacleaner.components.categories.TextCategory;
-import org.datacleaner.util.HasGroupLiteral;
-import org.datacleaner.util.NamedPattern;
-import org.datacleaner.util.NamedPatternMatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
 
 @Named("URL parser")
 @Description("Retrieve the individual parts of an URL, including protocol, domain, port, path and querystring.")
 @Categorized({ TextCategory.class })
 public class UrlStandardizerTransformer implements Transformer {
+    private static final Logger logger = LoggerFactory.getLogger(UrlStandardizerTransformer.class);
+    @Configured
+    InputColumn<String> inputColumn;
 
-	public static final String[] PATTERNS = { "PROTOCOL://DOMAIN:PORTPATH\\?QUERYSTRING",
-			"PROTOCOL://DOMAINPATH\\?QUERYSTRING", "PROTOCOL://DOMAIN:PORTPATH", "PROTOCOL://DOMAIN:PORT\\?QUERYSTRING",
-			"PROTOCOL://DOMAIN\\?QUERYSTRING", "PROTOCOL://DOMAINPATH", "PROTOCOL://DOMAIN:PORT", "PROTOCOL://DOMAIN" };
+    @Override
+    public OutputColumns getOutputColumns() {
+        return new OutputColumns(String.class, new String[] { "Protocol", "Domain", "Port", "Path", "Querystring" });
+    }
 
-	public static enum UrlPart implements HasGroupLiteral {
-		PROTOCOL, DOMAIN, PORT, PATH, QUERYSTRING;
+    @Override
+    public String[] transform(InputRow inputRow) {
+        String value = inputRow.getValue(inputColumn);
+        return transform(value);
+    }
 
-		@Override
-		public String getGroupLiteral() {
-			if (this == DOMAIN) {
-				return "([a-zA-Z0-9\\._\\-@]+)";
-			}
-			if (this == PORT) {
-				return "([0-9]+)";
-			}
-			if (this == PATH) {
-				return "(/[a-zA-Z0-9\\._\\-/#:%]+)";
-			}
-			if (this == QUERYSTRING) {
-				return "([a-zA-Z0-9\\.=\\?_\\-/%]+)";
-			}
-			return null;
-		}
-	}
+    public String[] transform(String value) {
+        String protocol = null;
+        String host = null;
+        String port = null;
+        String path = null;
+        String queryString = null;
 
-	@Configured
-	InputColumn<String> inputColumn;
+        if (value != null) {
+            try {
+                final URI url = new URI(value);
 
-	private List<NamedPattern<UrlPart>> namedPatterns;
+                protocol = url.getScheme();
+                host = url.getHost();
 
-	@Initialize
-	public void init() {
-		namedPatterns = new ArrayList<NamedPattern<UrlPart>>(PATTERNS.length);
-		for (String pattern : PATTERNS) {
-			namedPatterns.add(new NamedPattern<UrlPart>(pattern, UrlPart.class));
-		}
-	}
+                if (url.getPort() != -1) {
+                    port = Integer.toString(url.getPort());
+                }
 
-	@Override
-	public OutputColumns getOutputColumns() {
-		return new OutputColumns(String.class, "Protocol", "Domain", "Port", "Path", "Querystring");
-	}
+                if (!Strings.isNullOrEmpty(url.getPath())) {
+                    path = url.getPath();
+                }
+                queryString = url.getRawQuery();
 
-	@Override
-	public String[] transform(InputRow inputRow) {
-		String value = inputRow.getValue(inputColumn);
-		return transform(value);
-	}
+            } catch (URISyntaxException e) {
+                logger.info("Throwing away illegal URL \"{}\"", value);
+            }
+        }
 
-	public String[] transform(String value) {
-		String protocol = null;
-		String domain = null;
-		String port = null;
-		String path = null;
-		String queryString = null;
-
-		if (value != null) {
-			for (NamedPattern<UrlPart> namedPattern : namedPatterns) {
-				NamedPatternMatch<UrlPart> match = namedPattern.match(value);
-				if (match != null) {
-					protocol = match.get(UrlPart.PROTOCOL);
-					domain = match.get(UrlPart.DOMAIN);
-					port = match.get(UrlPart.PORT);
-					path = match.get(UrlPart.PATH);
-					queryString = match.get(UrlPart.QUERYSTRING);
-					break;
-				}
-			}
-		}
-
-		return new String[] { protocol, domain, port, path, queryString };
-	}
-
+        return new String[] { protocol, host, port, path, queryString };
+    }
 }

--- a/components/standardizers/src/test/java/org/datacleaner/beans/standardize/UrlStandardizerTransformerTest.java
+++ b/components/standardizers/src/test/java/org/datacleaner/beans/standardize/UrlStandardizerTransformerTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 
 import org.datacleaner.api.InputRow;
 import org.datacleaner.api.OutputColumns;
-import org.datacleaner.beans.standardize.UrlStandardizerTransformer;
 import org.datacleaner.data.MockInputRow;
 
 import junit.framework.TestCase;
@@ -36,7 +35,6 @@ public class UrlStandardizerTransformerTest extends TestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		transformer = new UrlStandardizerTransformer();
-		transformer.init();
 	}
 
 	public void testGetOutputColumns() throws Exception {
@@ -50,7 +48,7 @@ public class UrlStandardizerTransformerTest extends TestCase {
 	}
 
 	public void testTransformValidUrls() throws Exception {
-		String[] result;
+		Object[] result;
 
 		result = transformer
 				.transform("http://www.google.com/search?q=eobjects");
@@ -66,6 +64,18 @@ public class UrlStandardizerTransformerTest extends TestCase {
 		assertEquals("[http, localhost, 8080, null, null]",
 				Arrays.toString(result));
 
+		result = transformer.transform("http://www.yahoo.com/");
+		assertEquals("[http, www.yahoo.com, null, /, null]",
+				Arrays.toString(result));
+
+		result = transformer.transform("http://www.rethe.com/ref=bleh/234-2565344-2354454");
+		assertEquals("[http, www.rethe.com, null, /ref=bleh/234-2565344-2354454, null]",
+				Arrays.toString(result));
+
+		result = transformer.transform("https://www.ghzsffs.com/gswdp/nav/redir.html/ref=some-page");
+		assertEquals("[https, www.ghzsffs.com, null, /gswdp/nav/redir.html/ref=some-page, null]",
+				Arrays.toString(result));
+
 		result = transformer.transform("http://localhost:8080/trac");
 		assertEquals("[http, localhost, 8080, /trac, null]",
 				Arrays.toString(result));
@@ -73,7 +83,7 @@ public class UrlStandardizerTransformerTest extends TestCase {
 		result = transformer
 				.transform("http://eobjects.org/trac/ticket/395#comment:1");
 		assertEquals(
-				"[http, eobjects.org, null, /trac/ticket/395#comment:1, null]",
+				"[http, eobjects.org, null, /trac/ticket/395, null]",
 				Arrays.toString(result));
 
 		result = transformer.transform("http://localhost?string=hello%20world");
@@ -87,12 +97,13 @@ public class UrlStandardizerTransformerTest extends TestCase {
 				Arrays.toString(result));
 
 		result = transformer.transform("ftp://username@hostname/path");
-		assertEquals("[ftp, username@hostname, null, /path, null]",
+		assertEquals("[ftp, hostname, null, /path, null]",
 				Arrays.toString(result));
 	}
 
+	// Best effort
 	public void testInvalidUrls() throws Exception {
-		String[] result;
+		Object[] result;
 
 		// white space is not allowed
 		result = transformer
@@ -104,11 +115,11 @@ public class UrlStandardizerTransformerTest extends TestCase {
 		result = transformer
 				.transform("http://www.google.com;8080/search?q=eobjects");
 		assertEquals(5, result.length);
-		assertEquals("[null, null, null, null, null]", Arrays.toString(result));
+		assertEquals("[http, null, null, /search, q=eobjects]", Arrays.toString(result));
 	}
 
 	public void testTransformNull() throws Exception {
-		String[] result = transformer.transform((InputRow) new MockInputRow());
+		Object[] result = transformer.transform((InputRow) new MockInputRow());
 		assertEquals(5, result.length);
 		assertEquals("[null, null, null, null, null]", Arrays.toString(result));
 	}


### PR DESCRIPTION
This many issues with the standardizer, but also breaks compatibility a little bit, as it does not add username to host, or fragment to query. I did keep the a field with no path at all as null, as it is not technically filled. I had a bit of a hard time deciding here, so please comment if you disagree.

For the sake of not breaking jobs, the port number is kept a string even though that makes no sense.

Please note that I did a full-file reformat as it is only the same file in name and (intended) function.

 Fixes #1490