### PR TITLE
Many jobs at Monitor -- performance

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -42,7 +42,8 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 public interface SchedulingService extends RemoteService {
 
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
-    public List<ScheduleDefinition> getSchedules(TenantIdentifier tenant) throws DCSecurityException;
+    public List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, boolean loadProperties) 
+            throws DCSecurityException;
 
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     public ScheduleDefinition updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
@@ -35,7 +35,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
  */
 public interface SchedulingServiceAsync {
 
-    void getSchedules(TenantIdentifier tenant, AsyncCallback<List<ScheduleDefinition>> callback);
+    void getSchedules(TenantIdentifier tenant, boolean loadProperties, 
+            AsyncCallback<List<ScheduleDefinition>> callback);
 
     void updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition,
             AsyncCallback<ScheduleDefinition> callback);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
@@ -68,8 +68,8 @@ public class SchedulingServiceServlet extends SecureGwtServlet implements Schedu
     }
 
     @Override
-    public List<ScheduleDefinition> getSchedules(TenantIdentifier tenant) {
-        return _delegate.getSchedules(tenant);
+    public List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, boolean loadProperties) {
+        return _delegate.getSchedules(tenant, loadProperties);
     }
 
     @Override

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/listeners/JobModificationEventUpdateSchedulesListener.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/listeners/JobModificationEventUpdateSchedulesListener.java
@@ -59,7 +59,7 @@ public class JobModificationEventUpdateSchedulesListener implements ApplicationL
         final TenantIdentifier tenant = new TenantIdentifier(event.getTenant());
         _schedulingService.removeSchedule(tenant, new JobIdentifier(oldJobName));
         
-        final List<ScheduleDefinition> schedules = _schedulingService.getSchedules(tenant);
+        final List<ScheduleDefinition> schedules = _schedulingService.getSchedules(tenant, false);
         for (ScheduleDefinition schedule : schedules) {
             boolean update = false;
             if (schedule.getDependentJob() != null) {

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/SchedulingServiceImplIntegrationTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/SchedulingServiceImplIntegrationTest.java
@@ -142,7 +142,7 @@ public class SchedulingServiceImplIntegrationTest extends TestCase {
 
             final TenantIdentifier tenant = new TenantIdentifier("tenant1");
 
-            final List<ScheduleDefinition> schedules = service.getSchedules(tenant);
+            final List<ScheduleDefinition> schedules = service.getSchedules(tenant, true);
 
             // sort to make it deterministic
             Collections.sort(schedules);

--- a/monitor/ui/src/main/java/org/datacleaner/monitor/Scheduling.gwt.xml
+++ b/monitor/ui/src/main/java/org/datacleaner/monitor/Scheduling.gwt.xml
@@ -21,7 +21,8 @@
 
 -->
 <module rename-to='scheduling'>
-
+	<inherits name="com.google.gwt.logging.Logging"/>
+	
 	<inherits name="org.datacleaner.monitor.Widgets"/>
 
 	<entry-point class='org.datacleaner.monitor.scheduling.SchedulingEntryPoint' />

--- a/monitor/ui/src/main/webapp/scheduling.xhtml
+++ b/monitor/ui/src/main/webapp/scheduling.xhtml
@@ -45,11 +45,11 @@
 		<div id="SchedulingPage" class="container">
 			<h:panelGroup rendered="#{param['job_upload'] == 'Success'}">
 				<div class="alert alert-success">
-					File upload was successfull: #{param['job_filename'].replace("%2C", ", ")} 
+					File upload was successful: #{param['job_filename'].replace("%2C", ", ")} 
 				</div>
 			</h:panelGroup>
 			<h:panelGroup rendered="#{param['job_upload'] != null and param['job_upload'] != 'Success'}">
-				<div class="alert alert-danger">File upload was not successfull. </div>
+				<div class="alert alert-danger">File upload was not successful. </div>
 			</h:panelGroup>
 		
 			<c:if test="#{user.scheduleEditor}">

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
@@ -55,7 +55,7 @@ public class SchedulingOverviewPanel extends Composite {
     }
 
     public void initialize(final Runnable listener) {
-        _service.getSchedules(_clientConfig.getTenant(), new DCAsyncCallback<List<ScheduleDefinition>>() {
+        _service.getSchedules(_clientConfig.getTenant(), false, new DCAsyncCallback<List<ScheduleDefinition>>() {
             @Override
             public void onSuccess(List<ScheduleDefinition> result) {
 

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/wizard/JobWizardController.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/wizard/JobWizardController.java
@@ -194,7 +194,7 @@ public class JobWizardController extends AbstractWizardController<WizardServiceA
     }
 
     private void getSchedule(final Runnable runnable, final String jobName) {
-        schedulingService.getSchedules(getTenant(), new DCAsyncCallback<List<ScheduleDefinition>>() {
+        schedulingService.getSchedules(getTenant(), true, new DCAsyncCallback<List<ScheduleDefinition>>() {
             @Override
             public void onSuccess(List<ScheduleDefinition> result) {
                 for (ScheduleDefinition scheduleDefinition : result) {


### PR DESCRIPTION
Fixes #1501 

For Scheduling page (listing of jobs) I used lighter version of "getSchedules" where I omitted properties loading. It does not seem to be necessary just for listing and then simple actions (run, delete, show history, ...). 

Time of listing 1000 copies of a simple job was decreased from 26s to 9s. 