### PR TITLE
#1567 Docker testing build error: Dockerfile COPY command was updated

### DIFF
--- a/monitor/ui/src/test/resources/Dockerfile
+++ b/monitor/ui/src/test/resources/Dockerfile
@@ -3,4 +3,4 @@ FROM tomcat:8-jre8
 # The docker-maven-plugin adds the war to the maven folder because of the result of the <assembly> element within
 # <build> is added to the created docker image. Files and artifacts contained in the assembly are by default copied
 # under the "/maven" directory.
-COPY maven/${project.build.finalName}.war /usr/local/tomcat/webapps
+COPY maven/${project.build.finalName}.war /usr/local/tomcat/webapps/${project.build.finalName}.war


### PR DESCRIPTION
Fixes #1567 

COPY command in Dockerfile was updated with target file instead of target directory. 