### PR TITLE
Allow all non-file datastore in isValidSourceDatastore()

### DIFF
--- a/engine/env/spark/src/main/java/org/datacleaner/spark/utils/HadoopJobExecutionUtils.java
+++ b/engine/env/spark/src/main/java/org/datacleaner/spark/utils/HadoopJobExecutionUtils.java
@@ -37,6 +37,7 @@ import org.datacleaner.configuration.DomConfigurationWriter;
 import org.datacleaner.configuration.RemoteServerData;
 import org.datacleaner.connection.CsvDatastore;
 import org.datacleaner.connection.Datastore;
+import org.datacleaner.connection.FileDatastore;
 import org.datacleaner.connection.FixedWidthDatastore;
 import org.datacleaner.connection.JsonDatastore;
 import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
@@ -60,6 +61,12 @@ import com.google.common.collect.Iterators;
 public class HadoopJobExecutionUtils {
 
     public static boolean isValidSourceDatastore(Datastore datastore) {
+        if(!(datastore instanceof FileDatastore)) {
+            // Most types of non-filebased datastore should work given the right configuration.
+            // Or at least, we have no sure-fire way to rule them out.
+            return true;
+        }
+
         if (isHdfsResourcedDatastore(datastore)) {
             if (datastore instanceof CsvDatastore) {
                 final CsvDatastore csvDatastore = (CsvDatastore) datastore;

--- a/engine/env/spark/src/test/java/org/datacleaner/spark/HadoopConfigurationUtilsTest.java
+++ b/engine/env/spark/src/test/java/org/datacleaner/spark/HadoopConfigurationUtilsTest.java
@@ -19,15 +19,19 @@
  */
 package org.datacleaner.spark;
 
+import java.io.File;
+
 import org.apache.metamodel.csv.CsvConfiguration;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.HdfsResource;
 import org.datacleaner.connection.CsvDatastore;
+import org.datacleaner.connection.Datastore;
 import org.datacleaner.connection.ExcelDatastore;
 import org.datacleaner.connection.FixedWidthDatastore;
 import org.datacleaner.connection.JsonDatastore;
 import org.datacleaner.connection.Neo4jDatastore;
+import org.datacleaner.connection.SasDatastore;
 import org.datacleaner.spark.utils.HadoopJobExecutionUtils;
 import org.junit.Test;
 
@@ -64,10 +68,10 @@ public class HadoopConfigurationUtilsTest extends TestCase{
     
     @Test
     public void testInvalidDatastore(){
-        final ExcelDatastore excelDatastore = new ExcelDatastore("MyTest", new FileResource("C://test"), "Test");
+        final Datastore excelDatastore = new ExcelDatastore("MyTest", new FileResource("C://test"), "Test");
         assertFalse(HadoopJobExecutionUtils.isValidSourceDatastore(excelDatastore)); 
-        final Neo4jDatastore neo4jDatastore = new Neo4jDatastore("neo", "localhost", "me", "password"); 
-        assertFalse(HadoopJobExecutionUtils.isValidSourceDatastore(neo4jDatastore));
+        final Datastore sasDatastore = new SasDatastore("sas", new File(File.pathSeparator));
+        assertFalse(HadoopJobExecutionUtils.isValidSourceDatastore(sasDatastore));
     }
 
     public void testFixedWidthDatastore() {


### PR DESCRIPTION
This should allow most datastores we can't rule out to work. Will also make the running from GUI a little less fool-proof, but that's the lesser of two evils

Fixes #1549