### PR TITLE
Move MonitorRestEndpoint to testware

### DIFF
--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -423,7 +423,6 @@
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>3.0.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/monitor/ui/src/test/java/org/datacleaner/monitor/AuthenticationIT.java
+++ b/monitor/ui/src/test/java/org/datacleaner/monitor/AuthenticationIT.java
@@ -22,6 +22,7 @@ package org.datacleaner.monitor;
 import java.io.IOException;
 
 import org.apache.http.HttpStatus;
+import org.datacleaner.test.MonitorRestEndpoint;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/monitor/ui/src/test/java/org/datacleaner/monitor/JobServicesIT.java
+++ b/monitor/ui/src/test/java/org/datacleaner/monitor/JobServicesIT.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.apache.http.HttpStatus;
+import org.datacleaner.test.MonitorRestEndpoint;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -1452,6 +1452,11 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>io.rest-assured</groupId>
+				<artifactId>rest-assured</artifactId>
+				<version>3.0.1</version>
+			</dependency>
+			<dependency>
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest_2.11</artifactId>
 				<version>2.2.0</version>

--- a/testware/pom.xml
+++ b/testware/pom.xml
@@ -61,5 +61,10 @@
 			<artifactId>scalatest_2.11</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testware/src/main/java/org/datacleaner/test/MonitorRestEndpoint.java
+++ b/testware/src/main/java/org/datacleaner/test/MonitorRestEndpoint.java
@@ -17,7 +17,7 @@
  * 51 Franklin Street, Fifth Floor
  * Boston, MA  02110-1301  USA
  */
-package org.datacleaner.monitor;
+package org.datacleaner.test;
 
 import java.net.URI;
 import java.net.URISyntaxException;


### PR DESCRIPTION
This should make it available outside core DC.

Fixes #1607

(Note: Travis might fail with an unrelated issue in desktop-ui. I'll merge master when the #1606 PR has been merged, so we're sure Travis is happy about this)