### PR TITLE
Set DATACLEANER_HOME to the temp folder

### DIFF
--- a/testware/src/main/java/org/datacleaner/cli/JobTestHelper.java
+++ b/testware/src/main/java/org/datacleaner/cli/JobTestHelper.java
@@ -88,6 +88,7 @@ public class JobTestHelper {
         final String[] processBuilderArguments = ArrayUtils.addAll(new String[] { JAVA_EXECUTABLE, DATACLEANER_MAIN_CLASS_NAME,
                 "-job", jobFileName, "-conf", confFileName }, extraCLIArgs);
         final ProcessBuilder builder = new ProcessBuilder(processBuilderArguments);
+        builder.environment().put("DATACLEANER_HOME", URLDecoder.decode(repository.getAbsolutePath(), "UTF-8"));
         builder.environment().put("CLASSPATH", System.getProperty("java.class.path"));
 
         final Process process = builder.start();


### PR DESCRIPTION
This will always use the temporary repository folder as DATACLEANER_HOME, so that files cannot conflict with developer home and other tests.

Fixes #1627 
