### PR TITLE
Added caches to SourceColumnFinder to prevent unneccesary recursion

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/SourceColumnFinder.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SourceColumnFinder.java
@@ -47,8 +47,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Helper class for traversing dependencies between virtual and physical
- * columns.
+ * Helper class for traversing dependencies between virtual and physical columns.
+ *
+ * For performance reasons this class stores found sources in an internal cache. As there is no mechanism to
+ * invalidate or refresh this cache, instances of this class should not be assigned to fields of other
+ * classes.
  */
 public class SourceColumnFinder {
 

--- a/engine/core/src/main/java/org/datacleaner/util/SourceColumnFinder.java
+++ b/engine/core/src/main/java/org/datacleaner/util/SourceColumnFinder.java
@@ -61,8 +61,8 @@ public class SourceColumnFinder {
     private Set<HasFilterOutcomes> _outcomeSources = new HashSet<HasFilterOutcomes>();
     private Set<HasComponentRequirement> _outcomeSinks = new HashSet<HasComponentRequirement>();
 
-    private Map<InputColumn<?>, Set<Column>> originatingColumnsOfInputColumnCache = new HashMap<>();
-    private Map<Object, Set<Column>> originatingColumnsOfSourceCache = new HashMap<>();
+    private final Map<InputColumn<?>, Set<Column>> originatingColumnsOfInputColumnCache = new HashMap<>();
+    private final Map<Object, Set<Column>> originatingColumnsOfSourceCache = new HashMap<>();
 
     private void addSources(Object... sources) {
         for (Object source : sources) {
@@ -297,7 +297,7 @@ public class SourceColumnFinder {
             return cachedOriginatingColumns;
         }
 
-        Set<Column> originatingColumns = new HashSet<>();
+        final Set<Column> originatingColumns = new HashSet<>();
 
         if (inputColumn != null) {
             if (inputColumn.isPhysicalColumn()) {
@@ -325,7 +325,7 @@ public class SourceColumnFinder {
             return cachedOriginatingColumns;
         }
 
-        Set<Column> originatingColumns = new HashSet<>();
+        final Set<Column> originatingColumns = new HashSet<>();
 
         if (source != null) {
             if (source instanceof InputColumnSinkJob) {


### PR DESCRIPTION
Fixes #1552.

When a job is executed the RowProcessingPublishers class partitions the job into RowProcessingPublishers, part of this is registering the job on a RowProcessingPublishers object. When doing this it uses a SourceColumnFinder to register the relevant columns to a RowProcessingPublishers object. On the SourceColumnFinder the findOriginatingColumns is invoked which goes into a recursion to determine which columns in a job are the "origin" of a given column. The more components the job has the more often this is caused and the deeper the recursion gets.

This pull request fixes this by putting objects for which the originating Columns have been found into an internal cache on the SourceColumnFinder so they don't have to be retrieved more than once. 

I also refactored the signature of some of the internal methods a bit to make this possible. A set was passed on to store the results in, but that made it hard for me to add a result to a cache at some moment.