### PR TITLE
Bug/302 filter pattern values not updated in job

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/DictionaryListPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DictionaryListPanel.java
@@ -39,8 +39,8 @@ import org.datacleaner.reference.DatastoreDictionary;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.reference.SimpleDictionary;
 import org.datacleaner.reference.TextFileDictionary;
-import org.datacleaner.user.DictionaryChangeListener;
 import org.datacleaner.user.MutableReferenceDataCatalog;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.WidgetFactory;
@@ -56,7 +56,7 @@ import org.jdesktop.swingx.VerticalLayout;
 
 import com.google.inject.Injector;
 
-public class DictionaryListPanel extends DCPanel implements DictionaryChangeListener {
+public class DictionaryListPanel extends DCPanel implements ReferenceDataChangeListener<Dictionary> {
 
     private static final long serialVersionUID = 1L;
 
@@ -262,27 +262,22 @@ public class DictionaryListPanel extends DCPanel implements DictionaryChangeList
 
     @Override
     public void onAdd(Dictionary dictionary) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                updateComponents();
-            }
-        });
+        SwingUtilities.invokeLater(() -> updateComponents());
     }
 
     @Override
     public void onRemove(Dictionary dictionary) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                updateComponents();
-            }
-        });
+        SwingUtilities.invokeLater(() -> updateComponents());
     }
 
     @Override
     public void removeNotify() {
         super.removeNotify();
         _catalog.removeDictionaryListener(this);
+    }
+
+    @Override
+    public void onChange(Dictionary oldPattern, Dictionary newPattern) {
+        SwingUtilities.invokeLater(() -> updateComponents());
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/panels/DictionaryListPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/DictionaryListPanel.java
@@ -104,8 +104,8 @@ public class DictionaryListPanel extends DCPanel implements ReferenceDataChangeL
         textFileDictionaryButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                Injector injector = _injectorBuilder.with(TextFileDictionary.class, null).createInjector();
-                TextFileDictionaryDialog dialog = injector.getInstance(TextFileDictionaryDialog.class);
+                final Injector injector = _injectorBuilder.with(TextFileDictionary.class, null).createInjector();
+                final TextFileDictionaryDialog dialog = injector.getInstance(TextFileDictionaryDialog.class);
                 dialog.open();
             }
         });
@@ -115,8 +115,8 @@ public class DictionaryListPanel extends DCPanel implements ReferenceDataChangeL
         simpleDictionaryButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                Injector injector = _injectorBuilder.with(SimpleDictionary.class, null).createInjector();
-                SimpleDictionaryDialog dialog = injector.getInstance(SimpleDictionaryDialog.class);
+                final Injector injector = _injectorBuilder.with(SimpleDictionary.class, null).createInjector();
+                final SimpleDictionaryDialog dialog = injector.getInstance(SimpleDictionaryDialog.class);
                 dialog.open();
             }
         });
@@ -126,8 +126,8 @@ public class DictionaryListPanel extends DCPanel implements ReferenceDataChangeL
         datastoreDictionaryButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                Injector injector = _injectorBuilder.with(DatastoreDictionary.class, null).createInjector();
-                DatastoreDictionaryDialog dialog = injector.getInstance(DatastoreDictionaryDialog.class);
+                final Injector injector = _injectorBuilder.with(DatastoreDictionary.class, null).createInjector();
+                final DatastoreDictionaryDialog dialog = injector.getInstance(DatastoreDictionaryDialog.class);
                 dialog.open();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/panels/StringPatternListPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/StringPatternListPanel.java
@@ -38,7 +38,7 @@ import org.datacleaner.reference.StringPattern;
 import org.datacleaner.reference.regexswap.RegexSwapStringPattern;
 import org.datacleaner.regexswap.RegexSwapDialog;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.StringPatternChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.user.UserPreferences;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
@@ -52,7 +52,7 @@ import org.datacleaner.windows.RegexStringPatternDialog;
 import org.datacleaner.windows.SimpleStringPatternDialog;
 import org.jdesktop.swingx.VerticalLayout;
 
-public class StringPatternListPanel extends DCPanel implements StringPatternChangeListener {
+public class StringPatternListPanel extends DCPanel implements ReferenceDataChangeListener<StringPattern> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -231,4 +231,9 @@ public class StringPatternListPanel extends DCPanel implements StringPatternChan
 		super.removeNotify();
 		_catalog.removeStringPatternListener(this);
 	}
+
+    @Override
+    public void onChange(StringPattern oldPattern, StringPattern newPattern) {
+        SwingUtilities.invokeLater(() -> updateComponents());
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/panels/SynonymCatalogListPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/SynonymCatalogListPanel.java
@@ -38,7 +38,7 @@ import org.datacleaner.reference.DatastoreSynonymCatalog;
 import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.reference.TextFileSynonymCatalog;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.SynonymCatalogChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.WidgetFactory;
@@ -53,7 +53,7 @@ import org.jdesktop.swingx.VerticalLayout;
 
 import com.google.inject.Injector;
 
-public final class SynonymCatalogListPanel extends DCPanel implements SynonymCatalogChangeListener {
+public final class SynonymCatalogListPanel extends DCPanel implements ReferenceDataChangeListener<SynonymCatalog> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -228,22 +228,12 @@ public final class SynonymCatalogListPanel extends DCPanel implements SynonymCat
 
 	@Override
 	public void onAdd(SynonymCatalog synonymCatalog) {
-		SwingUtilities.invokeLater(new Runnable() {
-			@Override
-			public void run() {
-				updateComponents();
-			}
-		});
+	    SwingUtilities.invokeLater(() -> updateComponents());
 	}
 
 	@Override
 	public void onRemove(SynonymCatalog synonymCatalog) {
-		SwingUtilities.invokeLater(new Runnable() {
-			@Override
-			public void run() {
-				updateComponents();
-			}
-		});
+	    SwingUtilities.invokeLater(() -> updateComponents());
 	}
 
 	@Override
@@ -251,4 +241,9 @@ public final class SynonymCatalogListPanel extends DCPanel implements SynonymCat
 		super.removeNotify();
 		_catalog.removeSynonymCatalogListener(this);
 	}
+
+    @Override
+    public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+        SwingUtilities.invokeLater(() -> updateComponents());
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/DictionaryChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/DictionaryChangeListener.java
@@ -28,7 +28,9 @@ import org.datacleaner.reference.Dictionary;
 @Deprecated
 public interface DictionaryChangeListener {
 
+    @Deprecated
 	public void onAdd(Dictionary dictionary);
 
+    @Deprecated
 	public void onRemove(Dictionary dictionary);
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/DictionaryChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/DictionaryChangeListener.java
@@ -21,6 +21,11 @@ package org.datacleaner.user;
 
 import org.datacleaner.reference.Dictionary;
 
+
+/**
+ *  Use {@link org.datacleaner.user.ReferenceDataChangeListener} instead
+ */
+@Deprecated
 public interface DictionaryChangeListener {
 
 	public void onAdd(Dictionary dictionary);

--- a/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
@@ -41,16 +41,17 @@ import com.google.common.base.Strings;
  * catalog wraps an immutable instance, which typically represents what is
  * configured in datacleaner's xml file.
  */
+@SuppressWarnings("deprecation")
 public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
 
     private static final long serialVersionUID = 1L;
 
     private final List<DictionaryChangeListener> _dictionaryListeners = new ArrayList<>();
-    private final List<ReferenceDataChangeListener<Dictionary>> _dictionaryV2Listeners = new ArrayList<>();
+    private final List<ReferenceDataChangeListener<Dictionary>> _dictionaryChangeListeners = new ArrayList<>();
     private final List<SynonymCatalogChangeListener> _synonymCatalogListeners = new ArrayList<>();
-    private final List<ReferenceDataChangeListener<SynonymCatalog>> _synonymCatalogV2Listeners = new ArrayList<>();
+    private final List<ReferenceDataChangeListener<SynonymCatalog>> _synonymCatalogChangeListeners = new ArrayList<>();
     private final List<StringPatternChangeListener> _stringPatternListeners = new ArrayList<>();
-    private final List<ReferenceDataChangeListener<StringPattern>> _stringPatternV2Listeners = new ArrayList<>();
+    private final List<ReferenceDataChangeListener<StringPattern>> _stringPatternChangeListeners = new ArrayList<>();
     private final ReferenceDataCatalog _immutableDelegate;
     private final LifeCycleHelper _lifeCycleHelper;
     private final DomConfigurationWriter _configurationWriter;
@@ -141,7 +142,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         for (DictionaryChangeListener listener : _dictionaryListeners) {
             listener.onAdd(dict);
         }
-        for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryV2Listeners){
+        for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryChangeListeners){
             listener.onAdd(dict);
         }
 
@@ -178,7 +179,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             for (DictionaryChangeListener listener : _dictionaryListeners) {
                 listener.onRemove(dict);
             }
-            for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryV2Listeners){
+            for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryChangeListeners){
                 listener.onRemove(dict);
             }
         }
