### PR TITLE
Adding JobWizard interfaces

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
@@ -26,23 +26,66 @@ import org.datacleaner.connection.Datastore;
 import org.datacleaner.util.IconUtils;
 
 /**
- * Defines a wizard on the first screen of the commercial editions of
- * DataCleaner
+ * Defines a wizard which is shown on the DataCleaner welcome screen. The wizard can be used to create a job,
+ * which can either be opened in DataCleaner or be directly run.
  */
 public interface JobWizard {
+    /**
+     * Text for next button in wizard.
+     */
     static final String BUTTON_NEXT_TEXT = "Next >";
+
+    /**
+     * Icon for next button in wizard.
+     */
     static final String BUTTON_NEXT_ICON = IconUtils.ACTION_FORWARD;
 
+    /**
+     * Checks if all necessary components to use the wizard are available.
+     *
+     * @return <code>true</code> if the wizard can be used
+     */
     boolean isAvailable();
 
+    /**
+     * Gets the icon which is shown for the wizard on the welcome screen, or <code>null</code> if none is
+     * defined for the wizard.
+     *
+     * @return an {@link Icon}
+     */
     Icon getIcon();
 
+    /**
+     * Gets the title for the wizard.
+     *
+     * @return Title for the wizard
+     */
     String getTitle();
 
+    /**
+     * Gets the description of the wizard. Describes what the wizard can be used for.
+     *
+     * @return description of the wizard
+     */
     String getDescription();
 
-    void startWizard(DataCleanerConfiguration configuration, Datastore selectedDatastore,
-            JobWizardCallback callback);
+    /**
+     * Starts wizard when it is activated from the welcome screen, after a Datastore has been selected to use
+     * with it.
+     *
+     * @param configuration
+     *            {@link DataCleanerConfiguration} passed by DataCleaner
+     * @param selectedDatastore
+     *            {@link Datastore} which is selected to use the wizard with
+     * @param callback
+     *            {@link JobWizardCallback} which contains some signaling logic
+     */
+    void startWizard(DataCleanerConfiguration configuration, Datastore selectedDatastore, JobWizardCallback callback);
 
+    /**
+     * Gets the category the JobWizard belongs to.
+     *
+     * @return A String representing the category
+     */
     String getCategory();
 }

--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
@@ -30,17 +30,19 @@ import org.datacleaner.util.IconUtils;
  * DataCleaner
  */
 public interface JobWizard {
-    public static final String BUTTON_NEXT_TEXT = "Next >";
-    public static final String BUTTON_NEXT_ICON = IconUtils.ACTION_FORWARD;
+    static final String BUTTON_NEXT_TEXT = "Next >";
+    static final String BUTTON_NEXT_ICON = IconUtils.ACTION_FORWARD;
 
-    public boolean isAvailable();
+    boolean isAvailable();
 
-    public Icon getIcon();
+    Icon getIcon();
 
-    public String getTitle();
+    String getTitle();
 
-    public String getDescription();
+    String getDescription();
 
-    public void startWizard(DataCleanerConfiguration configuration, Datastore selectedDatastore,
+    void startWizard(DataCleanerConfiguration configuration, Datastore selectedDatastore,
             JobWizardCallback callback);
+
+    String getCategory();
 }

--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizard.java
@@ -1,0 +1,46 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.wizard;
+
+import javax.swing.Icon;
+
+import org.datacleaner.configuration.DataCleanerConfiguration;
+import org.datacleaner.connection.Datastore;
+import org.datacleaner.util.IconUtils;
+
+/**
+ * Defines a wizard on the first screen of the commercial editions of
+ * DataCleaner
+ */
+public interface JobWizard {
+    public static final String BUTTON_NEXT_TEXT = "Next >";
+    public static final String BUTTON_NEXT_ICON = IconUtils.ACTION_FORWARD;
+
+    public boolean isAvailable();
+
+    public Icon getIcon();
+
+    public String getTitle();
+
+    public String getDescription();
+
+    public void startWizard(DataCleanerConfiguration configuration, Datastore selectedDatastore,
+            JobWizardCallback callback);
+}

--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
@@ -25,7 +25,7 @@ import org.datacleaner.job.builder.AnalysisJobBuilder;
 
 public interface JobWizardCallback {
 
-    public void setWizardContent(JComponent component);
+    void setWizardContent(JComponent component);
 
-    public void setWizardFinished(AnalysisJobBuilder analysisJobBuilder);
+    void setWizardFinished(AnalysisJobBuilder analysisJobBuilder);
 }

--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
@@ -1,0 +1,31 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.wizard;
+
+import javax.swing.JComponent;
+
+import org.datacleaner.job.builder.AnalysisJobBuilder;
+
+public interface JobWizardCallback {
+
+    public void setWizardContent(JComponent component);
+
+    public void setWizardFinished(AnalysisJobBuilder analysisJobBuilder);
+}

--- a/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/JobWizardCallback.java
@@ -23,9 +23,27 @@ import javax.swing.JComponent;
 
 import org.datacleaner.job.builder.AnalysisJobBuilder;
 
+/**
+ * Defines a callback for a JobWizard which contains some logic which may be invoked when or when done using a
+ * {@link JobWizard}.
+ */
 public interface JobWizardCallback {
 
+    /**
+     * Sets the contents of the wizard panel to the given component, which is typically used within the flow
+     * of the wizard for rendering.
+     *
+     * @param component
+     *            {@link JComponent} with content for wizard panel
+     */
     void setWizardContent(JComponent component);
 
+    /**
+     * Indicates the wizard is finished and passed the analysisJobBuilder which has been built using a
+     * {@link JobWizard}.
+     *
+     * @param analysisJobBuilder
+     *            {@link AnalysisJobBuilder} which has been built using the {@link JobWizard}
+     */
     void setWizardFinished(AnalysisJobBuilder analysisJobBuilder);
 }

--- a/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
@@ -21,8 +21,21 @@ package org.datacleaner.wizard;
 
 import java.util.List;
 
+/**
+ * Defines a provider which provides wizards which can be used to create a job.
+ */
 public interface WizardProvider {
+    /**
+     * Gets the name of the provider.
+     *
+     * @return a {@link String} representing the name
+     */
     String getName();
 
+    /**
+     * Instantiates and returns a list of {@link JobWizard} objects.
+     *
+     * @return a list of {@link JobWizard} object instances
+     */
     List<JobWizard> getWizards();
 }

--- a/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
@@ -1,0 +1,9 @@
+package org.datacleaner.wizard;
+
+import java.util.List;
+
+public interface WizardProvider {
+    String getName();
+
+    List<JobWizard> getWizards();
+}

--- a/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
+++ b/desktop/api/src/main/java/org/datacleaner/wizard/WizardProvider.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.wizard;
 
 import java.util.List;


### PR DESCRIPTION
Fixes #1599.

Add `JobWizard` and `JobWizardCallback` interfaces to DataCleaner to make it possible to add pluggable  wizards which can be used to kick-start jobs to DataCleaner.