### PR TITLE
Find metrics from analyzers within outputdatastreams as well

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/AnalyzerJobHelper.java
+++ b/engine/core/src/main/java/org/datacleaner/job/AnalyzerJobHelper.java
@@ -19,11 +19,6 @@
  */
 package org.datacleaner.job;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.metamodel.util.Predicate;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.descriptors.ComponentDescriptor;
@@ -31,6 +26,12 @@ import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.util.CollectionUtils2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Helper class that wraps a collection of {@link AnalyzerJob}s and provides
@@ -48,7 +49,8 @@ public class AnalyzerJobHelper {
     }
 
     public AnalyzerJobHelper(AnalysisJob analysisJob) {
-        this(analysisJob.getAnalyzerJobs());
+        this(analysisJob.flattened().flatMap(analysisJob1 -> analysisJob1.getAnalyzerJobs().stream())
+                .collect(Collectors.toList()));
     }
 
     public Collection<AnalyzerJob> getAnalyzerJobs() {

--- a/engine/core/src/main/java/org/datacleaner/result/ListResult.java
+++ b/engine/core/src/main/java/org/datacleaner/result/ListResult.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.datacleaner.api.AnalyzerResult;
+import org.datacleaner.api.Metric;
 
 /**
  * A very simple AnalyzerResult that simply holds a list of values
@@ -64,5 +65,10 @@ public class ListResult<E> implements AnalyzerResult {
 			sb.append(value);
 		}
 		return sb.toString();
+	}
+
+	@Metric(order = 1, value = "Row count")
+	public int getTotalRowCount() {
+		return _values.size();
 	}
 }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
@@ -19,17 +19,8 @@
  */
 package org.datacleaner.monitor.server;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.el.ELContext;
-import javax.el.ExpressionFactory;
-import javax.el.ValueExpression;
-
+import de.odysseus.el.ExpressionFactoryImpl;
+import de.odysseus.el.util.SimpleContext;
 import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.HasNameMapper;
 import org.apache.metamodel.util.Predicate;
@@ -37,18 +28,8 @@ import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.AnalyzerResultFuture;
 import org.datacleaner.api.InputColumn;
 import org.datacleaner.beans.stringpattern.PatternFinderAnalyzer;
-import org.datacleaner.descriptors.ComponentDescriptor;
-import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
-import org.datacleaner.descriptors.Descriptors;
-import org.datacleaner.descriptors.HasAnalyzerResultComponentDescriptor;
-import org.datacleaner.descriptors.MetricDescriptor;
-import org.datacleaner.descriptors.MetricParameters;
-import org.datacleaner.descriptors.ResultDescriptor;
-import org.datacleaner.job.AnalysisJob;
-import org.datacleaner.job.AnalyzerJob;
-import org.datacleaner.job.AnalyzerJobHelper;
-import org.datacleaner.job.ComponentJob;
-import org.datacleaner.job.InputColumnSinkJob;
+import org.datacleaner.descriptors.*;
+import org.datacleaner.job.*;
 import org.datacleaner.monitor.job.MetricJobContext;
 import org.datacleaner.monitor.job.MetricJobEngine;
 import org.datacleaner.monitor.shared.model.MetricGroup;
@@ -60,8 +41,11 @@ import org.datacleaner.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.odysseus.el.ExpressionFactoryImpl;
-import de.odysseus.el.util.SimpleContext;
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class MetricValueUtils {
 
@@ -435,9 +419,9 @@ public class MetricValueUtils {
      */
     public List<MetricGroup> getMetricGroups(MetricJobContext jobContext, AnalysisJob analysisJob) {
         final List<MetricGroup> metricGroups = new ArrayList<>();
-        final List<AnalyzerJob> analyzerJobs =
-                analysisJob.flattened().flatMap(analysisJob1 -> analysisJob1.getAnalyzerJobs().stream())
-                        .collect(Collectors.toList());
+        final List<AnalyzerJob> analyzerJobs = analysisJob.flattened()
+                .flatMap(analysisJob1 -> analysisJob1.getAnalyzerJobs().stream()).collect(Collectors.toList());
+
         for (AnalyzerJob analyzerJob : analyzerJobs) {
             final Set<MetricDescriptor> metricDescriptors = analyzerJob.getDescriptor().getResultMetrics();
             final MetricGroup metricGroup = getMetricGroup(jobContext, analyzerJob, metricDescriptors);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/MetricValueUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.el.ELContext;
 import javax.el.ExpressionFactory;
@@ -433,9 +434,10 @@ public class MetricValueUtils {
      * @return
      */
     public List<MetricGroup> getMetricGroups(MetricJobContext jobContext, AnalysisJob analysisJob) {
-        final Collection<AnalyzerJob> analyzerJobs = analysisJob.getAnalyzerJobs();
-
-        final List<MetricGroup> metricGroups = new ArrayList<MetricGroup>();
+        final List<MetricGroup> metricGroups = new ArrayList<>();
+        final List<AnalyzerJob> analyzerJobs =
+                analysisJob.flattened().flatMap(analysisJob1 -> analysisJob1.getAnalyzerJobs().stream())
+                        .collect(Collectors.toList());
         for (AnalyzerJob analyzerJob : analyzerJobs) {
             final Set<MetricDescriptor> metricDescriptors = analyzerJob.getDescriptor().getResultMetrics();
             final MetricGroup metricGroup = getMetricGroup(jobContext, analyzerJob, metricDescriptors);

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/MetricValueUtilsTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/MetricValueUtilsTest.java
@@ -19,33 +19,15 @@
  */
 package org.datacleaner.monitor.server;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.metamodel.util.ImmutableRef;
-import org.datacleaner.api.AnalyzerResult;
-import org.datacleaner.api.AnalyzerResultFuture;
-import org.datacleaner.api.AnalyzerResultFutureImpl;
-import org.datacleaner.api.Metric;
-import org.datacleaner.api.OutputDataStream;
+import org.datacleaner.api.*;
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.DataCleanerConfigurationImpl;
-import org.datacleaner.configuration.DataCleanerEnvironment;
 import org.datacleaner.connection.Datastore;
 import org.datacleaner.data.MetaModelInputColumn;
-import org.datacleaner.descriptors.Descriptors;
-import org.datacleaner.descriptors.MetricDescriptor;
-import org.datacleaner.descriptors.MetricParameters;
-import org.datacleaner.descriptors.ResultDescriptor;
-import org.datacleaner.descriptors.SimpleDescriptorProvider;
+import org.datacleaner.descriptors.*;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.ComponentJob;
-import org.datacleaner.job.JaxbJobReader;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.monitor.job.MetricJobContext;
@@ -63,6 +45,12 @@ import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/MetricValueUtilsTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/MetricValueUtilsTest.java
@@ -19,9 +19,12 @@
  */
 package org.datacleaner.monitor.server;
 
-import static org.junit.Assert.assertEquals;
-
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.metamodel.util.ImmutableRef;
@@ -29,6 +32,12 @@ import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.AnalyzerResultFuture;
 import org.datacleaner.api.AnalyzerResultFutureImpl;
 import org.datacleaner.api.Metric;
+import org.datacleaner.api.OutputDataStream;
+import org.datacleaner.configuration.DataCleanerConfiguration;
+import org.datacleaner.configuration.DataCleanerConfigurationImpl;
+import org.datacleaner.configuration.DataCleanerEnvironment;
+import org.datacleaner.connection.Datastore;
+import org.datacleaner.data.MetaModelInputColumn;
 import org.datacleaner.descriptors.Descriptors;
 import org.datacleaner.descriptors.MetricDescriptor;
 import org.datacleaner.descriptors.MetricParameters;
@@ -36,17 +45,26 @@ import org.datacleaner.descriptors.ResultDescriptor;
 import org.datacleaner.descriptors.SimpleDescriptorProvider;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.ComponentJob;
+import org.datacleaner.job.JaxbJobReader;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.AnalyzerComponentBuilder;
 import org.datacleaner.monitor.job.MetricJobContext;
 import org.datacleaner.monitor.server.job.DataCleanerJobEngine;
+import org.datacleaner.monitor.shared.model.MetricGroup;
 import org.datacleaner.monitor.shared.model.MetricIdentifier;
 import org.datacleaner.result.AnalysisResult;
 import org.datacleaner.result.SimpleAnalysisResult;
+import org.datacleaner.test.MockAnalyzer;
+import org.datacleaner.test.MockOutputDataStreamAnalyzer;
+import org.datacleaner.test.TestHelper;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(EasyMockRunner.class)
 public class MetricValueUtilsTest extends EasyMockSupport {
@@ -126,5 +144,40 @@ public class MetricValueUtilsTest extends EasyMockSupport {
         assertEquals(7, value2);
 
         verifyAll();
+    }
+
+    @Test
+    public void testGetMetricGroupsFromAnalysisJob() throws URISyntaxException, FileNotFoundException {
+        final Datastore datastore = TestHelper.createSampleDatabaseDatastore("orderdb");
+        final DataCleanerConfiguration configuration = new DataCleanerConfigurationImpl().withDatastores(datastore);
+
+        try (final AnalysisJobBuilder ajb = new AnalysisJobBuilder(configuration)) {
+            ajb.setDatastore(datastore);
+
+            ajb.addSourceColumns("customers.contactfirstname");
+            ajb.addSourceColumns("customers.contactlastname");
+            ajb.addSourceColumns("customers.city");
+
+            final AnalyzerComponentBuilder<MockOutputDataStreamAnalyzer> analyzer1 = ajb
+                    .addAnalyzer(MockOutputDataStreamAnalyzer.class);
+
+            final List<MetaModelInputColumn> sourceColumns = ajb.getSourceColumns();
+            analyzer1.setName("analyzer1");
+            analyzer1.addInputColumn(sourceColumns.get(0));
+            final OutputDataStream outputDataStream = analyzer1.getOutputDataStreams().get(0);
+            final AnalysisJobBuilder outputDataStreamJobBuilder =
+                    analyzer1.getOutputDataStreamJobBuilder(outputDataStream);
+            final List<MetaModelInputColumn> outputDataStreamColumns = outputDataStreamJobBuilder.getSourceColumns();
+
+
+            final AnalyzerComponentBuilder<MockAnalyzer> analyzer2 = outputDataStreamJobBuilder
+                    .addAnalyzer(MockAnalyzer.class);
+            analyzer2.addInputColumns(outputDataStreamColumns);
+            analyzer2.setName("analyzer2");
+
+            final MetricValueUtils metricValueUtils = new MetricValueUtils();
+            final List<MetricGroup> metricGroups = metricValueUtils.getMetricGroups(jobContext, ajb.toAnalysisJob());
+            assertEquals(2, metricGroups.size()); // One from each analyzer
+        }
     }
 }

--- a/monitor/services/src/test/resources/multiscope.analysis.xml
+++ b/monitor/services/src/test/resources/multiscope.analysis.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<job xmlns="http://eobjects.org/analyzerbeans/job/1.0">
+    <job-metadata>
+        <job-description>Created with DataCleaner Enterprise edition 5.1.3</job-description>
+        <author>dennisd</author>
+        <updated-date>2016-09-20+02:00</updated-date>
+        <metadata-properties>
+            <property name="CoordinatesX.PUBLIC.CUSTOMERS">91</property>
+            <property name="CoordinatesY.PUBLIC.CUSTOMERS">96</property>
+        </metadata-properties>
+    </job-metadata>
+    <source>
+        <data-context ref="orderdb"/>
+        <columns>
+            <column id="col_customernumber" path="CUSTOMERS.CUSTOMERNUMBER" type="INTEGER"/>
+            <column id="col_customername" path="CUSTOMERS.CUSTOMERNAME" type="VARCHAR"/>
+            <column id="col_contactlastname" path="CUSTOMERS.CONTACTLASTNAME" type="VARCHAR"/>
+            <column id="col_contactfirstname" path="CUSTOMERS.CONTACTFIRSTNAME" type="VARCHAR"/>
+            <column id="col_phone" path="CUSTOMERS.PHONE" type="VARCHAR"/>
+            <column id="col_addressline1" path="CUSTOMERS.ADDRESSLINE1" type="VARCHAR"/>
+            <column id="col_addressline2" path="CUSTOMERS.ADDRESSLINE2" type="VARCHAR"/>
+            <column id="col_city" path="CUSTOMERS.CITY" type="VARCHAR"/>
+            <column id="col_state" path="CUSTOMERS.STATE" type="VARCHAR"/>
+            <column id="col_postalcode" path="CUSTOMERS.POSTALCODE" type="VARCHAR"/>
+            <column id="col_country" path="CUSTOMERS.COUNTRY" type="VARCHAR"/>
+            <column id="col_salesrepemployeenumber" path="CUSTOMERS.SALESREPEMPLOYEENUMBER" type="INTEGER"/>
+            <column id="col_creditlimit" path="CUSTOMERS.CREDITLIMIT" type="NUMERIC"/>
+            <column id="col_jobtitle" path="CUSTOMERS.JOBTITLE" type="VARCHAR"/>
+        </columns>
+    </source>
+    <transformation/>
+    <analysis>
+        <analyzer>
+            <descriptor ref="Completeness analyzer"/>
+            <metadata-properties>
+                <property name="CoordinatesY">156</property>
+                <property name="CoordinatesX">233</property>
+            </metadata-properties>
+            <properties>
+                <property name="Conditions" value="[NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL,NOT_BLANK_OR_NULL]"/>
+                <property name="Evaluation mode" value="ANY_FIELD"/>
+            </properties>
+            <input ref="col_addressline1" name="Values"/>
+            <input ref="col_city" name="Values"/>
+            <input ref="col_postalcode" name="Values"/>
+            <input ref="col_country" name="Values"/>
+            <output-data-stream name="Incomplete rows">
+                <job>
+                    <source>
+                        <columns>
+                            <column id="col_addressline12" path="ADDRESSLINE1" type="VARCHAR"/>
+                            <column id="col_city2" path="CITY" type="VARCHAR"/>
+                            <column id="col_postalcode2" path="POSTALCODE" type="VARCHAR"/>
+                            <column id="col_country2" path="COUNTRY" type="VARCHAR"/>
+                        </columns>
+                    </source>
+                    <transformation/>
+                    <analysis>
+                        <analyzer>
+                            <descriptor ref="Value distribution"/>
+                            <metadata-properties>
+<property name="CoordinatesY">234</property>
+<property name="CoordinatesX">414</property>
+                            </metadata-properties>
+                            <properties>
+<property name="Record unique values" value="true"/>
+<property name="Record drill-down information" value="true"/>
+<property name="Top n most frequent values" value="&lt;null&gt;"/>
+<property name="Bottom n most frequent values" value="&lt;null&gt;"/>
+                            </properties>
+                            <input ref="col_country2" name="Column"/>
+                        </analyzer>
+                    </analysis>
+                </job>
+            </output-data-stream>
+        </analyzer>
+    </analysis>
+</job>

--- a/testware/src/main/java/org/datacleaner/result/ListResult.java
+++ b/testware/src/main/java/org/datacleaner/result/ListResult.java
@@ -22,6 +22,7 @@ package org.datacleaner.result;
 import java.util.List;
 
 import org.datacleaner.api.AnalyzerResult;
+import org.datacleaner.api.Metric;
 
 /**
  * A very simple AnalyzerResult that simply holds a list of values
@@ -54,5 +55,10 @@ public class ListResult<E> implements AnalyzerResult {
 			sb.append(value);
 		}
 		return sb.toString();
+	}
+
+	@Metric(order = 1, value = "Row count")
+	public int getTotalRowCount() {
+		return _values.size();
 	}
 }


### PR DESCRIPTION
This will make it possible to add timeline metrics for analyzers from all scopes, not just those in the root scope.

Fixes #1437 