### PR TITLE
Improve Coalesce and Union behavior when deleting tables

### DIFF
--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
@@ -119,7 +119,7 @@ public class CoalesceUnit {
                 if(exceptionOnMissing) {
                     final List<String> names =
                             Arrays.stream(allInputColumns).map(InputColumn::getName).collect(Collectors.toList());
-                    throw new IllegalStateException(
+                    throw new CoalesceUnitMissingColumnException(this, newInputColumnName,
                             "Column '" + newInputColumnName + "' not found. Available columns: " + names);
                 }
             } else {

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
@@ -114,7 +114,7 @@ public class CoalesceUnit {
         final List<InputColumn<?>> newInputColumns = new ArrayList<>(newInputColumnNames.length);
 
         for (final String newInputColumnName : newInputColumnNames) {
-            final InputColumn<?> updatedInputColumn = updateInputColumn(allInputColumns, newInputColumnName);
+            final InputColumn<?> updatedInputColumn = findInputColumn(allInputColumns, newInputColumnName);
             if (updatedInputColumn == null) {
                 if (exceptionOnMissing) {
                     final List<String> names =
@@ -129,10 +129,10 @@ public class CoalesceUnit {
         return newInputColumns.toArray(new InputColumn[newInputColumns.size()]);
     }
 
-    private InputColumn<?> updateInputColumn(final InputColumn<?>[] allInputColumns, final String newInputColumnName) {
+    private InputColumn<?> findInputColumn(final InputColumn<?>[] allInputColumns, final String inputColumnName) {
         // Exact match round on path.
         for (final InputColumn<?> inputColumn : allInputColumns) {
-            if (newInputColumnName.contains(".") && inputColumn.isPhysicalColumn() && newInputColumnName
+            if (inputColumnName.contains(".") && inputColumn.isPhysicalColumn() && inputColumnName
                     .equals(inputColumn.getPhysicalColumn().getQualifiedLabel())) {
                 return inputColumn;
             }
@@ -140,7 +140,7 @@ public class CoalesceUnit {
 
         // Trimmed and case-insensitive path match round.
         for (final InputColumn<?> inputColumn : allInputColumns) {
-            if (newInputColumnName.contains(".") && inputColumn.isPhysicalColumn() && newInputColumnName.trim()
+            if (inputColumnName.contains(".") && inputColumn.isPhysicalColumn() && inputColumnName.trim()
                     .equalsIgnoreCase(inputColumn.getPhysicalColumn().getQualifiedLabel())) {
                 return inputColumn;
             }
@@ -148,14 +148,14 @@ public class CoalesceUnit {
 
         // Legacy: Exact name match round
         for (final InputColumn<?> inputColumn : allInputColumns) {
-            if (newInputColumnName.equals(inputColumn.getName())) {
+            if (inputColumnName.equals(inputColumn.getName())) {
                 return inputColumn;
             }
         }
 
         // Legacy: Trimmed and case-insensitive name match round.
         for (final InputColumn<?> inputColumn : allInputColumns) {
-            if (newInputColumnName.trim().equalsIgnoreCase(inputColumn.getName().trim())) {
+            if (inputColumnName.trim().equalsIgnoreCase(inputColumn.getName().trim())) {
                 return inputColumn;
             }
         }

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnit.java
@@ -87,7 +87,7 @@ public class CoalesceUnit {
      * @return New {@link CoalesceUnit} if {@link InputColumn}s has truly changed, otherwise this.
      */
     public CoalesceUnit getUpdatedCoalesceUnit(InputColumn<?>[] newInputColumns) {
-        if(Arrays.equals(_inputColumns, newInputColumns)){
+        if (Arrays.equals(_inputColumns, newInputColumns)) {
             return this;
         } else {
             return new CoalesceUnit(newInputColumns);
@@ -99,10 +99,10 @@ public class CoalesceUnit {
      * {@link CoalesceUnit}. This is necessary to do before any job execution to
      * ensure that the {@link InputColumn} references are intact and don't point
      * to e.g. a copy of the input columns from a cloned job.
-     * 
+     *
      * Not doing this will result in issues such as
      * <a href="https://github.com/datacleaner/DataCleaner/issues/923">issue #923</a>
-     * 
+     *
      * @return A new CoalesceUnit containing the updated columns.
      */
     public CoalesceUnit updateInputColumns(InputColumn<?>[] allInputColumns) {
@@ -116,7 +116,7 @@ public class CoalesceUnit {
         for (final String newInputColumnName : newInputColumnNames) {
             final InputColumn<?> updatedInputColumn = updateInputColumn(allInputColumns, newInputColumnName);
             if (updatedInputColumn == null) {
-                if(exceptionOnMissing) {
+                if (exceptionOnMissing) {
                     final List<String> names =
                             Arrays.stream(allInputColumns).map(InputColumn::getName).collect(Collectors.toList());
                     throw new CoalesceUnitMissingColumnException(this, newInputColumnName,
@@ -162,7 +162,6 @@ public class CoalesceUnit {
 
         return null;
     }
-
 
     public InputColumn<?>[] getInputColumns() {
         return _inputColumns;

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnitMissingColumnException.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnitMissingColumnException.java
@@ -1,0 +1,39 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.components.fuse;
+
+public class CoalesceUnitMissingColumnException extends IllegalStateException {
+    private final CoalesceUnit _coalesceUnit;
+    private final String _inputColunmName;
+
+    public CoalesceUnitMissingColumnException(CoalesceUnit coalesceUnit, String inputColunmName, String message) {
+        super(message);
+        _coalesceUnit = coalesceUnit;
+        _inputColunmName = inputColunmName;
+    }
+
+    public CoalesceUnit getCoalesceUnit() {
+        return _coalesceUnit;
+    }
+
+    public String getInputColunmName() {
+        return _inputColunmName;
+    }
+}

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnitMissingColumnException.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/CoalesceUnitMissingColumnException.java
@@ -20,6 +20,8 @@
 package org.datacleaner.components.fuse;
 
 public class CoalesceUnitMissingColumnException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
+
     private final CoalesceUnit _coalesceUnit;
     private final String _inputColunmName;
 

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
@@ -124,11 +124,16 @@ public class FuseStreamsComponent extends MultiStreamComponent {
         final OutputDataStreamBuilder builder = OutputDataStreams.pushDataStream(OUTPUT_DATA_STREAM_NAME);
         for (int i = 0; i < _units.length; i++) {
             // Not necessarily initialized yet, so no _initializedUnits available
-            final CoalesceUnit unit = _units[i].updateInputColumns(_inputs);
-            final Class<?> dataType = unit.getOutputDataType();
-            final String columnName = unit.getSuggestedOutputColumnName();
-            final ColumnType columnType = ColumnTypeImpl.convertColumnType(dataType);
-            builder.withColumn(columnName, columnType);
+            try {
+                final CoalesceUnit unit = _units[i].updateInputColumns(_inputs);
+                final Class<?> dataType = unit.getOutputDataType();
+                final String columnName = unit.getSuggestedOutputColumnName();
+                final ColumnType columnType = ColumnTypeImpl.convertColumnType(dataType);
+                builder.withColumn(columnName, columnType);
+            } catch (CoalesceUnitMissingColumnException e) {
+                logger.warn("Coalesce unit missing columns", e);
+                return new OutputDataStream[0];
+            }
         }
         return new OutputDataStream[] { builder.toOutputDataStream() };
     }

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
@@ -38,7 +38,6 @@ import org.datacleaner.api.InputRow;
 import org.datacleaner.api.MultiStreamComponent;
 import org.datacleaner.api.OutputDataStream;
 import org.datacleaner.api.OutputRowCollector;
-import org.datacleaner.api.Validate;
 import org.datacleaner.components.categories.CompositionCategory;
 import org.datacleaner.job.output.OutputDataStreamBuilder;
 import org.datacleaner.job.output.OutputDataStreams;
@@ -85,11 +84,6 @@ public class FuseStreamsComponent extends MultiStreamComponent {
         }
     }
 
-    @Validate
-    public void validate() {
-        logger.debug("Yes yes");
-    }
-
     /**
      * Configures the transformer using the coalesce units provided
      * 
@@ -132,7 +126,7 @@ public class FuseStreamsComponent extends MultiStreamComponent {
         for (final CoalesceUnit _unit : _units) {
             // Not necessarily initialized yet, so no _initializedUnits available
             final InputColumn<?>[] updatedInputColumns = _unit.getUpdatedInputColumns(_inputs, false);
-            if(_unit.getInputColumns().length == updatedInputColumns.length){
+            if (_unit.getInputColumns().length == updatedInputColumns.length) {
                 // Valid Unit
                 foundOutputDataStream = true;
                 final CoalesceUnit unit = _unit.getUpdatedCoalesceUnit(updatedInputColumns);
@@ -144,7 +138,7 @@ public class FuseStreamsComponent extends MultiStreamComponent {
                 logger.info("Missing columns detected, skipping coalesce unit");
             }
         }
-        if(!foundOutputDataStream) {
+        if (!foundOutputDataStream) {
             return new OutputDataStream[0];
         }
         return new OutputDataStream[] { builder.toOutputDataStream() };

--- a/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
+++ b/components/fuse/src/main/java/org/datacleaner/components/fuse/FuseStreamsComponent.java
@@ -126,7 +126,7 @@ public class FuseStreamsComponent extends MultiStreamComponent {
         for (final CoalesceUnit _unit : _units) {
             // Not necessarily initialized yet, so no _initializedUnits available
             final InputColumn<?>[] updatedInputColumns = _unit.getUpdatedInputColumns(_inputs, false);
-            if (_unit.getInputColumns().length == updatedInputColumns.length) {
+            if (_unit.getInputColumnNames().length == updatedInputColumns.length) {
                 // Valid Unit
                 foundOutputDataStream = true;
                 final CoalesceUnit unit = _unit.getUpdatedCoalesceUnit(updatedInputColumns);

--- a/components/fuse/src/test/java/org/datacleaner/components/fuse/CoalesceUnitTest.java
+++ b/components/fuse/src/test/java/org/datacleaner/components/fuse/CoalesceUnitTest.java
@@ -109,7 +109,7 @@ public class CoalesceUnitTest {
         Assert.assertArrayEquals(colsB, namesCoalesceUnit.updateInputColumns(colsB).getInputColumns());
 
         // Mixed columns with correct path as well as incorrect path. Makes sure that the correct path is found.
-        Assert.assertArrayEquals(colsB, namesCoalesceUnit.updateInputColumns(mixedCols).getInputColumns());
+        Assert.assertArrayEquals(colsB, pathsCoalesceUnit.updateInputColumns(mixedCols).getInputColumns());
 
         expectedException.expect(IllegalStateException.class);
         pathsCoalesceUnit.updateInputColumns(colsA);

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CoalesceUnitPanel extends DCPanel {
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LoggerFactory.getLogger(CoalesceUnitPanel.class);
 
     private final ColumnListMultipleCoalesceUnitPropertyWidget _parent;
     private final DCComboBox<InputColumn<?>> _comboBox;
@@ -97,7 +96,7 @@ public class CoalesceUnitPanel extends DCPanel {
         setAvailableInputColumns(availableInputColumns);
 
         if (unit != null) {
-            InputColumn<?>[] updatedInputColumns = unit.getUpdatedInputColumns(availableInputColumns
+            final InputColumn<?>[] updatedInputColumns = unit.getUpdatedInputColumns(availableInputColumns
                     .toArray(new InputColumn[availableInputColumns.size()]), false);
             for (InputColumn<?> inputColumn : updatedInputColumns) {
                 addInputColumn(inputColumn);

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/CoalesceUnitPanel.java
@@ -97,14 +97,10 @@ public class CoalesceUnitPanel extends DCPanel {
         setAvailableInputColumns(availableInputColumns);
 
         if (unit != null) {
-            try  {
-                InputColumn<?>[] inputColumns = unit.updateInputColumns(availableInputColumns
-                        .toArray(new InputColumn[availableInputColumns.size()])).getInputColumns();
-                for (InputColumn<?> inputColumn : inputColumns) {
-                    addInputColumn(inputColumn);
-                }
-            } catch (IllegalStateException e){
-                logger.warn("Could not update columns on component {}", parent.getComponentBuilder().getName(), e);
+            InputColumn<?>[] updatedInputColumns = unit.getUpdatedInputColumns(availableInputColumns
+                    .toArray(new InputColumn[availableInputColumns.size()]), false);
+            for (InputColumn<?> inputColumn : updatedInputColumns) {
+                addInputColumn(inputColumn);
             }
         }
     }

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
@@ -277,7 +277,7 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
         }
 
         for (CoalesceUnit unit : units) {
-            final CoalesceUnit updatedCoalesceUnit = unit.updateInputColumns(allInputColumns, true);
+            final CoalesceUnit updatedCoalesceUnit = unit.updateInputColumns(allInputColumns);
             if (updatedCoalesceUnit != null) {
                 final InputColumn<?>[] inputColumns = updatedCoalesceUnit.getInputColumns();
                 Collections.addAll(resultList, inputColumns);
@@ -391,19 +391,18 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
         } catch (CoalesceUnitMissingColumnException e) {
             logger.warn("Missing input column for coalesce unit", e);
             final CoalesceUnit failingCoalesceUnit = e.getCoalesceUnit();
-            final CoalesceUnit[] newCoaleasceUnits =
+            final CoalesceUnit[] newCoalesceUnits =
                     (CoalesceUnit[]) ArrayUtils.removeElement(_unitPropertyWidget.getValue(), failingCoalesceUnit);
             for (InputColumn<?> inputColumn : failingCoalesceUnit.getInputColumns()) {
                 _pickedInputColumns.remove(inputColumn);
             }
-            for (CoalesceUnitPanel coalesceUnitPanel : getCoalesceUnitPanels()) {
-                if(coalesceUnitPanel.getCoalesceUnit().equals(failingCoalesceUnit)) {
-                    removeCoalesceUnitPanel(coalesceUnitPanel);
-                }
-            }
-            _unitPropertyWidget.onValueTouched(newCoaleasceUnits);
+            getCoalesceUnitPanels().stream()
+                    .filter(coalesceUnitPanel -> coalesceUnitPanel.getCoalesceUnit().equals(failingCoalesceUnit))
+                    .forEach(this::removeCoalesceUnitPanel);
+            _unitPropertyWidget.onValueTouched(newCoalesceUnits);
             updateAvailableInputColumns();
             fireBothValuesChanged();
+            updateUI();
         }
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/ColumnListMultipleCoalesceUnitPropertyWidget.java
@@ -277,11 +277,8 @@ public class ColumnListMultipleCoalesceUnitPropertyWidget extends AbstractProper
         }
 
         for (CoalesceUnit unit : units) {
-            final CoalesceUnit updatedCoalesceUnit = unit.updateInputColumns(allInputColumns);
-            if (updatedCoalesceUnit != null) {
-                final InputColumn<?>[] inputColumns = updatedCoalesceUnit.getInputColumns();
-                Collections.addAll(resultList, inputColumns);
-            }
+            final InputColumn<?>[] updatedInputColumns = unit.getUpdatedInputColumns(allInputColumns, true);
+            Collections.addAll(resultList, updatedInputColumns);
         }
 
         logger.debug("Returning Input.value = {}", resultList);

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
@@ -22,7 +22,9 @@ package org.datacleaner.panels.fuse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
@@ -72,7 +74,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
     public StreamColumnMatrixMultipleCoalesceUnitPropertyWidget(ComponentBuilder componentBuilder,
             ConfiguredPropertyDescriptor inputProperty, ConfiguredPropertyDescriptor unitProperty) {
         super(componentBuilder, inputProperty);
-        _unitProperty = unitProperty;
+            _unitProperty = unitProperty;
         _tablePanels = new ArrayList<>();
 
         getAnalysisJobBuilder().addTransformerChangeListener(this);
@@ -155,7 +157,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
                 for (CoalesceUnit unit : units) {
                     final List<InputColumn<?>> survivingColumns = new ArrayList<>(unit.getInputColumns().length);
                     for (InputColumn<?> inputColumn : unit.getInputColumns()) {
-                        if (sourceColumnFinder.findOriginatingTable(inputColumn) != null) {
+                        if (allTablesAndColumns.containsKey(inputColumn.getPhysicalColumn().getTable())) {
                             survivingColumns.add(inputColumn);
                         }
                     }
@@ -170,7 +172,14 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
                         }
                     }
                 }
-                _unitProperty
+                if (!Arrays.equals(units,
+                        survivingCoalesceUnits.toArray(new CoalesceUnit[survivingCoalesceUnits.size()]))) {
+                    Map<ConfiguredPropertyDescriptor, Object> properties = new HashMap<>();
+                    properties.put(getPropertyDescriptor(), getValue());
+                    properties.put(_unitProperty,
+                            survivingCoalesceUnits.toArray(new CoalesceUnit[survivingCoalesceUnits.size()]));
+                    fireValuesChanged(properties);
+                }
             }
 
             _tablePanels.add(tablePanel);

--- a/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/fuse/StreamColumnMatrixMultipleCoalesceUnitPropertyWidget.java
@@ -74,7 +74,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
     public StreamColumnMatrixMultipleCoalesceUnitPropertyWidget(ComponentBuilder componentBuilder,
             ConfiguredPropertyDescriptor inputProperty, ConfiguredPropertyDescriptor unitProperty) {
         super(componentBuilder, inputProperty);
-            _unitProperty = unitProperty;
+        _unitProperty = unitProperty;
         _tablePanels = new ArrayList<>();
 
         getAnalysisJobBuilder().addTransformerChangeListener(this);
@@ -110,7 +110,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
 
         final AnalysisJobBuilder ajb = getAnalysisJobBuilder();
 
-        InputColumn<?>[] inputColumns = ajb.getSourceColumns().toArray(new InputColumn[0]);
+        final InputColumn<?>[] inputColumns = ajb.getSourceColumns().toArray(new InputColumn[0]);
 
         // TODO: We need a SourceColumnFinder that is aware of also nested jobs
         final SourceColumnFinder sourceColumnFinder = new SourceColumnFinder();
@@ -121,7 +121,7 @@ public class StreamColumnMatrixMultipleCoalesceUnitPropertyWidget extends Abstra
         final Multimap<Table, InputColumn<?>> coalescedTablesAndColumns = ArrayListMultimap.create();
 
         for (InputColumn<?> inputColumn : inputColumns) {
-            Table table = sourceColumnFinder.findOriginatingTable(inputColumn);
+            final Table table = sourceColumnFinder.findOriginatingTable(inputColumn);
             allTablesAndColumns.put(table, inputColumn);
         }
 

--- a/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
@@ -288,8 +288,6 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
         // output changes
         if (isConfigured()) {
             getOutputColumns();
-        } else {
-            _outputColumns.clear();
         }
 
         List<TransformerChangeListener> listeners = getAllListeners();

--- a/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/TransformerComponentBuilder.java
@@ -288,6 +288,8 @@ public final class TransformerComponentBuilder<T extends Transformer> extends
         // output changes
         if (isConfigured()) {
             getOutputColumns();
+        } else {
+            _outputColumns.clear();
         }
 
         List<TransformerChangeListener> listeners = getAllListeners();


### PR DESCRIPTION
This tries to make Fuse/Coalesce and Union components behave a bit better when removing tables. Fuse/Coalesce should no longer throw error as well as update as it should.

Union is also no longer throwing errors, however it will _not_ update until after closing and opening the dialog. A new issue will be created to deal with that.

Fixes #1580 