### PR TITLE
#1581 DescriptorMenuItem: missing components' icons

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/DescriptorMenuItem.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/DescriptorMenuItem.java
@@ -87,7 +87,7 @@ public class DescriptorMenuItem extends JMenuItem implements ActionListener {
 
     @Override
     public Icon getIcon() {
-        return IconUtils.getDescriptorIcon(_descriptor, IconUtils.ICON_SIZE_MENU_ITEM, true);
+        return IconUtils.getDescriptorIcon(_descriptor, IconUtils.ICON_SIZE_MENU_ITEM, false);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1581 

Missing icons in a context menu were replaced by a default icon. 

![default-icons](https://cloud.githubusercontent.com/assets/13213915/19718195/9464e23c-9b64-11e6-8f85-728f3287d5f7.png)
