### PR TITLE
Set a minimum size for dialogs

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
@@ -22,6 +22,7 @@ package org.datacleaner.windows;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -196,6 +197,8 @@ public abstract class AbstractDialog extends JDialog implements DCWindow, Window
 
         panel.setPreferredSize(getDialogWidth(),
                 bannerHeight + dialogContent.getPreferredSize().height + getDialogHeightBuffer());
+
+        setMinimumSize(new Dimension(getDialogWidth(), 200));
 
         return panel;
     }

--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
@@ -198,7 +198,7 @@ public abstract class AbstractDialog extends JDialog implements DCWindow, Window
         panel.setPreferredSize(getDialogWidth(),
                 bannerHeight + dialogContent.getPreferredSize().height + getDialogHeightBuffer());
 
-        setMinimumSize(new Dimension(getDialogWidth(), 200));
+        setMinimumSize(new Dimension(getDialogWidth(), 300));
 
         return panel;
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/DCFileChooser.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/DCFileChooser.java
@@ -23,9 +23,11 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.HeadlessException;
 import java.io.File;
 
 import javax.swing.Icon;
+import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JScrollPane;
 
@@ -55,7 +57,6 @@ public class DCFileChooser extends JFileChooser {
     public DCFileChooser(File dir) {
         super(dir);
         setPreferredSize(new Dimension(600, 550));
-        setMinimumSize(new Dimension(400,400));
         setFilePaneBackground(WidgetUtils.BG_COLOR_BRIGHTEST);
         setAcceptAllFileFilterUsed(false);
     }
@@ -91,6 +92,13 @@ public class DCFileChooser extends JFileChooser {
             }
         }
         component.setBackground(bg);
+    }
+
+    @Override
+    protected JDialog createDialog(final Component parent) throws HeadlessException {
+        JDialog dialog = super.createDialog(parent);
+        dialog.setMinimumSize(new Dimension(400,400));
+        return dialog;
     }
 
     public FileObject getSelectedFileObject() {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/DCFileChooser.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/DCFileChooser.java
@@ -55,6 +55,7 @@ public class DCFileChooser extends JFileChooser {
     public DCFileChooser(File dir) {
         super(dir);
         setPreferredSize(new Dimension(600, 550));
+        setMinimumSize(new Dimension(400,400));
         setFilePaneBackground(WidgetUtils.BG_COLOR_BRIGHTEST);
         setAcceptAllFileFilterUsed(false);
     }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AboutDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AboutDialog.java
@@ -107,7 +107,7 @@ public class AboutDialog extends AbstractDialog {
 
     @Override
     protected boolean isWindowResizable() {
-        return true;
+        return false;
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AboutDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AboutDialog.java
@@ -102,12 +102,12 @@ public class AboutDialog extends AbstractDialog {
 
     @Override
     protected int getDialogWidth() {
-        return 600;
+        return 650;
     }
 
     @Override
     protected boolean isWindowResizable() {
-        return false;
+        return true;
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -22,6 +22,7 @@ package org.datacleaner.windows;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Cursor;
+import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowEvent;
@@ -323,6 +324,8 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         _userPreferences = userPreferences;
         _windowSizePreference = new WindowSizePreferences(_userPreferences, getClass(), DEFAULT_WINDOW_WIDTH,
                 DEFAULT_WINDOW_HEIGHT);
+
+        setMinimumSize(new Dimension(900, 550));
 
         if (analysisJobBuilder == null) {
             _analysisJobBuilder = new AnalysisJobBuilder(_configuration);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
@@ -20,6 +20,7 @@
 package org.datacleaner.windows;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
@@ -84,6 +85,7 @@ public class OptionsDialog extends AbstractWindow {
             UserPreferences userPreferences, DatabaseDriversPanel databaseDriversPanel,
             ExtensionPackagesPanel extensionPackagesPanel, HadoopClustersOptionsPanel hadoopClustersOptionsPanel) {
         super(windowContext);
+        setMinimumSize(new Dimension(500,500));
         _userPreferences = userPreferences;
         _configuration = configuration;
         _tabbedPane = new CloseableTabbedPane(true);
@@ -363,6 +365,7 @@ public class OptionsDialog extends AbstractWindow {
         panel.add(_tabbedPane, BorderLayout.CENTER);
         panel.add(buttonPanel, BorderLayout.SOUTH);
         panel.setPreferredSize(700, 500);
+
         return panel;
     }
 


### PR DESCRIPTION
Currently uses the result of getDialogWidth, which might be too wide in some instances, though I haven't seen any yet.

Fixes #1519