### PR TITLE
#1499 DCPopupPanel dialog's width was extended

### DIFF
--- a/monitor/ui/src/main/java/org/datacleaner/monitor/dashboard/widgets/DrillToProfilingResultSelectHandler.java
+++ b/monitor/ui/src/main/java/org/datacleaner/monitor/dashboard/widgets/DrillToProfilingResultSelectHandler.java
@@ -110,6 +110,7 @@ public class DrillToProfilingResultSelectHandler {
         _popup.addButton(showResultButton);
         _popup.addButton(showResultFullPageButton);
         _popup.addButton(new CancelPopupButton(_popup));
+        _popup.setWidth("900px");
         _popup.center();
         _popup.show();
     }

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/resources/shared.css
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/resources/shared.css
@@ -117,7 +117,7 @@
  * General purpose style modifiers
  */
 .DCPopupPanel {
-	max-width: 800px;
+	max-width: 950px;
 }
 
 .dateBoxPopup, .gwt-SuggestBoxPopup {


### PR DESCRIPTION
Fixes #1499 

DCPopupPanel's width was extended from 800px to 950px because of the overflowing text in "Inspect profiling result". 

![950px](https://cloud.githubusercontent.com/assets/13213915/19314557/dcae887e-909a-11e6-8e67-a200494e6669.png)
