### PR TITLE
#1609 CategorizationResult does not show empty sample anymore

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/result/CategorizationResult.java
+++ b/engine/core/src/main/java/org/datacleaner/result/CategorizationResult.java
@@ -93,6 +93,11 @@ public class CategorizationResult implements AnalyzerResult {
         if (annotation == null) {
             return null;
         }
+
+        if (!rowAnnotationFactory.hasSampleRows(annotation)) {
+            return null;
+        }
+
         return new AnnotatedRowsResult(annotation, rowAnnotationFactory);
     }
 


### PR DESCRIPTION
Fixes #1609  

CategorizationResult (e. g. Country standardizer result) does not show the little green button to show the sample rows if there is none available (no empty list anymore).

![unexpected-no-button](https://cloud.githubusercontent.com/assets/13213915/20264261/ed892700-aa6a-11e6-8074-5bc459abb036.png)
