### PR TITLE
Stop inferring custom column names

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/connection/ExcelDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/ExcelDatastore.java
@@ -89,10 +89,6 @@ public final class ExcelDatastore extends UsageAwareDatastore<UpdateableDataCont
             dc = new ExcelDataContext(resource, excelConfiguration);
         }
         
-        if (_customColumnNames == null){
-            _customColumnNames = Arrays.asList(dc.getDefaultSchema().getTable(0).getColumnNames()); 
-        }
-       
         return new UpdateableDatastoreConnectionImpl<UpdateableDataContext>(dc, this);
     }
 

--- a/engine/core/src/main/java/org/datacleaner/connection/ExcelDatastore.java
+++ b/engine/core/src/main/java/org/datacleaner/connection/ExcelDatastore.java
@@ -22,7 +22,6 @@ package org.datacleaner.connection;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.Arrays;
 import java.util.List;
 
 import org.datacleaner.util.ReadObjectBuilder;


### PR DESCRIPTION
In case no column names were given, we tried to infer what they would be. Unfortunately that didn't work as expected, instead throw an exception, so we're removing again. This might need rethinking when we're actually going to use that data, but this was only a preparation for the new MM.

Fixes #1617