### PR TITLE
#1579 AbstractWindow: minimal size.

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractWindow.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractWindow.java
@@ -41,15 +41,17 @@ public abstract class AbstractWindow extends JFrame implements DCWindow, WindowL
     public static final String SYSTEM_PROPERTY_HIDE_WINDOWS = "DataCleaner.Windows.Hide";
 
     private static final long serialVersionUID = 1L;
+    private static final int MIN_WIDTH = 400;
+    private static final int MIN_HEIGHT = 300;
     private volatile boolean initialized = false;
     private final WindowContext _windowContext;
 
     public AbstractWindow(WindowContext windowContext) {
         _windowContext = windowContext;
+        setMinimumSize(new Dimension(MIN_WIDTH, MIN_HEIGHT));
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         addWindowListener(this);
         getContentPane().setBackground(WidgetUtils.BG_COLOR_BRIGHT);
-
     }
 
     protected boolean maximizeWindow(){


### PR DESCRIPTION
Fixes #1579 

setMinimumSize(...) was added in AbstractWindow. 

Now e. g. "preview" window or "analysis result" window can not be shrinked to nothing anymore. 