@@ -202,7 +203,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         }
         
         addDictionaryInternal(newDictionary, externalize);
-        for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryV2Listeners){
+        for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryChangeListeners){
             listener.onChange(oldDictionary, newDictionary);
         }
         for (DictionaryChangeListener listener : _dictionaryListeners) {
@@ -220,7 +221,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         for (StringPatternChangeListener listener : _stringPatternListeners) {
             listener.onAdd(sp);
         }
-        for(ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners){
+        for(ReferenceDataChangeListener<StringPattern> listener : _stringPatternChangeListeners){
             listener.onAdd(sp);
         }
     }
@@ -257,7 +258,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             for (StringPatternChangeListener listener : _stringPatternListeners) {
                 listener.onRemove(sp);
             }
-            for(ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners){
+            for(ReferenceDataChangeListener<StringPattern> listener : _stringPatternChangeListeners){
                 listener.onRemove(sp);
             }
         }
@@ -273,8 +274,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     
     public void changeStringPattern(StringPattern oldPattern, StringPattern newPattern, boolean externalize){
         // The old reference is removed from user preferences and we add a new
-        // patern with the same name but with a
-        // different expression value
+        //pattern with the same name but with a different expression value
         final List<StringPattern> stringPatterns = _userPreferences.getUserStringPatterns();
         stringPatterns.remove(oldPattern);
         if (externalize) {
@@ -283,7 +283,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         }   
         addStringPatternInternal(newPattern, externalize);
 
-        for (ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners) {
+        for (ReferenceDataChangeListener<StringPattern> listener : _stringPatternChangeListeners) {
             listener.onChange(oldPattern, newPattern);
         }
         for (StringPatternChangeListener listener : _stringPatternListeners) {
@@ -319,7 +319,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         for (SynonymCatalogChangeListener listener : _synonymCatalogListeners) {
             listener.onAdd(sc);
         }
-        for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogV2Listeners){
+        for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogChangeListeners){
             listener.onAdd(sc);
         }
     }
@@ -356,7 +356,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             for (SynonymCatalogChangeListener listener : _synonymCatalogListeners) {
                 listener.onRemove(sc);
             }
-            for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogV2Listeners){
+            for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogChangeListeners){
                 listener.onRemove(sc);
             }
         }
@@ -380,7 +380,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
        }   
        addSynonymCatalogInternal(newSynonymCatalog, externalize);
        
-       for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogV2Listeners){
+       for (ReferenceDataChangeListener<SynonymCatalog> listener: _synonymCatalogChangeListeners){
            listener.onChange(oldSynonymcatalog, newSynonymCatalog);
        }
        for (SynonymCatalogChangeListener listener : _synonymCatalogListeners) {
@@ -428,11 +428,11 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     }
     
     public void addDictionaryListener(ReferenceDataChangeListener<Dictionary> listener){
-        _dictionaryV2Listeners.add(listener);
+        _dictionaryChangeListeners.add(listener);
     }
     
     public void removeDictionaryListener(ReferenceDataChangeListener<Dictionary> listener){
-        _dictionaryV2Listeners.remove(listener);
+        _dictionaryChangeListeners.remove(listener);
     }
 
     public void addSynonymCatalogListener(SynonymCatalogChangeListener listener) {
@@ -444,11 +444,11 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     }
     
     public void addSynonymCatalogListener(ReferenceDataChangeListener<SynonymCatalog> listener){
-        _synonymCatalogV2Listeners.add(listener); 
+        _synonymCatalogChangeListeners.add(listener); 
     }
     
     public void removeSynonymCatalogListener(ReferenceDataChangeListener<SynonymCatalog> listener){
-        _synonymCatalogV2Listeners.remove(listener);
+        _synonymCatalogChangeListeners.remove(listener);
     }
 
     public void addStringPatternListener(StringPatternChangeListener listener) {
@@ -460,10 +460,10 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     }
     
     public void addStringPatternListener(ReferenceDataChangeListener<StringPattern> listener){
-        _stringPatternV2Listeners.add(listener);
+        _stringPatternChangeListeners.add(listener);
     }
     
     public void removeStringPatternListener(ReferenceDataChangeListener<StringPattern> listener){
-        _stringPatternV2Listeners.remove(listener);
+        _stringPatternChangeListeners.remove(listener);
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
@@ -275,7 +275,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         if (externalize) {
             _configurationWriter.removeStringPattern(oldPattern.getName());
             _userPreferences.save();
-        }        
+        }   
         addStringPatternHelper(newPattern, externalize);
 
         for (ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners) {

--- a/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
@@ -135,7 +135,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     }
 
     public void addDictionary(Dictionary dict, boolean externalize) {
-        addDictionaryHelper(dict, externalize);
+        addDictionaryInternal(dict, externalize);
         
         for (DictionaryChangeListener listener : _dictionaryListeners) {
             listener.onAdd(dict);
@@ -146,7 +146,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
 
     }
 
-    private void addDictionaryHelper(Dictionary dict, boolean externalize) {
+    private void addDictionaryInternal(Dictionary dict, boolean externalize) {
         String name = dict.getName();
         if (Strings.isNullOrEmpty(name)) {
             throw new IllegalArgumentException("Dictionary has no name!");
@@ -200,7 +200,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             }
         }
         
-        addDictionaryHelper(newDictionary, externalize);
+        addDictionaryInternal(newDictionary, externalize);
         for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryV2Listeners){
             listener.onChange(oldDictionary, newDictionary);
         }
@@ -211,7 +211,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
     }
 
     public void addStringPattern(StringPattern sp, boolean externalize) {
-        addStringPatternHelper(sp, externalize);
+        addStringPatternInternal(sp, externalize);
         for (StringPatternChangeListener listener : _stringPatternListeners) {
             listener.onAdd(sp);
         }
@@ -219,7 +219,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             listener.onAdd(sp);
         }
     }
