### PR TITLE
Align Eclipse formatter with IntelliJ

### DIFF
--- a/Formatter-Eclipse.xml
+++ b/Formatter-Eclipse.xml
@@ -8,7 +8,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
@@ -64,8 +64,8 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
@@ -73,7 +73,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
@@ -127,7 +127,7 @@
 <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
@@ -199,7 +199,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
@@ -262,7 +262,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/shared/JavaScriptCallbacks.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/shared/JavaScriptCallbacks.java
@@ -41,6 +41,7 @@ public final class JavaScriptCallbacks {
      *
      * @return
      */
+    // @formatter:off
     public static native String getJobGroupingCategory() /*-{
         if ($wnd.datacleaner && $wnd.datacleaner.getJobGroupingCategory) {
             var v = $wnd.datacleaner.getJobGroupingCategory();
@@ -50,6 +51,7 @@ public final class JavaScriptCallbacks {
         }
         return null;
     }-*/;
+    // @formatter:on
 
     /**
      * Called when the user navigates in a wizard to the next step.
@@ -62,6 +64,7 @@ public final class JavaScriptCallbacks {
      *            state.
      * @return
      */
+    // @formatter:off
     public static native boolean onWizardProgress(String wizardDisplayName, int stepIndex, int steps) /*-{
         if ($wnd.datacleaner && $wnd.datacleaner.onWizardProgress) {
             var v = $wnd.datacleaner.onWizardProgress(wizardDisplayName, stepIndex, steps);
@@ -72,6 +75,7 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Called when the wizard is finished and the last screen is shown.
@@ -81,6 +85,7 @@ public final class JavaScriptCallbacks {
      *
      * @return whether or not a callback was invoked
      */
+    // @formatter:off
     public static native boolean onWizardFinished(String wizardDisplayName, String resultEntityName) /*-{
         if ($wnd.datacleaner && $wnd.datacleaner.onWizardFinished) {
             var v = $wnd.datacleaner.onWizardFinished(wizardDisplayName, resultEntityName);
@@ -91,6 +96,7 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Called when a wizard is finished and the user clicks a button to close
@@ -103,6 +109,7 @@ public final class JavaScriptCallbacks {
      *
      * @return whether or not a callback was invoked
      */
+    // @formatter:off
     public static native boolean onWizardPanelClosing(String wizardDisplayName, String wizardResultName) /*-{
         if ($wnd.datacleaner && $wnd.datacleaner.onWizardPanelClosing) {
             var v = $wnd.datacleaner.onWizardPanelClosing(wizardDisplayName, wizardResultName);
@@ -113,6 +120,7 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Called when a wizard is closed/cancelled before finishing it.
@@ -122,6 +130,7 @@ public final class JavaScriptCallbacks {
      *
      * @return whether or not a callback was invoked
      */
+    // @formatter:off
     public static native boolean onWizardCancelled(String wizardDisplayName) /*-{
 
         if ($wnd.datacleaner && $wnd.datacleaner.onWizardCancelled) {
@@ -133,12 +142,14 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Called when the user clicks a button to close the execution status panel.
      *
      * @return whether or not a callback was invoked
      */
+    // @formatter:off
     public static native boolean onExecutionStatusPanelClosing() /*-{
 
         if ($wnd.datacleaner && $wnd.datacleaner.onExecutionStatusPanelClosing) {
@@ -151,12 +162,14 @@ public final class JavaScriptCallbacks {
         return false;
 
     }-*/;
+    // @formatter:on
 
     /**
      * Called when the DataCleaner API has been initialized
      *
      * @return
      */
+    // @formatter:off
     public static native boolean onApiInitialized() /*-{
         if ($wnd.datacleaner && $wnd.datacleaner.onApiInitialized) {
             var v = $wnd.datacleaner.onApiInitialized();
@@ -167,6 +180,7 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Native method to call Javascript onError function, in case onError method
@@ -179,6 +193,7 @@ public final class JavaScriptCallbacks {
      *            produced by the system/code.
      * @return boolean
      */
+    // @formatter:off
     public static native boolean onError(String message, boolean userFeedback)/*-{
         if ($wnd.datacleaner && (typeof $wnd.datacleaner.onError == 'function')) {
             var v = $wnd.datacleaner.onError(message, userFeedback);
@@ -189,6 +204,7 @@ public final class JavaScriptCallbacks {
         }
         return false;
     }-*/;
+    // @formatter:on
 
     /**
      * Exposes the DataCleaner wizard JS API.
@@ -206,12 +222,14 @@ public final class JavaScriptCallbacks {
      * startJobWizard(datastoreName, wizardName, htmlDivId)
      */
     @SuppressWarnings("checkstyle:LineLength")
+    // @formatter:off
     public static native void exportStartJobWizard() /*-{
         if (!$wnd.datacleaner) {
             $wnd.datacleaner = {};
         }
         $wnd.datacleaner.startJobWizard = @org.datacleaner.monitor.shared.JavaScriptCallbacks::startJobWizard(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;);
     }-*/;
+    // @formatter:on
 
     /**
      * Exports a JS method:
@@ -219,12 +237,14 @@ public final class JavaScriptCallbacks {
      * startJobWizard(wizardName, htmlDivId)
      */
     @SuppressWarnings("checkstyle:LineLength")
+    // @formatter:off
     public static native void exportStartDatastoreWizard() /*-{
         if (!$wnd.datacleaner) {
             $wnd.datacleaner = {};
         }
         $wnd.datacleaner.startDatastoreWizard = @org.datacleaner.monitor.shared.JavaScriptCallbacks::startDatastoreWizard(Ljava/lang/String;Ljava/lang/String;);
     }-*/;
+    // @formatter:on
 
     /**
      * Exports a JS method:
@@ -232,12 +252,14 @@ public final class JavaScriptCallbacks {
      * startReferenceDataWizard(referenceDataType, wizardName, htmlDivId)
      */
     @SuppressWarnings("checkstyle:LineLength")
+    // @formatter:off
     public static native void exportStartReferenceDataWizard() /*-{
         if (!$wnd.datacleaner) {
             $wnd.datacleaner = {};
         }
         $wnd.datacleaner.startReferenceDataWizard = @org.datacleaner.monitor.shared.JavaScriptCallbacks::startReferenceDataWizard(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;);
     }-*/;
+    // @formatter:on
 
     /**
      * Starts a job wizard based on parameters given from a native JS call.


### PR DESCRIPTION
Changed eclipse code formatter so it formats the code more like Intellij does using the IDEA formatter.

Also added a few @formatter:off, @formatter:on annotations for some difficult cases.