### PR TITLE
Copy example repo to temp dir in unit tests

### DIFF
--- a/monitor/services/src/test/java/org/datacleaner/monitor/scheduling/quartz/ExecuteJobTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/scheduling/quartz/ExecuteJobTest.java
@@ -47,6 +47,8 @@ import org.quartz.JobDetail;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import com.google.common.io.Files;
+
 import junit.framework.TestCase;
 
 public class ExecuteJobTest extends TestCase {
@@ -126,9 +128,9 @@ public class ExecuteJobTest extends TestCase {
      * Testing Hadoop execution in debug mode. The example job from example_hadoop_repo should be modified accordingly. 
      */
     public void ignoreTestHadoopExecution() throws Exception {
-        
-        final File targetDir = new File("target/example_hadoop_repo");
-        FileUtils.deleteDirectory(targetDir);
+
+        final File targetDir = Files.createTempDir();
+        targetDir.deleteOnExit();
         FileUtils.copyDirectory(new File("src/test/resources/example_hadoop_repo"), targetDir);
 
         final Repository repository = new FileRepository(targetDir); 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/ExampleFileRepository.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/ExampleFileRepository.java
@@ -1,0 +1,51 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.server;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.datacleaner.repository.file.FileRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Files;
+
+public class ExampleFileRepository extends FileRepository {
+    private static final long serialVersionUID = 1L;
+    private static final Logger logger = LoggerFactory.getLogger(ExampleFileRepository.class);
+
+    public ExampleFileRepository() {
+        super(generateTestFolder());
+    }
+
+    private static File generateTestFolder() {
+        final File tempDir = Files.createTempDir();
+        tempDir.deleteOnExit();
+        try {
+            FileUtils.copyDirectory(new File("src/test/resources/example_repo"), tempDir);
+        } catch (IOException e) {
+            logger.error("Could not generate test folder", e);
+        }
+
+        return tempDir.getAbsoluteFile();
+    }
+}

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/SchedulingServiceImplIntegrationTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/SchedulingServiceImplIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.monitor.configuration.TenantContextFactory;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
@@ -37,7 +36,6 @@ import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
 import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
 import org.datacleaner.monitor.shared.model.TenantIdentifier;
-import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.file.FileRepository;
 import org.quartz.CronTrigger;
 import org.quartz.Scheduler;
@@ -61,14 +59,10 @@ public class SchedulingServiceImplIntegrationTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
         if (service == null) {
-            final File targetDir = new File("target/example_repo");
-            FileUtils.deleteDirectory(targetDir);
-            FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-
             final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
                     "context/application-context.xml");
 
-            final Repository repository = new FileRepository(targetDir);
+            final FileRepository repository = applicationContext.getBean(FileRepository.class);
             tenantContextFactory = new TenantContextFactoryImpl(repository, new DataCleanerEnvironmentImpl(),
                     new DefaultJobEngineManager(applicationContext));
 
@@ -77,7 +71,7 @@ public class SchedulingServiceImplIntegrationTest extends TestCase {
 
             service.initialize();
 
-            resultDirectory = new File(targetDir, "tenant1/results");
+            resultDirectory = new File(repository.getFile(), "tenant1/results");
         }
     }
 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ExecutionLogControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ExecutionLogControllerTest.java
@@ -20,7 +20,6 @@
 package org.datacleaner.monitor.server.controllers;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 
 import javax.servlet.ServletOutputStream;
@@ -28,27 +27,26 @@ import javax.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
-import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.file.FileRepository;
 import org.easymock.EasyMock;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class ExecutionLogControllerTest extends TestCase {
 
     private ExecutionLogController executionLogController;
-    private Repository repository;
 
     protected void setUp() throws Exception {
-        File targetDir = new File("target/repo_result_modification");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-        repository = new FileRepository(targetDir);
+        final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+                "context/application-context.xml");
+        final Repository repository = applicationContext.getBean(FileRepository.class);
 
         TenantContextFactoryImpl tenantContextFactory = new TenantContextFactoryImpl(repository,
-                new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
+                new DataCleanerEnvironmentImpl(), new DefaultJobEngineManager(applicationContext));
 
         executionLogController = new ExecutionLogController();
         executionLogController._contextFactory = tenantContextFactory;

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobCopyAndDeleteControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobCopyAndDeleteControllerTest.java
@@ -19,22 +19,22 @@
  */
 package org.datacleaner.monitor.server.controllers;
 
-import java.io.File;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
 import org.datacleaner.monitor.events.JobCopyEvent;
 import org.datacleaner.monitor.events.JobDeletionEvent;
-import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.file.FileRepository;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class JobCopyAndDeleteControllerTest extends TestCase {
 
@@ -42,12 +42,12 @@ public class JobCopyAndDeleteControllerTest extends TestCase {
     private TenantContextFactoryImpl tenantContextFactory;
 
     protected void setUp() throws Exception {
-        File targetDir = new File("target/repo_job_copy");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-        repository = new FileRepository(targetDir);
+        final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+                "context/application-context.xml");
+        repository = applicationContext.getBean(FileRepository.class);
 
-        tenantContextFactory = new TenantContextFactoryImpl(repository, new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
+        tenantContextFactory = new TenantContextFactoryImpl(repository, new DataCleanerEnvironmentImpl(),
+                new DefaultJobEngineManager(applicationContext));
     }
 
     public void testRenameJobAndResult() throws Exception {

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobModificationControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobModificationControllerTest.java
@@ -19,14 +19,12 @@
  */
 package org.datacleaner.monitor.server.controllers;
 
-import java.io.File;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
 import org.datacleaner.monitor.dashboard.model.TimelineDefinition;
@@ -35,14 +33,16 @@ import org.datacleaner.monitor.events.JobModificationEvent;
 import org.datacleaner.monitor.server.dao.ResultDao;
 import org.datacleaner.monitor.server.dao.ResultDaoImpl;
 import org.datacleaner.monitor.server.dao.TimelineDaoImpl;
-import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.monitor.server.listeners.JobModificationEventRenameResultsListener;
 import org.datacleaner.monitor.server.listeners.JobModificationEventUpdateTimelinesListener;
 import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.RepositoryFolder;
 import org.datacleaner.repository.file.FileRepository;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class JobModificationControllerTest extends TestCase {
@@ -54,13 +54,12 @@ public class JobModificationControllerTest extends TestCase {
     private TimelineDaoImpl timelineDao;
 
     protected void setUp() throws Exception {
-        File targetDir = new File("target/repo_job_modification");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-        repository = new FileRepository(targetDir);
+        final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+                "context/application-context.xml");
+        repository = applicationContext.getBean(FileRepository.class);
 
         final TenantContextFactoryImpl tenantContextFactory = new TenantContextFactoryImpl(repository,
-                new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
+                new DataCleanerEnvironmentImpl(), new DefaultJobEngineManager(applicationContext));
 
         final ResultDao resultDao = new ResultDaoImpl(tenantContextFactory, null);
         timelineDao = new TimelineDaoImpl(tenantContextFactory, repository);

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobTriggeringControllerIntegrationTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobTriggeringControllerIntegrationTest.java
@@ -21,10 +21,8 @@ package org.datacleaner.monitor.server.controllers;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.InputStream;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.monitor.configuration.TenantContextFactory;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
@@ -46,22 +44,17 @@ public class JobTriggeringControllerIntegrationTest {
      * Tests if a job is trigger to run as expected and the override properties
      * are applied. The job can't run successful if the override properties
      * aren't applied, because the standard conf.xml refers to a non-existing
-     * dictionary, which is corrected by the override properties. 
+     * dictionary, which is corrected by the override properties.
      */
     @Test
     public void testPostWithOverrideProperties() throws Throwable {
         final String repositoryName = "example_repo";
         final String tenantName = "tenant5";
         final String jobName = "countries";
-        
-        final File targetDir = new File("target/" + repositoryName);
-        
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/" + repositoryName), targetDir);
 
         final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
                 "context/application-context.xml");
-        final Repository repository = new FileRepository(targetDir);
+        final Repository repository = applicationContext.getBean(FileRepository.class);;
         final TenantContextFactory tenantContextFactory = new TenantContextFactoryImpl(repository,
                 new DataCleanerEnvironmentImpl(), new DefaultJobEngineManager(applicationContext));
 

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/RepositoryZipControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/RepositoryZipControllerTest.java
@@ -31,10 +31,12 @@ import java.util.zip.ZipOutputStream;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.repository.RepositoryFile;
 import org.datacleaner.repository.RepositoryFolder;
 import org.datacleaner.repository.file.FileRepository;
+
+import com.google.common.io.Files;
+
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.Func;
 
@@ -50,9 +52,8 @@ public class RepositoryZipControllerTest extends TestCase {
         }
 
         ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream("target/test_zipfile.zip"));
-        File targetRepoFolder = new File("target/decompressed_repo");
-        FileUtils.deleteDirectory(targetRepoFolder);
-        targetRepoFolder.mkdirs();
+        final File targetRepoFolder = Files.createTempDir();
+        targetRepoFolder.deleteOnExit();
         RepositoryFolder targetFolder = new FileRepository(targetRepoFolder).createFolder("tenant1");
         targetFolder.createFolder("foobar_removeMe");
         targetFolder.createFile("Yes_remove_me.too", null);

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ResultModificationControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ResultModificationControllerTest.java
@@ -19,14 +19,12 @@
  */
 package org.datacleaner.monitor.server.controllers;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.Map;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.metamodel.util.Action;
 import org.datacleaner.components.convert.ConvertToDateTransformer;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
@@ -35,7 +33,7 @@ import org.datacleaner.monitor.events.ResultModificationEvent;
 import org.datacleaner.monitor.scheduling.model.ExecutionLog;
 import org.datacleaner.monitor.server.dao.ResultDaoImpl;
 import org.datacleaner.monitor.server.jaxb.JaxbExecutionLogReader;
-import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.monitor.server.listeners.ResultModificationEventExecutionLogListener;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
 import org.datacleaner.monitor.shared.model.TenantIdentifier;
@@ -43,8 +41,10 @@ import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.RepositoryFile;
 import org.datacleaner.repository.RepositoryNode;
 import org.datacleaner.repository.file.FileRepository;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class ResultModificationControllerTest extends TestCase {
 
@@ -53,13 +53,12 @@ public class ResultModificationControllerTest extends TestCase {
     private Repository repository;
 
     protected void setUp() throws Exception {
-        File targetDir = new File("target/repo_result_modification");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-        repository = new FileRepository(targetDir);
+        final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+                "context/application-context.xml");
+        repository = applicationContext.getBean(FileRepository.class);
 
-        TenantContextFactoryImpl tenantContextFactory = new TenantContextFactoryImpl(repository,
-                new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
+        final TenantContextFactoryImpl tenantContextFactory = new TenantContextFactoryImpl(repository,
+                new DataCleanerEnvironmentImpl(), new DefaultJobEngineManager(applicationContext));
 
         resultModificationController = new ResultModificationController();
         resultModificationListener = new ResultModificationEventExecutionLogListener(tenantContextFactory);

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/dao/DatastoreDaoImplTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/dao/DatastoreDaoImplTest.java
@@ -19,31 +19,27 @@
  */
 package org.datacleaner.monitor.server.dao;
 
-import java.io.File;
-
 import junit.framework.TestCase;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
 import org.datacleaner.connection.Datastore;
 import org.datacleaner.monitor.configuration.TenantContext;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
-import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.monitor.server.job.DefaultJobEngineManager;
 import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.file.FileRepository;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class DatastoreDaoImplTest extends TestCase {
 
     public void testRemoveDatastore() throws Exception {
-        final File targetDir = new File("target/repo_remove_datastore");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-
-        final Repository repository = new FileRepository(targetDir);
+        final ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+                "context/application-context.xml");
+        final Repository repository = applicationContext.getBean(FileRepository.class);
 
         final TenantContextFactoryImpl tenantContextFactory = new TenantContextFactoryImpl(repository,
-                new DataCleanerEnvironmentImpl(), new MockJobEngineManager());
-
+                new DataCleanerEnvironmentImpl(), new DefaultJobEngineManager(applicationContext));
         DatastoreDao dao = new DatastoreDaoImpl();
 
         TenantContext tenantContext = tenantContextFactory.getContext("tenant1");

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/job/DefaultJobEngineManagerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/job/DefaultJobEngineManagerTest.java
@@ -19,9 +19,6 @@
  */
 package org.datacleaner.monitor.server.job;
 
-import java.io.File;
-
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.monitor.job.JobEngine;
 import org.datacleaner.monitor.job.JobEngineManager;
 import org.datacleaner.monitor.job.MetricJobContext;
@@ -37,10 +34,7 @@ public class DefaultJobEngineManagerTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        final File targetDir = new File("target/example_repo");
-        FileUtils.deleteDirectory(targetDir);
-        FileUtils.copyDirectory(new File("src/test/resources/example_repo"), targetDir);
-        
+
         if (applicationContext == null) {
             applicationContext  = new ClassPathXmlApplicationContext("context/application-context.xml");
         }

--- a/monitor/services/src/test/resources/context/application-context.xml
+++ b/monitor/services/src/test/resources/context/application-context.xml
@@ -33,10 +33,7 @@
 	
 	<bean class="org.datacleaner.descriptors.SimpleDescriptorProvider" />
 
-	<bean id="repository" class="org.datacleaner.repository.file.FileRepository">
-		<constructor-arg type="java.io.File"
-			value="target/example_repo" />
-	</bean>
+	<bean id="repository" class="org.datacleaner.monitor.server.ExampleFileRepository" />
 
 	<bean id="alertNotificationService" name="alertNotificationService"
 		class="org.datacleaner.monitor.alertnotification.AlertNotificationServiceImpl"


### PR DESCRIPTION
Fixes #1562.

Use a FileRepository which copies the example repo to a real temp dir to prevent IOExceptions when running tests on Windows.