### PR TITLE
Use proper AnalysisJob and column names for union

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingPublisher.java
+++ b/engine/core/src/main/java/org/datacleaner/job/runner/AbstractRowProcessingPublisher.java
@@ -162,8 +162,7 @@ public abstract class AbstractRowProcessingPublisher implements RowProcessingPub
 
         for (RowProcessingConsumer consumer : getConsumers()) {
             final ComponentJob componentJob = consumer.getComponentJob();
-            final RowProcessingMetrics rowProcessingMetrics = getRowProcessingMetrics();
-            final ComponentMetrics metrics = rowProcessingMetrics.getAnalysisJobMetrics()
+            final ComponentMetrics metrics = new AnalysisJobMetricsImpl(consumer.getAnalysisJob(), publishers)
                     .getComponentMetrics(componentJob);
             analysisListener.componentBegin(getStream().getAnalysisJob(), componentJob, metrics);
 

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -971,7 +971,12 @@ public class JaxbJobReader implements JobReader<InputStream> {
                                     final String path = getPath(columnsTypes, column_id);
                                     if (oldColumn.contains('.' + path)) {
                                         // add the mapped column.
-                                        newInputColumns.add(entry.getValue().getName());
+                                        final InputColumn<?> entryValue = entry.getValue();
+                                        if(entryValue.isPhysicalColumn()) {
+                                            newInputColumns.add(entryValue.getPhysicalColumn().getQualifiedLabel());
+                                        } else {
+                                            newInputColumns.add(entryValue.getName());
+                                        }
                                         found = true;
                                         break;
                                     }

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -524,7 +524,7 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("PUBLIC.CUSTOMERS.CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
         assertEquals("CONTACTLASTNAME (Upper case)", units[0].getInputColumnNames()[1]);
     }
 
@@ -544,10 +544,10 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
-        assertEquals("CONTACTFIRSTNAME", units[0].getInputColumnNames()[1]);
-        assertEquals("PHONE", units[1].getInputColumnNames()[0]);
-        assertEquals("CITY", units[1].getInputColumnNames()[1]);
+        assertEquals("PUBLIC.CUSTOMERS.CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("PUBLIC.CUSTOMERS.CONTACTFIRSTNAME", units[0].getInputColumnNames()[1]);
+        assertEquals("PUBLIC.CUSTOMERS.PHONE", units[1].getInputColumnNames()[0]);
+        assertEquals("PUBLIC.CUSTOMERS.CITY", units[1].getInputColumnNames()[1]);
     }
 
     public void testUnionJob() throws Exception {
@@ -567,11 +567,11 @@ public class JaxbJobReaderTest extends TestCase {
                 .getConfiguredProperty("Units");
         final CoalesceUnit[] units = (CoalesceUnit[]) componentBuilder.getConfiguredProperty(
                 configuredPropertyDescriptor);
-        assertEquals("CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
-        assertEquals("LASTNAME", units[0].getInputColumnNames()[1]);
+        assertEquals("PUBLIC.CUSTOMERS.CONTACTLASTNAME", units[0].getInputColumnNames()[0]);
+        assertEquals("PUBLIC.EMPLOYEES.LASTNAME", units[0].getInputColumnNames()[1]);
         assertEquals("CONTACTLASTNAME", units[0].getSuggestedOutputColumnName());
-        assertEquals("CONTACTFIRSTNAME", units[1].getInputColumnNames()[0]);
-        assertEquals("FIRSTNAME", units[1].getInputColumnNames()[1]);
+        assertEquals("PUBLIC.CUSTOMERS.CONTACTFIRSTNAME", units[1].getInputColumnNames()[0]);
+        assertEquals("PUBLIC.EMPLOYEES.FIRSTNAME", units[1].getInputColumnNames()[1]);
         assertEquals("CONTACTFIRSTNAME", units[1].getSuggestedOutputColumnName());
 
         final List<OutputDataStream> outputDataStreams = componentBuilder.getOutputDataStreams();


### PR DESCRIPTION
The Union component was pretty badly broken; Components down the line would render metrics using the outer scope's AnalysisJob, and columns with the same not from different tables would end up in the wrong table when job was loaded. This should fix both issues.

Fixes #1540