### PR TITLE
Change line wrapping and indentation for enums by Eclipse formatter

### DIFF
--- a/Formatter-Eclipse.xml
+++ b/Formatter-Eclipse.xml
@@ -26,7 +26,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
 <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>


### PR DESCRIPTION
Changed the Eclipse formatter, so for enums the constants are placed on one line if they all fit, otherwise they are all put beneath each other with the same indentation.