-    private void addStringPatternHelper(StringPattern sp, boolean externalize) {
+    private void addStringPatternInternal(StringPattern sp, boolean externalize) {
         String name = sp.getName();
         if (Strings.isNullOrEmpty(name)) {
             throw new IllegalArgumentException("StringPattern has no name!");
@@ -276,7 +276,7 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
             _configurationWriter.removeStringPattern(oldPattern.getName());
             _userPreferences.save();
         }   
-        addStringPatternHelper(newPattern, externalize);
+        addStringPatternInternal(newPattern, externalize);
 
         for (ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners) {
             listener.onChange(oldPattern, newPattern);

--- a/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/MutableReferenceDataCatalog.java
@@ -204,6 +204,10 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         for(ReferenceDataChangeListener<Dictionary> listener : _dictionaryV2Listeners){
             listener.onChange(oldDictionary, newDictionary);
         }
+        for (DictionaryChangeListener listener : _dictionaryListeners) {
+            listener.onRemove(oldDictionary);
+            listener.onAdd(newDictionary);
+        }
     }
 
     public void addStringPattern(StringPattern sp) {
@@ -262,11 +266,11 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
         }
     }
 
-    public void changeStringPattern(StringPattern newPattern, StringPattern oldPattern){
-        changeStringPattern(newPattern, oldPattern, true);
+    public void changeStringPattern(StringPattern oldPattern, StringPattern newPattern){
+        changeStringPattern(oldPattern, newPattern, true);
     }
     
-    public void changeStringPattern(StringPattern newPattern, StringPattern oldPattern, boolean externalize){
+    public void changeStringPattern(StringPattern oldPattern, StringPattern newPattern, boolean externalize){
         // The old reference is removed from user preferences and we add a new
         // patern with the same name but with a
         // different expression value
@@ -280,6 +284,10 @@ public class MutableReferenceDataCatalog implements ReferenceDataCatalog {
 
         for (ReferenceDataChangeListener<StringPattern> listener : _stringPatternV2Listeners) {
             listener.onChange(oldPattern, newPattern);
+        }
+        for (StringPatternChangeListener listener : _stringPatternListeners) {
+            listener.onRemove(oldPattern);
+            listener.onAdd(newPattern);
         }
     }
     

--- a/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
@@ -8,7 +8,7 @@ public interface ReferenceDataChangeListener<ReferenceData> {
     
     public void onAdd(ReferenceData referenceData);
 
-    public void onChange(ReferenceData oldReferenceData, ReferenceData newreferenceData);
+    public void onChange(ReferenceData oldReferenceData, ReferenceData newReferenceData);
     
     public void onRemove(ReferenceData referenceData);
 

--- a/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
@@ -1,7 +1,7 @@
 package org.datacleaner.user;
 
 /**
- * Interface for changing the value of a Reference
+ * Interface for adding, removing, changing the value of a Reference
  * @param <ReferenceData>
  */
 public interface ReferenceDataChangeListener<ReferenceData> {

--- a/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.user;
 
 /**

--- a/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
@@ -6,10 +6,10 @@ package org.datacleaner.user;
  */
 public interface ReferenceDataChangeListener<ReferenceData> {
     
-    public void onAdd(ReferenceData stringPattern);
+    public void onAdd(ReferenceData referenceData);
 
-    public void onChange(ReferenceData oldPattern, ReferenceData newPattern);
+    public void onChange(ReferenceData oldReferenceData, ReferenceData newreferenceData);
     
-    public void onRemove(ReferenceData stringPattern);
+    public void onRemove(ReferenceData referenceData);
 
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/ReferenceDataChangeListener.java
@@ -1,0 +1,15 @@
+package org.datacleaner.user;
+
+/**
+ * Interface for changing the value of a Reference
+ * @param <ReferenceData>
+ */
+public interface ReferenceDataChangeListener<ReferenceData> {
+    
+    public void onAdd(ReferenceData stringPattern);
+
+    public void onChange(ReferenceData oldPattern, ReferenceData newPattern);
+    
+    public void onRemove(ReferenceData stringPattern);
+
+}

--- a/desktop/ui/src/main/java/org/datacleaner/user/StringPatternChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/StringPatternChangeListener.java
@@ -28,7 +28,9 @@ import org.datacleaner.reference.StringPattern;
 @Deprecated
 public interface StringPatternChangeListener {
 
+    @Deprecated
 	public void onAdd(StringPattern stringPattern);
 
+    @Deprecated
 	public void onRemove(StringPattern stringPattern);
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/StringPatternChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/StringPatternChangeListener.java
@@ -21,6 +21,11 @@ package org.datacleaner.user;
 
 import org.datacleaner.reference.StringPattern;
 
+
+/** 
+ *  Use {@link org.datacleaner.user.ReferenceDataChangeListener} instead
+ */
+@Deprecated
 public interface StringPatternChangeListener {
 
 	public void onAdd(StringPattern stringPattern);

--- a/desktop/ui/src/main/java/org/datacleaner/user/SynonymCatalogChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/SynonymCatalogChangeListener.java
@@ -21,6 +21,10 @@ package org.datacleaner.user;
 
 import org.datacleaner.reference.SynonymCatalog;
 
+/**
+ *  Use {@link org.datacleaner.user.ReferenceDataChangeListener} instead
+ */
+@Deprecated
 public interface SynonymCatalogChangeListener {
 
 	public void onAdd(SynonymCatalog synonymCatalog);

--- a/desktop/ui/src/main/java/org/datacleaner/user/SynonymCatalogChangeListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/SynonymCatalogChangeListener.java
@@ -27,7 +27,9 @@ import org.datacleaner.reference.SynonymCatalog;
 @Deprecated
 public interface SynonymCatalogChangeListener {
 
+    @Deprecated
 	public void onAdd(SynonymCatalog synonymCatalog);
 	
+    @Deprecated
 	public void onRemove(SynonymCatalog synonymCatalog);
 }

--- a/desktop/ui/src/main/java/org/datacleaner/user/UserPreferencesImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/UserPreferencesImpl.java
@@ -77,8 +77,8 @@ public class UserPreferencesImpl implements UserPreferences, Serializable {
     private List<UserDatabaseDriver> databaseDrivers = new ArrayList<>();
     private List<ExtensionPackage> extensionPackages = new ArrayList<>();
     private List<Datastore> userDatastores = new ArrayList<>();
-    private List<Dictionary> userDictionaries = new ArrayList<>();
-    private List<StringPattern> userStringPatterns = new ArrayList<>();
+    private final List<Dictionary> userDictionaries = new ArrayList<>();
+    private final List<StringPattern> userStringPatterns = new ArrayList<>();
     private List<SynonymCatalog> userSynonymCatalogs = new ArrayList<>();
     private Map<String, String> additionalProperties = new HashMap<>();
 
@@ -287,9 +287,6 @@ public class UserPreferencesImpl implements UserPreferences, Serializable {
 
     @Override
     public List<Dictionary> getUserDictionaries() {
-        if (userDictionaries == null) {
-            userDictionaries = new ArrayList<Dictionary>();
-        }
         return userDictionaries;
     }
 
@@ -311,9 +308,6 @@ public class UserPreferencesImpl implements UserPreferences, Serializable {
 
     @Override
     public List<StringPattern> getUserStringPatterns() {
-        if (userStringPatterns == null) {
-            userStringPatterns = new ArrayList<StringPattern>();
-        }
         return userStringPatterns;
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
@@ -184,7 +184,8 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
             checkBox.setSelected(isSelected, true);
             _checkBoxes.put(name, checkBox);
             add(checkBox);
-            // 'fireValueChanged' changes the value in the component builder. Otherwise the listener is activated at the later point(when the window is opened again) *
+            // 'fireValueChanged' changes the value in the component builder. Otherwise the listener 
+            // is activated at the later point(when the window is opened again) *
             fireValueChanged();
         } else {
             addCheckBox(newValue, true);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
@@ -173,6 +173,27 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
         return checkBox;
     }
 
+    protected void editCheckBox(E oldvalue, E newValue) {
+        final String name = getName(oldvalue);
+        final DCCheckBox<E> checkBox = _checkBoxes.get(name);
+        _checkBoxes.remove(name);
+        if (checkBox != null) {
+            checkBox.addListener(CHANGE_LISTENER);
+            boolean isSelected = checkBox.isSelected();
+            checkBox.setValue(newValue);
+            checkBox.setSelected(isSelected, true);
+            _checkBoxes.put(name, checkBox);
+            add(checkBox);
+            // change the value of the component builder. The listener is
+            // activated at the later point
+            fireValueChanged();
+            updateVisibility();
+            updateUI();
+        } else {
+            addCheckBox(newValue, true);
+        }
+    }
+
     protected void removeCheckBox(E item) {
         DCCheckBox<E> checkBox = _checkBoxes.remove(getName(item));
         if (checkBox != null) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
@@ -176,10 +176,10 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
     protected void editCheckBox(E oldvalue, E newValue) {
         final String name = getName(oldvalue);
         final DCCheckBox<E> checkBox = _checkBoxes.get(name);
-        _checkBoxes.remove(name);
         if (checkBox != null) {
+            _checkBoxes.remove(name);
             checkBox.addListener(CHANGE_LISTENER);
-            boolean isSelected = checkBox.isSelected();
+            final boolean isSelected = checkBox.isSelected();
             checkBox.setValue(newValue);
             checkBox.setSelected(isSelected, true);
             _checkBoxes.put(name, checkBox);
@@ -187,11 +187,11 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
             // change the value of the component builder. The listener is
             // activated at the later point
             fireValueChanged();
-            updateVisibility();
-            updateUI();
         } else {
             addCheckBox(newValue, true);
         }
+        updateVisibility();
+        updateUI();
     }
 
     protected void removeCheckBox(E item) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
@@ -184,8 +184,7 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
             checkBox.setSelected(isSelected, true);
             _checkBoxes.put(name, checkBox);
             add(checkBox);
-            /* 'fireValueChanged' changes the value in the component builder. Otherwise the listener is
-            activated at the later point(when the window is opened again) */
+            // 'fireValueChanged' changes the value in the component builder. Otherwise the listener is activated at the later point(when the window is opened again) *
             fireValueChanged();
         } else {
             addCheckBox(newValue, true);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/AbstractMultipleCheckboxesPropertyWidget.java
@@ -184,8 +184,8 @@ public abstract class AbstractMultipleCheckboxesPropertyWidget<E> extends Abstra
             checkBox.setSelected(isSelected, true);
             _checkBoxes.put(name, checkBox);
             add(checkBox);
-            // change the value of the component builder. The listener is
-            // activated at the later point
+            /* 'fireValueChanged' changes the value in the component builder. Otherwise the listener is
+            activated at the later point(when the window is opened again) */
             fireValueChanged();
         } else {
             addCheckBox(newValue, true);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleDictionariesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleDictionariesPropertyWidget.java
@@ -113,8 +113,8 @@ public class MultipleDictionariesPropertyWidget extends AbstractMultipleCheckbox
 	}
 
     @Override
-    public void onChange(Dictionary oldReferenceData, Dictionary newreferenceData) {
-        editCheckBox(oldReferenceData, newreferenceData);
+    public void onChange(Dictionary oldDictionary, Dictionary newDictionary) {
+        editCheckBox(oldDictionary, newDictionary);
     }
 
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleDictionariesPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleDictionariesPropertyWidget.java
@@ -30,14 +30,14 @@ import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.panels.DCPanel;
-import org.datacleaner.user.DictionaryChangeListener;
 import org.datacleaner.user.MutableReferenceDataCatalog;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.windows.ReferenceDataDialog;
 
 public class MultipleDictionariesPropertyWidget extends AbstractMultipleCheckboxesPropertyWidget<Dictionary> implements
-		DictionaryChangeListener {
+ ReferenceDataChangeListener<Dictionary> {
 
 	private final MutableReferenceDataCatalog _referenceDataCatalog;
 	private Provider<ReferenceDataDialog> _referenceDataDialogProvider;
@@ -111,5 +111,10 @@ public class MultipleDictionariesPropertyWidget extends AbstractMultipleCheckbox
 	protected String getNotAvailableText() {
 		return "- no dictionaries available -";
 	}
+
+    @Override
+    public void onChange(Dictionary oldReferenceData, Dictionary newreferenceData) {
+        editCheckBox(oldReferenceData, newreferenceData);
+    }
 
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleStringPatternPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleStringPatternPropertyWidget.java
@@ -110,11 +110,9 @@ public class MultipleStringPatternPropertyWidget extends AbstractMultipleCheckbo
 	@Override
 	public void onChange(StringPattern oldPattern, StringPattern newPattern) {
 	    editCheckBox(oldPattern, newPattern);
-	    
 	}
 	@Override
 	protected String getNotAvailableText() {
 		return "- no string patterns available - ";
 	}
-
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleStringPatternPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleStringPatternPropertyWidget.java
@@ -31,13 +31,13 @@ import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.StringPattern;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.StringPatternChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.windows.ReferenceDataDialog;
 
 public class MultipleStringPatternPropertyWidget extends AbstractMultipleCheckboxesPropertyWidget<StringPattern> implements
-		StringPatternChangeListener {
+    ReferenceDataChangeListener<StringPattern> {
 
 	private final MutableReferenceDataCatalog _referenceDataCatalog;
 	private final Provider<ReferenceDataDialog> _referenceDataDialogProvider;
@@ -108,7 +108,13 @@ public class MultipleStringPatternPropertyWidget extends AbstractMultipleCheckbo
 	}
 
 	@Override
+	public void onChange(StringPattern oldPattern, StringPattern newPattern) {
+	    editCheckBox(oldPattern, newPattern);
+	    
+	}
+	@Override
 	protected String getNotAvailableText() {
 		return "- no string patterns available - ";
 	}
+
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleSynonymCatalogsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleSynonymCatalogsPropertyWidget.java
@@ -31,13 +31,13 @@ import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.SynonymCatalogChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.windows.ReferenceDataDialog;
 
 public class MultipleSynonymCatalogsPropertyWidget extends AbstractMultipleCheckboxesPropertyWidget<SynonymCatalog>
-		implements SynonymCatalogChangeListener {
+		implements ReferenceDataChangeListener<SynonymCatalog> {
 
 	private final MutableReferenceDataCatalog _referenceDataCatalog;
 	private final Provider<ReferenceDataDialog> _referenceDataDialogProvider;
@@ -111,4 +111,9 @@ public class MultipleSynonymCatalogsPropertyWidget extends AbstractMultipleCheck
 	protected String getNotAvailableText() {
 		return "- no synonym catalogs available - ";
 	}
+
+    @Override
+    public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+        editCheckBox(oldReferenceData, newReferenceData);
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleSynonymCatalogsPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleSynonymCatalogsPropertyWidget.java
@@ -113,7 +113,7 @@ public class MultipleSynonymCatalogsPropertyWidget extends AbstractMultipleCheck
 	}
 
     @Override
-    public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
-        editCheckBox(oldReferenceData, newReferenceData);
+    public void onChange(SynonymCatalog oldSynonymCatalog, SynonymCatalog newSynonymCatalog) {
+        editCheckBox(oldSynonymCatalog, newSynonymCatalog);
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
@@ -133,13 +133,13 @@ public class SingleDictionaryPropertyWidget extends AbstractPropertyWidget<Dicti
     }
 
     @Override
-    public void onChange(Dictionary oldReferenceData, Dictionary newReferenceData) {
+    public void onChange(Dictionary oldDictionary, Dictionary newDictionary) {
         final Dictionary selectedItem = _comboBox.getSelectedItem();
-        _comboBox.removeItem(oldReferenceData);
-        _comboBox.addItem(newReferenceData);
+        _comboBox.removeItem(oldDictionary);
+        _comboBox.addItem(newDictionary);
 
-        if (selectedItem.equals(oldReferenceData)) {
-            _comboBox.setSelectedItem(newReferenceData);
+        if (selectedItem.equals(oldDictionary)) {
+            _comboBox.setSelectedItem(newDictionary);
         }
         fireValueChanged();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
@@ -30,8 +30,8 @@ import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.panels.DCPanel;
-import org.datacleaner.user.DictionaryChangeListener;
 import org.datacleaner.user.MutableReferenceDataCatalog;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.widgets.DCComboBox;
@@ -40,8 +40,9 @@ import org.datacleaner.widgets.ReferenceDataComboBoxListRenderer;
 import org.datacleaner.windows.ReferenceDataDialog;
 import org.jdesktop.swingx.HorizontalLayout;
 
+
 public class SingleDictionaryPropertyWidget extends AbstractPropertyWidget<Dictionary> implements
-        DictionaryChangeListener {
+ ReferenceDataChangeListener<Dictionary> {
 
     private final DCComboBox<Dictionary> _comboBox;
     private final MutableReferenceDataCatalog _referenceDataCatalog;
@@ -129,5 +130,18 @@ public class SingleDictionaryPropertyWidget extends AbstractPropertyWidget<Dicti
     @Override
     public void onRemove(Dictionary dictionary) {
         _comboBox.removeItem(dictionary);
+    }
+
+    @Override
+    public void onChange(Dictionary oldReferenceData, Dictionary newReferenceData) {
+
+        final Dictionary selectedItem = _comboBox.getSelectedItem();
+        _comboBox.removeItem(oldReferenceData);
+        _comboBox.addItem(newReferenceData);
+
+        if (selectedItem.equals(oldReferenceData)) {
+            _comboBox.setSelectedItem(newReferenceData);
+        }
+        fireValueChanged();
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleDictionaryPropertyWidget.java
@@ -134,7 +134,6 @@ public class SingleDictionaryPropertyWidget extends AbstractPropertyWidget<Dicti
 
     @Override
     public void onChange(Dictionary oldReferenceData, Dictionary newReferenceData) {
-
         final Dictionary selectedItem = _comboBox.getSelectedItem();
         _comboBox.removeItem(oldReferenceData);
         _comboBox.addItem(newReferenceData);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleStringPatternPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleStringPatternPropertyWidget.java
@@ -31,7 +31,7 @@ import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.StringPattern;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.StringPatternChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.widgets.DCComboBox;
@@ -41,7 +41,7 @@ import org.datacleaner.windows.ReferenceDataDialog;
 import org.jdesktop.swingx.HorizontalLayout;
 
 public class SingleStringPatternPropertyWidget extends AbstractPropertyWidget<StringPattern> implements
-		StringPatternChangeListener {
+		ReferenceDataChangeListener<StringPattern> {
 
 	private final DCComboBox<StringPattern> _comboBox;
 	private final MutableReferenceDataCatalog _referenceDataCatalog;
@@ -129,4 +129,16 @@ public class SingleStringPatternPropertyWidget extends AbstractPropertyWidget<St
 	public void onRemove(StringPattern stringPattern) {
 		_comboBox.removeItem(stringPattern);
 	}
+
+    @Override
+    public void onChange(StringPattern oldStringPattern, StringPattern newStringPattern) {
+        final StringPattern selectedItem = _comboBox.getSelectedItem();
+        _comboBox.removeItem(oldStringPattern);
+        _comboBox.addItem(newStringPattern);
+
+        if (selectedItem.equals(oldStringPattern)) {
+            _comboBox.setSelectedItem(newStringPattern);
+        }
+        fireValueChanged();
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleSynonymCatalogPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleSynonymCatalogPropertyWidget.java
@@ -132,12 +132,12 @@ ReferenceDataChangeListener<SynonymCatalog> {
 	}
 
     @Override
-    public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+    public void onChange(SynonymCatalog oldSynonymCatalog, SynonymCatalog newSynonymCatalog) {
         final SynonymCatalog selectedItem = _comboBox.getSelectedItem();
-        _comboBox.removeItem(oldReferenceData);
-        _comboBox.addItem(newReferenceData);
-        if (selectedItem.equals(oldReferenceData)){
-            _comboBox.setSelectedItem(newReferenceData);
+        _comboBox.removeItem(oldSynonymCatalog);
+        _comboBox.addItem(newSynonymCatalog);
+        if (selectedItem.equals(oldSynonymCatalog)){
+            _comboBox.setSelectedItem(newSynonymCatalog);
         }
         fireValueChanged();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleSynonymCatalogPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleSynonymCatalogPropertyWidget.java
@@ -31,7 +31,7 @@ import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.MutableReferenceDataCatalog;
-import org.datacleaner.user.SynonymCatalogChangeListener;
+import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
 import org.datacleaner.widgets.DCComboBox;
@@ -41,7 +41,7 @@ import org.datacleaner.windows.ReferenceDataDialog;
 import org.jdesktop.swingx.HorizontalLayout;
 
 public class SingleSynonymCatalogPropertyWidget extends AbstractPropertyWidget<SynonymCatalog> implements
-		SynonymCatalogChangeListener {
+ReferenceDataChangeListener<SynonymCatalog> {
 
 	private final DCComboBox<SynonymCatalog> _comboBox;
 	private final MutableReferenceDataCatalog _referenceDataCatalog;
@@ -131,4 +131,14 @@ public class SingleSynonymCatalogPropertyWidget extends AbstractPropertyWidget<S
 		_comboBox.removeItem(synonymCatalog);
 	}
 
+    @Override
+    public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+        final SynonymCatalog selectedItem = _comboBox.getSelectedItem();
+        _comboBox.removeItem(oldReferenceData);
+        _comboBox.addItem(newReferenceData);
+        if (selectedItem.equals(oldReferenceData)){
+            _comboBox.setSelectedItem(newReferenceData);
+        }
+        fireValueChanged();
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -1054,8 +1054,8 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
           for (ComponentBuilder componentBuilder: componentBuilders){
               final Map<ConfiguredPropertyDescriptor, Object> configuredProperties = componentBuilder.getConfiguredProperties();
               for (Map.Entry<ConfiguredPropertyDescriptor, Object> entry : configuredProperties.entrySet()) {
-                  final ConfiguredPropertyDescriptor propertyDeescriptor = entry.getKey();
-                  if (referenceDataClass.isAssignableFrom(propertyDeescriptor.getBaseType())) {
+                  final ConfiguredPropertyDescriptor propertyDescriptor = entry.getKey();
+                  if (referenceDataClass.isAssignableFrom(propertyDescriptor.getBaseType())) {
                       final Object valueObject = entry.getValue();
                       //In some cases the configured property is an array
                       if (valueObject.getClass().isArray()) {
@@ -1068,7 +1068,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
                           }
                       } else {
                           if (oldReferenceData.equals(valueObject)) {
-                              componentBuilder.setConfiguredProperty(propertyDeescriptor,
+                              componentBuilder.setConfiguredProperty(propertyDescriptor,
                                       newReferenceData);
                           }
                       }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -316,7 +316,8 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
             Provider<ReferenceDataDialog> referenceDataDialogProvider, UsageLogger usageLogger,
             Provider<OptionsDialog> optionsDialogProvider,
             Provider<MonitorConnectionDialog> monitorConnectionDialogProvider,
-            OpenAnalysisJobActionListener openAnalysisJobActionListener, DatabaseDriverCatalog databaseDriverCatalog, MutableReferenceDataCatalog mutableReferenceCatalog) {
+            OpenAnalysisJobActionListener openAnalysisJobActionListener, DatabaseDriverCatalog databaseDriverCatalog,
+            MutableReferenceDataCatalog mutableReferenceCatalog) {
         super(windowContext);
         _jobFilename = jobFilename;
         _configuration = configuration;

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -85,6 +85,7 @@ import org.datacleaner.user.ReferenceDataChangeListener;
 import org.datacleaner.reference.Dictionary;
 import org.datacleaner.reference.ReferenceData;
 import org.datacleaner.reference.StringPattern;
+import org.datacleaner.reference.SynonymCatalog;
 import org.datacleaner.job.builder.SourceColumnChangeListener;
 import org.datacleaner.job.builder.TransformerChangeListener;
 import org.datacleaner.job.builder.TransformerComponentBuilder;
@@ -181,6 +182,24 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         public void onRequirementChanged(final AnalyzerComponentBuilder<?> analyzerJobBuilder) {
             _graph.refresh();
         }
+    }
+    private class WindowChangeSynonymCatalogListener implements ReferenceDataChangeListener<SynonymCatalog>{
+
+        @Override
+        public void onAdd(SynonymCatalog referenceData) {
+            
+        }
+
+        @Override
+        public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+            changeReferenceDataValuesInComponents(oldReferenceData, newReferenceData, SynonymCatalog.class);   
+        }
+
+        @Override
+        public void onRemove(SynonymCatalog referenceData) {
+            
+        }
+        
     }
     
     private class WindowChangeDictionaryListener implements ReferenceDataChangeListener<Dictionary>{
@@ -333,6 +352,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
     private final AnalysisJobChangeListener _analysisJobChangeListener = new WindowAnalysisJobChangeListener();
     private final ReferenceDataChangeListener<StringPattern> _stringPatternChangeListener = new WindowChangeStringPatternListener();
     private final ReferenceDataChangeListener<Dictionary> _dictionaryChangeListener = new WindowChangeDictionaryListener();
+    private final ReferenceDataChangeListener<SynonymCatalog> _synonymCatalogListener = new WindowChangeSynonymCatalogListener();
     private FileObject _jobFilename;
     private Datastore _datastore;
     private DatastoreConnection _datastoreConnection;
@@ -391,6 +411,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
         //Add listeners for ReferenceData classes 
         _mutableReferenceCatalog.addStringPatternListener(_stringPatternChangeListener);
         _mutableReferenceCatalog.addDictionaryListener(_dictionaryChangeListener);
+        _mutableReferenceCatalog.addSynonymCatalogListener(_synonymCatalogListener);
 
         _saveButton = WidgetFactory.createToolbarButton("Save", IconUtils.ACTION_SAVE_BRIGHT);
         _saveAsButton = WidgetFactory.createToolbarButton("Save As...", IconUtils.ACTION_SAVE_BRIGHT);
@@ -680,8 +701,10 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow implement
             _datastoreConnection.close();
         }
         
+        //Remove the reference data listener
         _mutableReferenceCatalog.removeStringPatternListener(_stringPatternChangeListener);
         _mutableReferenceCatalog.removeDictionaryListener(_dictionaryChangeListener);
+        _mutableReferenceCatalog.removeSynonymCatalogListener(_synonymCatalogListener);
         
         getContentPane().removeAll();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/DatastoreDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/DatastoreDictionaryDialog.java
@@ -209,11 +209,12 @@ public final class DatastoreDictionaryDialog extends AbstractDialog {
                     return;
                 }
 
-                DatastoreDictionary dictionary = new DatastoreDictionary(name, datastoreName, columnPath);
+                final DatastoreDictionary dictionary = new DatastoreDictionary(name, datastoreName, columnPath);
                 if (_originalDictionary != null) {
-                    _referenceDataCatalog.removeDictionary(_originalDictionary);
+                    _referenceDataCatalog.changeDictionary(_originalDictionary, dictionary);
+                } else {
+                    _referenceDataCatalog.addDictionary(dictionary);
                 }
-                _referenceDataCatalog.addDictionary(dictionary);
                 DatastoreDictionaryDialog.this.dispose();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/DatastoreSynonymCatalogDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/DatastoreSynonymCatalogDialog.java
@@ -184,11 +184,14 @@ public final class DatastoreSynonymCatalogDialog extends AbstractDialog {
                 Column selectedItem = _masterTermColumnComboBox.getSelectedItem();
                 String[] synonymColumnNames = _synonymColumnsPanel.getColumnNames();
 
-                DatastoreSynonymCatalog dataStoreBasedSynonymCatalog = new DatastoreSynonymCatalog(name,
+                final DatastoreSynonymCatalog dataStoreBasedSynonymCatalog = new DatastoreSynonymCatalog(name,
                         nameOfDatastore, selectedItem.getQualifiedLabel(), synonymColumnNames);
 
                 if (_originalsynonymCatalog != null) {
-                    _mutableReferenceCatalog.removeSynonymCatalog(_originalsynonymCatalog);
+                    _mutableReferenceCatalog.changeSynonymCatalog(_originalsynonymCatalog,
+                            dataStoreBasedSynonymCatalog);
+                } else {
+                    _mutableReferenceCatalog.addSynonymCatalog(dataStoreBasedSynonymCatalog);
                 }
 
                 _mutableReferenceCatalog.addSynonymCatalog(dataStoreBasedSynonymCatalog);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ReferenceDataAnalysisJobWindowImplListeners.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ReferenceDataAnalysisJobWindowImplListeners.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.windows;
 
 import java.lang.reflect.Array;

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ReferenceDataAnalysisJobWindowImplListeners.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ReferenceDataAnalysisJobWindowImplListeners.java
@@ -1,0 +1,166 @@
+package org.datacleaner.windows;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Map;
+
+import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+import org.datacleaner.job.builder.ComponentBuilder;
+import org.datacleaner.reference.Dictionary;
+import org.datacleaner.reference.ReferenceData;
+import org.datacleaner.reference.StringPattern;
+import org.datacleaner.reference.SynonymCatalog;
+import org.datacleaner.user.ReferenceDataChangeListener;
+
+/**
+ * It contains all the listeners for ReferenceData type used in
+ * {@link AnalysisJobBuilderWindowImpl}
+ */
+public class ReferenceDataAnalysisJobWindowImplListeners {
+
+    private final AnalysisJobBuilder _analysisJobBuilder;
+
+    ReferenceDataAnalysisJobWindowImplListeners(AnalysisJobBuilder analysisJobBuilder) {
+        _analysisJobBuilder = analysisJobBuilder;
+    }
+
+    class WindowChangeSynonymCatalogListener implements ReferenceDataChangeListener<SynonymCatalog> {
+
+        @Override
+        public void onAdd(SynonymCatalog referenceData) {
+            // DO NOTHING (because we do not want to automatically select the
+            // reference data to be used in the job)
+        }
+
+        @Override
+        public void onChange(SynonymCatalog oldReferenceData, SynonymCatalog newReferenceData) {
+            changeReferenceDataValuesInComponents(oldReferenceData, newReferenceData, SynonymCatalog.class);
+        }
+
+        @Override
+        public void onRemove(SynonymCatalog referenceData) {
+            removeReferenceDataValuesInComponents(referenceData, SynonymCatalog.class);
+        }
+
+    }
+
+    class WindowChangeDictionaryListener implements ReferenceDataChangeListener<Dictionary> {
+
+        @Override
+        public void onAdd(Dictionary referenceData) {
+            // DO NOTHING (because we do not want to automatically select the
+            // reference data to be used in the job)
+        }
+
+        @Override
+        public void onChange(Dictionary oldReferenceData, Dictionary newReferenceData) {
+            changeReferenceDataValuesInComponents(oldReferenceData, newReferenceData, Dictionary.class);
+        }
+
+        @Override
+        public void onRemove(Dictionary referenceData) {
+            removeReferenceDataValuesInComponents(referenceData, Dictionary.class);
+
+        }
+    }
+
+    class WindowChangeStringPatternListener implements ReferenceDataChangeListener<StringPattern> {
+
+        @Override
+        public void onAdd(StringPattern referenceData) {
+            // DO NOTHING (because we do not want to automatically select the
+            // reference data to be used in the job)
+        }
+
+        @Override
+        public void onChange(StringPattern oldReferenceData, StringPattern newReferenceData) {
+            changeReferenceDataValuesInComponents(oldReferenceData, newReferenceData, StringPattern.class);
+        }
+
+        @Override
+        public void onRemove(StringPattern referenceData) {
+            removeReferenceDataValuesInComponents(referenceData, StringPattern.class);
+        }
+
+    }
+
+    /**
+     * Method used to change the reference data(String Patterns, Dictionaries,
+     * Synonyms) components' values in components
+     * 
+     * @param oldReferenceData
+     * @param newReferenceData
+     * @param referenceDataClass
+     */
+    private void changeReferenceDataValuesInComponents(ReferenceData oldReferenceData, ReferenceData newReferenceData,
+            Class<?> referenceDataClass) {
+        final Collection<ComponentBuilder> componentBuilders = _analysisJobBuilder.getComponentBuilders();
+        for (ComponentBuilder componentBuilder : componentBuilders) {
+            final Map<ConfiguredPropertyDescriptor, Object> configuredProperties = componentBuilder
+                    .getConfiguredProperties();
+            for (Map.Entry<ConfiguredPropertyDescriptor, Object> entry : configuredProperties.entrySet()) {
+                final ConfiguredPropertyDescriptor propertyDescriptor = entry.getKey();
+                if (referenceDataClass.isAssignableFrom(propertyDescriptor.getBaseType())) {
+                    final Object valueObject = entry.getValue();
+                    // In some cases the configured property is an array
+                    if (valueObject.getClass().isArray()) {
+                        final Object[] values = (Object[]) valueObject;
+                        for (int i = 0; i < values.length; i++) {
+                            if (oldReferenceData.equals(values[i])) {
+                                // change the old value of the pattern in the
+                                // array with the new value
+                                values[i] = newReferenceData;
+                            }
+                        }
+                    } else {
+                        if (oldReferenceData.equals(valueObject)) {
+                            componentBuilder.setConfiguredProperty(propertyDescriptor, newReferenceData);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Method used to remove the reference data(String Patterns, Dictionaries,
+     * Synonyms) components' values in components
+     * 
+     * @param referenceData
+     * @param referenceDataClass
+     */
+    private void removeReferenceDataValuesInComponents(ReferenceData referenceData, Class<?> referenceDataClass) {
+        final Collection<ComponentBuilder> componentBuilders = _analysisJobBuilder.getComponentBuilders();
+        for (ComponentBuilder componentBuilder : componentBuilders) {
+            final Map<ConfiguredPropertyDescriptor, Object> configuredProperties = componentBuilder
+                    .getConfiguredProperties();
+            for (Map.Entry<ConfiguredPropertyDescriptor, Object> entry : configuredProperties.entrySet()) {
+                final ConfiguredPropertyDescriptor propertyDescriptor = entry.getKey();
+                if (referenceDataClass.isAssignableFrom(propertyDescriptor.getBaseType())) {
+                    final Object valueObject = entry.getValue();
+                    // In some cases the configured property is an array
+                    if (valueObject.getClass().isArray()) {
+                        final Object[] values = (Object[]) valueObject;
+                        final Class<?> componentType = valueObject.getClass().getComponentType();
+                        // create the new array
+                        final Object[] newArray = (Object[]) Array.newInstance(componentType, values.length - 1);
+                        int j = 0;
+                        for (int i = 0; i < values.length; i++) {
+                            if (!referenceData.equals(values[i])) {
+                                // keep only the values different than the one select to be removed
+                                newArray[j] = values[i];
+                                j++;
+                            }
+                        }
+                        componentBuilder.setConfiguredProperty(propertyDescriptor, newArray);
+                    } else {
+                        if (referenceData.equals(valueObject)) {
+                            componentBuilder.setConfiguredProperty(propertyDescriptor, null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/windows/RegexStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/RegexStringPatternDialog.java
@@ -163,12 +163,13 @@ public final class RegexStringPatternDialog extends AbstractDialog {
                             "Please fill out the regular expression");
                     return;
                 }
+                final RegexStringPattern regexStringPattern = new RegexStringPattern(expressionName, expression, true);
                 if (_regexStringPattern != null && _catalog.containsStringPattern(_regexStringPattern.getName())) {
-                    _catalog.removeStringPattern(_catalog.getStringPattern(_regexStringPattern.getName()));
+                    _catalog.changeStringPattern(_regexStringPattern, regexStringPattern);
+                } else {
+                    _catalog.addStringPattern(regexStringPattern);
                 }
-                RegexStringPattern regexStringPattern = new RegexStringPattern(expressionName, expression, true);
                 _regexStringPattern = regexStringPattern;
-                _catalog.addStringPattern(regexStringPattern);
                 RegexStringPatternDialog.this.dispose();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
@@ -138,7 +138,6 @@ public final class SimpleDictionaryDialog extends AbstractDialog {
                 final SimpleDictionary dict = new SimpleDictionary(name, caseSensitive, values.split("\n"));
 
                 if (_originalDictionary != null) {
-                    // _catalog.removeDictionary(_originalDictionary);
                     _catalog.changeDictionary(_originalDictionary, dict);
                 } else {
                     _catalog.addDictionary(dict);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleDictionaryDialog.java
@@ -138,9 +138,11 @@ public final class SimpleDictionaryDialog extends AbstractDialog {
                 final SimpleDictionary dict = new SimpleDictionary(name, caseSensitive, values.split("\n"));
 
                 if (_originalDictionary != null) {
-                    _catalog.removeDictionary(_originalDictionary);
+                    // _catalog.removeDictionary(_originalDictionary);
+                    _catalog.changeDictionary(_originalDictionary, dict);
+                } else {
+                    _catalog.addDictionary(dict);
                 }
-                _catalog.addDictionary(dict);
                 SimpleDictionaryDialog.this.dispose();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
@@ -157,12 +157,13 @@ public final class SimpleStringPatternDialog extends AbstractDialog {
                             "Please fill out the string expression");
                     return;
                 }
+                final SimpleStringPattern simpleStringPattern = new SimpleStringPattern(expressionName, expression);
                 if (_simpleStringPattern != null && _catalog.containsStringPattern(_simpleStringPattern.getName())) {
-                    _catalog.removeStringPattern(_catalog.getStringPattern(_simpleStringPattern.getName()));
+                    _catalog.changeStringPattern(simpleStringPattern, _simpleStringPattern);
+                }else{
+                    _catalog.addStringPattern(simpleStringPattern);
                 }
-                SimpleStringPattern simpleStringPattern = new SimpleStringPattern(expressionName, expression);
                 _simpleStringPattern = simpleStringPattern;
-                _catalog.addStringPattern(simpleStringPattern);
                 SimpleStringPatternDialog.this.dispose();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
@@ -249,8 +249,8 @@ public final class SimpleStringPatternDialog extends AbstractDialog {
         if ("".equals(text)) {
             label.setIcon(null);
         } else {
-            _simpleStringPattern = new SimpleStringPattern(_expressionNameField.getText(), _expressionField.getText());
-            if (_simpleStringPattern.matches(text)) {
+            final SimpleStringPattern simpleStringPattern = new SimpleStringPattern(_expressionNameField.getText(), _expressionField.getText());
+            if (simpleStringPattern.matches(text)) {
                 label.setIcon(ICON_SUCCESS);
             } else {
                 label.setIcon(ICON_ERROR);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
@@ -160,7 +160,7 @@ public final class SimpleStringPatternDialog extends AbstractDialog {
                 final SimpleStringPattern simpleStringPattern = new SimpleStringPattern(expressionName, expression);
                 if (_simpleStringPattern != null && _catalog.containsStringPattern(_simpleStringPattern.getName())) {
                     _catalog.changeStringPattern(simpleStringPattern, _simpleStringPattern);
-                }else{
+                } else {
                     _catalog.addStringPattern(simpleStringPattern);
                 }
                 _simpleStringPattern = simpleStringPattern;

--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
@@ -159,7 +159,7 @@ public final class SimpleStringPatternDialog extends AbstractDialog {
                 }
                 final SimpleStringPattern simpleStringPattern = new SimpleStringPattern(expressionName, expression);
                 if (_simpleStringPattern != null && _catalog.containsStringPattern(_simpleStringPattern.getName())) {
-                    _catalog.changeStringPattern(simpleStringPattern, _simpleStringPattern);
+                    _catalog.changeStringPattern(_simpleStringPattern, simpleStringPattern);
                 } else {
                     _catalog.addStringPattern(simpleStringPattern);
                 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/TextFileDictionaryDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/TextFileDictionaryDialog.java
@@ -171,9 +171,10 @@ public final class TextFileDictionaryDialog extends AbstractDialog {
                 final TextFileDictionary dict = new TextFileDictionary(name, path, encoding, caseSensitive);
 
                 if (_originalDictionary != null) {
-                    _catalog.removeDictionary(_originalDictionary);
+                    _catalog.changeDictionary(_originalDictionary, dict);
+                } else {
+                    _catalog.addDictionary(dict);
                 }
-                _catalog.addDictionary(dict);
                 TextFileDictionaryDialog.this.dispose();
             }
         });

--- a/desktop/ui/src/main/java/org/datacleaner/windows/TextFileSynonymCatalogDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/TextFileSynonymCatalogDialog.java
@@ -175,9 +175,10 @@ public final class TextFileSynonymCatalogDialog extends AbstractDialog {
                 final TextFileSynonymCatalog sc = new TextFileSynonymCatalog(name, path, caseSensitive, encoding);
 
                 if (_originalsynonymCatalog != null) {
-                    _catalog.removeSynonymCatalog(_originalsynonymCatalog);
+                    _catalog.changeSynonymCatalog(_originalsynonymCatalog, sc);
+                } else {
+                    _catalog.addSynonymCatalog(sc);
                 }
-                _catalog.addSynonymCatalog(sc);
                 TextFileSynonymCatalogDialog.this.dispose();
             }
         });


### PR DESCRIPTION
Fixes #302 

Fixes: 
- Filter pattern
- Simple dictionary
- Synonym catalog

An interface "ReferenceDataChangeListener" is implemented to signal that a dictionary or string pattern has been edited. 

The redundant listeners have been kept so that no extension is broken. 