### PR TITLE
Bug/153 multiple mapped input columns property

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/writers/CustomHeaderColumnNamesAnalyzerJobPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/writers/CustomHeaderColumnNamesAnalyzerJobPanel.java
@@ -55,8 +55,7 @@ public class CustomHeaderColumnNamesAnalyzerJobPanel extends AnalyzerComponentBu
 
             @Override
             public void onConfigurationChanged(final AnalyzerComponentBuilder<?> builder) {
-                _mappedWidget.onConfigurationChanged(null);
-                updateFields();
+                _mappedWidget.updateMappedStrings();
             }
 
             @Override
@@ -79,27 +78,9 @@ public class CustomHeaderColumnNamesAnalyzerJobPanel extends AnalyzerComponentBu
     
     @Override
     protected void onConfigurationChanged() {
-        updateFields();
+        _mappedWidget.updateMappedStrings();
     }
     
-    private void updateFields() {
-        if (_mappedWidget == null) {
-            return;
-        }
-        
-        final InputColumn<?>[] columns = _mappedWidget.getValue();
-        final String[] newFields = new String[columns.length];
-        
-        for (int i = 0; i < columns.length; i++) {
-            newFields[i] = columns[i].getName();
-        }
-        
-        if (newFields.length > 0) {
-            _mappedWidget.setMappedStrings(newFields);
-            _mappedWidget.fireValueChanged();
-        }
-    }
-
     @Override
     protected PropertyWidget<?> createPropertyWidget(ComponentBuilder componentBuilder,
             ConfiguredPropertyDescriptor propertyDescriptor) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedStringsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedStringsPropertyWidget.java
@@ -210,15 +210,12 @@ public class MultipleMappedStringsPropertyWidget extends MultipleInputColumnsPro
             return;
         }
         
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                _alreadyUpdating = true;
-                onConfigurationChanged(null);
-                setMappedStrings(null);
-                _mappedStringsPropertyWidget.fireValueChanged();
-                _alreadyUpdating = false;
-            }
+        SwingUtilities.invokeLater(() -> {
+            _alreadyUpdating = true;
+            onConfigurationChanged(null);
+            setMappedStrings(null);
+            _mappedStringsPropertyWidget.fireValueChanged();
+            _alreadyUpdating = false;
         });
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedStringsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedStringsPropertyWidget.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.WeakHashMap;
 
 import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 
 import org.datacleaner.api.InputColumn;
@@ -44,6 +45,7 @@ import org.jdesktop.swingx.JXTextField;
  * fields.
  */
 public class MultipleMappedStringsPropertyWidget extends MultipleInputColumnsPropertyWidget {
+    private transient boolean _alreadyUpdating = false;
 
     public class MappedStringsPropertyWidget extends MinimalPropertyWidget<String[]> {
 
@@ -137,11 +139,7 @@ public class MultipleMappedStringsPropertyWidget extends MultipleInputColumnsPro
         textField.getDocument().addDocumentListener(new DCDocumentListener() {
             @Override
             protected void onChange(DocumentEvent event) {
-                if (isBatchUpdating()) {
-                    return;
-                }
-                fireValueChanged();
-                _mappedStringsPropertyWidget.fireValueChanged();
+                updateMappedStrings();
             }
         });
         return textField;
@@ -173,16 +171,7 @@ public class MultipleMappedStringsPropertyWidget extends MultipleInputColumnsPro
                 updateUI();
             }
         });
-        checkBox.addListener(new DCCheckBox.Listener<InputColumn<?>>() {
-            @Override
-            public void onItemSelected(InputColumn<?> item, boolean selected) {
-                if (isBatchUpdating()) {
-                    return;
-                }
-                _mappedStringsPropertyWidget.fireValueChanged();
-            }
-        });
-
+        checkBox.addListener((item, selected) -> updateMappedStrings());
         textField.setVisible(checkBox.isSelected());
 
         final DCPanel panel = new DCPanel();
@@ -214,6 +203,23 @@ public class MultipleMappedStringsPropertyWidget extends MultipleInputColumnsPro
             }
         }
         return result.toArray(new InputColumn[result.size()]);
+    }
+    
+    public void updateMappedStrings() {
+        if (_alreadyUpdating) {
+            return;
+        }
+        
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                _alreadyUpdating = true;
+                onConfigurationChanged(null);
+                setMappedStrings(null);
+                _mappedStringsPropertyWidget.fireValueChanged();
+                _alreadyUpdating = false;
+            }
+        });
     }
 
     public void setMappedStrings(String[] value) {


### PR DESCRIPTION
Fixes https://github.com/NCIM/datacleaner-commercial-editions/issues/153

MultipleMappedInputColumnsPropertyWidget was not updated correctly when a component (which columns were used in the widget) was removed from the graph. 