### PR TITLE
Bug/1534 execution history fails sample jobs

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -88,7 +88,7 @@ public interface SchedulingService extends RemoteService {
      */
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
     public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job)
-            throws DCSecurityException;
+            throws DCSecurityException, IllegalStateException;
 
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     public List<JobIdentifier> getDependentJobCandidates(TenantIdentifier tenant, ScheduleDefinition schedule)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -90,7 +90,7 @@ public interface SchedulingService extends RemoteService {
      */
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
     public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job)
-            throws DCSecurityException, IllegalStateException, FileNotFoundException;
+            throws DCSecurityException, IllegalStateException;
 
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     public List<JobIdentifier> getDependentJobCandidates(TenantIdentifier tenant, ScheduleDefinition schedule)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.monitor.scheduling;
 
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map;
 
@@ -85,10 +86,11 @@ public interface SchedulingService extends RemoteService {
 
     /**
      * Gets all executions of a particular job.
+     * @throws FileNotFoundException 
      */
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
     public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job)
-            throws DCSecurityException, IllegalStateException;
+            throws DCSecurityException, IllegalStateException, FileNotFoundException;
 
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     public List<JobIdentifier> getDependentJobCandidates(TenantIdentifier tenant, ScheduleDefinition schedule)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -681,7 +681,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         final RepositoryFile file = resultFolder.getFile(resultId + FileFilters.ANALYSIS_EXECUTION_LOG_XML
                 .getExtension());
         if (file == null) {
-            throw new IllegalArgumentException("No execution with result id: " + resultId);
+            logger.error("No execution with result id: " + resultId);
+            return null;
         }
 
         JobIdentifier jobIdentifier = JobIdentifier.fromExecutionIdentifier(executionIdentifier);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -650,8 +650,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                                 try {
                                     return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
                                 } catch (Exception e) {
-                                    logger.warn("The file " + file.getQualifiedPath() +" could not be read" + e);
-                                    return new ExecutionIdentifier(FilenameUtils.getBaseName(file.getQualifiedPath()));
+                                    logger.warn("The file " + file.getQualifiedPath() +" could not be read or parsed correctly" + e);
+                                    return new ExecutionIdentifier("Execution failed for " + FilenameUtils.getBaseName(file.getQualifiedPath()));
                                 }
                             }
                         });

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -20,6 +20,7 @@
 package org.datacleaner.monitor.server;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -634,7 +635,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     @Override
-    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws IllegalStateException {
+    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws IllegalStateException, FileNotFoundException {
         final TenantContext tenantContext = _tenantContextFactory.getContext(tenant);
         final RepositoryFolder resultFolder = tenantContext.getResultFolder();
         final List<RepositoryFile> files = resultFolder.getFiles(job.getName(), FileFilters.ANALYSIS_EXECUTION_LOG_XML

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -645,16 +645,17 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                     @Override
                     public ExecutionIdentifier eval(final RepositoryFile file) {
                         try {
-                            ExecutionIdentifier result = file.readFile(new Func<InputStream, ExecutionIdentifier>() {
-                                @Override
-                                public ExecutionIdentifier eval(InputStream in) {
-                                    return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
-                                }
-                            });
+                            final ExecutionIdentifier result = file.readFile(
+                                    new Func<InputStream, ExecutionIdentifier>() {
+                                        @Override
+                                        public ExecutionIdentifier eval(InputStream in) {
+                                            return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
+                                        }
+                                    });
                             return result;
                         } catch (Exception e) {
-                            logger.warn("The file " + file.getQualifiedPath() + " could not be read or parsed correctly"
-                                    + e);
+                            logger.warn("The file " + file.getQualifiedPath()
+                                    + " could not be read or parsed correctly " + e);
                             return new ExecutionIdentifier("Execution failed for " + FilenameUtils.getBaseName(file
                                     .getQualifiedPath()));
                         }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -634,7 +634,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     @Override
-    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) {
+    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws IllegalStateException {
         final TenantContext tenantContext = _tenantContextFactory.getContext(tenant);
         final RepositoryFolder resultFolder = tenantContext.getResultFolder();
         final List<RepositoryFile> files = resultFolder.getFiles(job.getName(), FileFilters.ANALYSIS_EXECUTION_LOG_XML

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -647,7 +647,12 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                         ExecutionIdentifier result = file.readFile(new Func<InputStream, ExecutionIdentifier>() {
                             @Override
                             public ExecutionIdentifier eval(InputStream in) {
-                                return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
+                                try {
+                                    return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
+                                } catch (Exception e) {
+                                    logger.error("The file {} could not be read" + e, file.getQualifiedPath());
+                                    return new ExecutionIdentifier(FilenameUtils.getBaseName(file.getQualifiedPath()));
+                                }
                             }
                         });
                         return result;

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -650,7 +650,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
                                 try {
                                     return SaxExecutionIdentifierReader.read(in, file.getQualifiedPath());
                                 } catch (Exception e) {
-                                    logger.error("The file {} could not be read" + e, file.getQualifiedPath());
+                                    logger.warn("The file " + file.getQualifiedPath() +" could not be read" + e);
                                     return new ExecutionIdentifier(FilenameUtils.getBaseName(file.getQualifiedPath()));
                                 }
                             }
@@ -681,7 +681,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         final RepositoryFile file = resultFolder.getFile(resultId + FileFilters.ANALYSIS_EXECUTION_LOG_XML
                 .getExtension());
         if (file == null) {
-            logger.error("No execution with result id: " + resultId);
+            logger.warn("No execution with result id: " + resultId);
             return null;
         }
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.monitor.server;
 
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +79,7 @@ public class SchedulingServiceServlet extends SecureGwtServlet implements Schedu
     }
 
     @Override
-    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) {
+    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws DCSecurityException, IllegalStateException, FileNotFoundException {
         return _delegate.getAllExecutions(tenant, job);
     }
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
@@ -19,7 +19,6 @@
  */
 package org.datacleaner.monitor.server;
 
-import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map;
 
@@ -79,7 +78,7 @@ public class SchedulingServiceServlet extends SecureGwtServlet implements Schedu
     }
 
     @Override
-    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws DCSecurityException, IllegalStateException, FileNotFoundException {
+    public List<ExecutionIdentifier> getAllExecutions(TenantIdentifier tenant, JobIdentifier job) throws DCSecurityException, IllegalStateException {
         return _delegate.getAllExecutions(tenant, job);
     }
 


### PR DESCRIPTION

The changes handle the situation when 

- Execution log is not readable:  the log is empty because the job was interrupted
- There is an execution log, but no execution result file because the job ended prematurely

Fixes #1534 