### PR TITLE
Bug/1419 open job as template scrolling

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
@@ -503,7 +503,7 @@ public final class WidgetUtils {
         showErrorMessage(shortMessage, sb.toString(), exception);
     }
 
-    public static JScrollPane scrolleable(final JComponent comp, final int maxHeight) {
+    public static JScrollPane scrollable(final JComponent comp, final int maxHeight) {
         final JScrollPane scrollPane = WidgetUtils.scrolleable(comp);
 
         if (comp.getPreferredSize().getHeight() > maxHeight) {

--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetUtils.java
@@ -503,6 +503,18 @@ public final class WidgetUtils {
         showErrorMessage(shortMessage, sb.toString(), exception);
     }
 
+    public static JScrollPane scrolleable(final JComponent comp, final int maxHeight) {
+        final JScrollPane scrollPane = WidgetUtils.scrolleable(comp);
+
+        if (comp.getPreferredSize().getHeight() > maxHeight) {
+            final Dimension preferredSize = comp.getPreferredSize();
+            final Dimension newSize = new Dimension(preferredSize.width, maxHeight);
+            scrollPane.getViewport().setPreferredSize(newSize);
+        }
+
+        return scrollPane;
+    }
+
     public static JScrollPane scrolleable(final JComponent comp) {
         final JScrollPane scroll = new JScrollPane();
         if (comp != null) {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/MetadataDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/MetadataDialog.java
@@ -26,6 +26,7 @@ import org.datacleaner.job.builder.AnalysisJobBuilder;
 import org.datacleaner.panels.MetadataPanel;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
+import org.datacleaner.util.WidgetUtils;
 
 /**
  * A dialog containing metadata about a job and it's data source
@@ -33,7 +34,7 @@ import org.datacleaner.util.ImageManager;
 public class MetadataDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;
-    
+    private static final int MAX_HEIGHT = 800; 
     private final AnalysisJobBuilder _jobBuilder;
 
     public MetadataDialog(WindowContext windowContext, AnalysisJobBuilder jobBuilder) {
@@ -58,7 +59,6 @@ public class MetadataDialog extends AbstractDialog {
 
     @Override
     protected JComponent getDialogContent() {
-        return new MetadataPanel(_jobBuilder);
+        return WidgetUtils.scrolleable(new MetadataPanel(_jobBuilder), MAX_HEIGHT);
     }
-
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/MetadataDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/MetadataDialog.java
@@ -59,6 +59,6 @@ public class MetadataDialog extends AbstractDialog {
 
     @Override
     protected JComponent getDialogContent() {
-        return WidgetUtils.scrolleable(new MetadataPanel(_jobBuilder), MAX_HEIGHT);
+        return WidgetUtils.scrollable(new MetadataPanel(_jobBuilder), MAX_HEIGHT);
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
@@ -345,7 +345,7 @@ public class OpenAnalysisJobAsTemplateDialog extends AbstractDialog {
 
             addOpenButtonPanel();
 
-            return WidgetUtils.scrolleable(_panel, MAX_HEIGHT);
+            return WidgetUtils.scrollable(_panel, MAX_HEIGHT);
         }
 
         private void addTopLabels() {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialog.java
@@ -320,6 +320,7 @@ public class OpenAnalysisJobAsTemplateDialog extends AbstractDialog {
     }
 
     private class DialogContentMaker {
+        private static final int MAX_HEIGHT = 800;
         private final DCPanel _panel;
         private int _row;
 
@@ -344,7 +345,7 @@ public class OpenAnalysisJobAsTemplateDialog extends AbstractDialog {
 
             addOpenButtonPanel();
 
-            return WidgetUtils.scrolleable(_panel);
+            return WidgetUtils.scrolleable(_panel, MAX_HEIGHT);
         }
 
         private void addTopLabels() {


### PR DESCRIPTION
Fixes #1419 

"Open as template dialog" and "Metadata dialog" did not have its maximal height limited. In special cases it caused the window going out of the screen with no scroll-bars available. This fix introduces an option how to specify this maximal height and provides scroll bars when it is reached. 