### PR TITLE
#1385 The legend in create-string-pattern-dialog was corrected

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/SimpleStringPatternDialog.java
@@ -213,7 +213,7 @@ public final class SimpleStringPatternDialog extends AbstractDialog {
 
         final DescriptionLabel descriptionLabel = new DescriptionLabel(
                 "<p>Simple string patterns are tokenized patterns made up of these elements.</p>"
-                        + "<p>* A = upper case letters<br>* a = lower case letters<br>* 9 = digits</p>");
+                        + "<p>* A = upper case letter<br>* a = lower case letters<br>* 9 = digits</p>");
 
         final DCPanel mainPanel = new DCPanel();
         mainPanel.setLayout(new BorderLayout());


### PR DESCRIPTION
Fixes #1385 

New string pattern dialog's legend: 'A' means one letter, not multiple letters.

![before](https://cloud.githubusercontent.com/assets/13213915/20668261/2e1be6dc-b56e-11e6-977f-97ca41067a9c.png)
![now](https://cloud.githubusercontent.com/assets/13213915/20668260/2e1ba938-b56e-11e6-9fd6-0069d04b5202.png)
