### PR TITLE
fixes #1641. fixed uploading of csv(upload without selecting a file)

### DIFF
--- a/monitor/extensions/csv-datastore-wizard/src/main/resources/org/datacleaner/monitor/server/wizard/CsvDatastoreUploadOrExistingFileWizardPage.html
+++ b/monitor/extensions/csv-datastore-wizard/src/main/resources/org/datacleaner/monitor/server/wizard/CsvDatastoreUploadOrExistingFileWizardPage.html
@@ -23,9 +23,10 @@
 			want to upload the file to the server (max. 50mb)</label><br />
 
 		<div id="csv_file_upload_div">
-			<input type="file" name="csv_file_upload" /> <input type="button"
+			<input type="file" name="csv_file_upload"  onchange="window.enableUploadButton('uploadButton');"/> 
+			<input type="button" id="uploadButton"
 				value="upload now"
-				onclick="window.uploadFile('csv_file_upload_div');" />
+				onclick="window.uploadFile('csv_file_upload_div');" disabled/>
 		</div>
 	</div>
 </div>

--- a/monitor/extensions/excel-datastore-wizard/src/main/resources/org/datacleaner/monitor/server/wizard/ExcelDatastoreUploadOrExistingFileWizardPage.html
+++ b/monitor/extensions/excel-datastore-wizard/src/main/resources/org/datacleaner/monitor/server/wizard/ExcelDatastoreUploadOrExistingFileWizardPage.html
@@ -22,9 +22,11 @@
 			want to upload the file to the server</label><br />
 
 		<div id="excel_spreadsheet_upload_div">
-			<input type="file" name="excel_spreadsheet_upload" /> <input type="button"
-				value="upload now"
-				onclick="window.uploadFile('excel_spreadsheet_upload_div');" />
+			<input type="file" name="excel_spreadsheet_upload"
+				onchange="window.enableUploadButton('uploadButton');" /> <input
+				type="button" id="uploadButton" value="upload now"
+				onclick="window.uploadFile('excel_spreadsheet_upload_div');"
+				disabled />
 		</div>
 	</div>
 </div>

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/shared/widgets/FileUploadFunctionHandler.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/shared/widgets/FileUploadFunctionHandler.java
@@ -41,6 +41,13 @@ import com.google.gwt.user.client.ui.RootPanel;
  * FileUploadServlet available in DC monitor.
  */
 public class FileUploadFunctionHandler {
+    
+    public static void enableUploadButton(final String buttonId) {
+        final Element element = Document.get().getElementById(buttonId);
+
+        GWT.log("Found file upload button element: " + element);
+        element.removeAttribute("disabled");
+    }
 
     public static void uploadFile(final String fileUploadElementId) {
         final Element element = Document.get().getElementById(fileUploadElementId);
@@ -134,4 +141,15 @@ public class FileUploadFunctionHandler {
     public static native void exportFileUploadFunction() /*-{
         $wnd.uploadFile = $entry(@org.datacleaner.monitor.shared.widgets.FileUploadFunctionHandler::uploadFile(Ljava/lang/String;));
     }-*/;
+    
+    /**
+     * Exports the "enableUploadButton(final String buttonId)" method as a function in the native
+     * javascript scope.
+     */
+    @SuppressWarnings("checkstyle:LineLength")
+    public static native void exportEnableUploadButtonFunction() /*-{
+        $wnd.enableUploadButton = $entry(@org.datacleaner.monitor.shared.widgets.FileUploadFunctionHandler::enableUploadButton(Ljava/lang/String;));
+    }-*/;
+    
+    
 }

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/wizard/AbstractWizardController.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/wizard/AbstractWizardController.java
@@ -78,6 +78,7 @@ public abstract class AbstractWizardController<S extends WizardNavigationService
         _tenant = tenant;
 
         FileUploadFunctionHandler.exportFileUploadFunction();
+        FileUploadFunctionHandler.exportEnableUploadButtonFunction();
 
         _loadingIndicator = new LoadingIndicator();
         _wizardPanel.setContent(_loadingIndicator);


### PR DESCRIPTION
fixes #1641. fixed uploading of csv(upload without selecting a file)
The upload button is disabled if no file has been selected for uploading. 

The changes can extended to the Excel datastore as well