### PR TITLE
#1662 .datacleaner_upload used properly

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/media/FileUploadServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/media/FileUploadServlet.java
@@ -119,8 +119,12 @@ public class FileUploadServlet extends HttpServlet {
         File tempFolder = FileHelper.getTempDir();
         try {
             final File subDirectory = new File(tempFolder, ".datacleaner_upload");
-            if (subDirectory.mkdirs()) {
+            subDirectory.mkdirs();
+
+            if (subDirectory.exists()) {
                 tempFolder = subDirectory;
+            } else {
+                logger.warn("Subdirectory '{}' was not created. ", subDirectory.getAbsolutePath());
             }
         } catch (final Exception e) {
             logger.warn("Could not create subdirectory in temp folder", e);


### PR DESCRIPTION
Fixes #1662 

Monitor's directory for temporary uploaded files was used only if it was created within the same run. Otherwise (if it already existed) it was not used. 