### PR TITLE
Add paging to monitor's scheduling page

### DIFF
--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -58,16 +58,14 @@ public interface SchedulingService extends RemoteService {
     List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, List<JobIdentifier> jobs) throws DCSecurityException;
 
     /**
-     * Gets a map where the keys represent the different categories and the values represent all available jobs for that
-     * category on the tenant identified by the tenant argument.
+     * Gets all available jobs on the tenant identified by the tenant argument.
      * 
      * @param tenant tenant that contains the jobs
-     * @return a map where the keys represent the different categories and the values represent all available jobs for
-     *         that category
+     * @return a list of job identifiers
      * @throws DCSecurityException in case the call isn't executed with the right authorization
      */
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
-    Map<String, List<JobIdentifier>> getJobsGroupedByCategory(TenantIdentifier tenant) throws DCSecurityException;
+    List<JobIdentifier> getJobs(TenantIdentifier tenant) throws DCSecurityException;
 
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     ScheduleDefinition updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition)

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingService.java
@@ -46,6 +46,29 @@ public interface SchedulingService extends RemoteService {
     @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
     List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, boolean loadProperties) throws DCSecurityException;
 
+    /**
+     * Gets all schedules for the jobs in the jobs argument.
+     * 
+     * @param tenant tenant that contains the jobs
+     * @param jobs List of jobs for which all schedules should be returned
+     * @return all schedules for the jobs in the jobs argument
+     * @throws DCSecurityException in case the call isn't executed with the right authorization
+     */
+    @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
+    List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, List<JobIdentifier> jobs) throws DCSecurityException;
+
+    /**
+     * Gets a map where the keys represent the different categories and the values represent all available jobs for that
+     * category on the tenant identified by the tenant argument.
+     * 
+     * @param tenant tenant that contains the jobs
+     * @return a map where the keys represent the different categories and the values represent all available jobs for
+     *         that category
+     * @throws DCSecurityException in case the call isn't executed with the right authorization
+     */
+    @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
+    Map<String, List<JobIdentifier>> getJobsGroupedByCategory(TenantIdentifier tenant) throws DCSecurityException;
+
     @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
     ScheduleDefinition updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition)
             throws DCSecurityException, CronExpressionException;

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
@@ -38,6 +38,25 @@ public interface SchedulingServiceAsync {
     void getSchedules(TenantIdentifier tenant, boolean loadProperties,
             AsyncCallback<List<ScheduleDefinition>> callback);
 
+    /**
+     * Gets all schedules for the jobs in the jobs argument and provides access through the callback argument.
+     * 
+     * @param tenant tenant that contains the jobs
+     * @param jobs List of jobs for which all schedules should be returned
+     * @param callback callback object which provides access to the results of the method call
+     */
+    void getSchedules(TenantIdentifier tenant, List<JobIdentifier> jobs,
+            AsyncCallback<List<ScheduleDefinition>> callback);
+
+    /**
+     * Gets a map where the keys represent the different categories and the values represent all available jobs for that
+     * category on the tenant identified by the tenant argument and provides access through the callback argument.
+     * 
+     * @param tenant tenant that contains the jobs
+     * @param callback callback object which provides access to the results of the method call
+     */
+    void getJobsGroupedByCategory(TenantIdentifier tenant, AsyncCallback<Map<String, List<JobIdentifier>>> callback);
+
     void updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition,
             AsyncCallback<ScheduleDefinition> callback);
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/SchedulingServiceAsync.java
@@ -22,10 +22,14 @@ package org.datacleaner.monitor.scheduling;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.security.RolesAllowed;
+
 import org.datacleaner.monitor.scheduling.model.ExecutionIdentifier;
 import org.datacleaner.monitor.scheduling.model.ExecutionLog;
 import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+import org.datacleaner.monitor.shared.model.DCSecurityException;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
+import org.datacleaner.monitor.shared.model.SecurityRoles;
 import org.datacleaner.monitor.shared.model.TenantIdentifier;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -49,13 +53,14 @@ public interface SchedulingServiceAsync {
             AsyncCallback<List<ScheduleDefinition>> callback);
 
     /**
-     * Gets a map where the keys represent the different categories and the values represent all available jobs for that
-     * category on the tenant identified by the tenant argument and provides access through the callback argument.
+     * Gets all available jobs on the tenant identified by the tenant argument and provides access through the callback
+     * argument.
      * 
      * @param tenant tenant that contains the jobs
      * @param callback callback object which provides access to the results of the method call
      */
-    void getJobsGroupedByCategory(TenantIdentifier tenant, AsyncCallback<Map<String, List<JobIdentifier>>> callback);
+    @RolesAllowed({ SecurityRoles.VIEWER, SecurityRoles.SCHEDULE_EDITOR })
+    void getJobs(TenantIdentifier tenant, AsyncCallback<List<JobIdentifier>> callback) throws DCSecurityException;
 
     void updateSchedule(TenantIdentifier tenant, ScheduleDefinition scheduleDefinition,
             AsyncCallback<ScheduleDefinition> callback);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -121,8 +120,6 @@ import com.google.common.collect.Maps;
  */
 @Component("schedulingService")
 public class SchedulingServiceImpl implements SchedulingService, ApplicationContextAware {
-    private static final String CATEGORY = "Category";
-    private static final String OTHERS = "(Other)";
 
     @Autowired
     HotFolderPreferences _hotFolderPreferences;
@@ -583,40 +580,10 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     @Override
-    public Map<String, List<JobIdentifier>> getJobsGroupedByCategory(final TenantIdentifier tenant) {
-        final Map<String, List<JobIdentifier>> categoryAndGroupMap = new TreeMap<>();
-
+    public List<JobIdentifier> getJobs(final TenantIdentifier tenant) {
         final TenantContext context = _tenantContextFactory.getContext(tenant);
 
-        final List<JobIdentifier> jobs = context.getJobs();
-
-        for (final JobIdentifier jobIdentifier : jobs) {
-            final JobContext jobContext = context.getJob(jobIdentifier);
-
-            final Map<String, String> jobMetadataProperties = jobContext.getMetadataProperties();
-
-            final String categoryName;
-            if (jobMetadataProperties == null) {
-                categoryName = OTHERS;
-            } else {
-                final String metadataValue = jobMetadataProperties.get(CATEGORY);
-                if (metadataValue != null && !"".equals(metadataValue.trim())) {
-                    categoryName = metadataValue;
-                } else {
-                    categoryName = OTHERS;
-                }
-            }
-
-            List<JobIdentifier> listOfJobWithSameCategory = categoryAndGroupMap.get(categoryName);
-
-            if (listOfJobWithSameCategory == null) {
-                listOfJobWithSameCategory = new ArrayList<>();
-
-                categoryAndGroupMap.put(categoryName, listOfJobWithSameCategory);
-            }
-            listOfJobWithSameCategory.add(jobIdentifier);
-        }
-        return categoryAndGroupMap;
+        return context.getJobs();
     }
 
     @Override

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
@@ -80,8 +80,8 @@ public class SchedulingServiceServlet extends SecureGwtServlet implements Schedu
     }
 
     @Override
-    public Map<String, List<JobIdentifier>> getJobsGroupedByCategory(final TenantIdentifier tenant) {
-        return _delegate.getJobsGroupedByCategory(tenant);
+    public List<JobIdentifier> getJobs(final TenantIdentifier tenant) {
+        return _delegate.getJobs(tenant);
     }
 
     @Override

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceServlet.java
@@ -74,6 +74,17 @@ public class SchedulingServiceServlet extends SecureGwtServlet implements Schedu
     }
 
     @Override
+    public List<ScheduleDefinition> getSchedules(TenantIdentifier tenant, List<JobIdentifier> jobs)
+            throws DCSecurityException {
+        return _delegate.getSchedules(tenant, jobs);
+    }
+
+    @Override
+    public Map<String, List<JobIdentifier>> getJobsGroupedByCategory(final TenantIdentifier tenant) {
+        return _delegate.getJobsGroupedByCategory(tenant);
+    }
+
+    @Override
     public ScheduleDefinition updateSchedule(final TenantIdentifier tenant,
             final ScheduleDefinition scheduleDefinition) throws DCSecurityException, CronExpressionException {
         return _delegate.updateSchedule(tenant, scheduleDefinition);

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
@@ -1,0 +1,93 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.scheduling.widgets;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.cellview.client.AbstractHasData;
+import com.google.gwt.view.client.SelectionModel;
+
+class ScheduleData extends AbstractHasData<ScheduleDefinition> {
+    private final ScheduleDataPanel _panel;
+    private final SchedulingOverviewPanel _overviewPanel;
+    private final Element childContainer;
+
+    ScheduleData(final ScheduleDataPanel panel, final SchedulingOverviewPanel overviewPanel) {
+        super(Document.get().createDivElement(), SchedulingOverviewPanel.PAGE_SIZE, null);
+
+        _panel = panel;
+        _overviewPanel = overviewPanel;
+
+        childContainer = Document.get().createDivElement();
+        final DivElement outerDiv = getElement().cast();
+        outerDiv.appendChild(childContainer);
+    }
+
+    @Override
+    protected boolean dependsOnSelection() {
+        return false;
+    }
+
+    @Override
+    protected Element getChildContainer() {
+        return childContainer;
+    }
+
+    @Override
+    protected Element getKeyboardSelectedElement() {
+        return null;
+    }
+
+    @Override
+    protected boolean isKeyboardNavigationSuppressed() {
+        return false;
+    }
+
+    @Override
+    protected void renderRowValues(SafeHtmlBuilder sb, List<ScheduleDefinition> values, int start,
+            SelectionModel<? super ScheduleDefinition> selectionModel) throws UnsupportedOperationException {
+        _panel.clearGroupPanels();
+
+        final Map<String, ScheduleGroupPanel> scheduleGroupPanels = new HashMap<>();
+        for (final ScheduleDefinition scheduleDefinition : values) {
+            final ScheduleGroupPanel groupPanel = _overviewPanel.addScheduleInGroup(scheduleDefinition,
+                    SchedulingOverviewPanel.JOB_GROUPING_CATEGORY, _panel, scheduleGroupPanels);
+            _panel.registerGroupPanel(groupPanel);
+        }
+    }
+
+    @Override
+    protected boolean resetFocusOnCell() {
+        return false;
+    }
+
+    @Override
+    protected void setKeyboardSelected(int index, boolean selected, boolean stealFocus) {
+        // Do nothing.
+    }
+}

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
@@ -35,7 +35,7 @@ import com.google.gwt.view.client.SelectionModel;
 class ScheduleData extends AbstractHasData<ScheduleDefinition> {
     private final ScheduleDataPanel _panel;
     private final SchedulingOverviewPanel _overviewPanel;
-    private final Element childContainer;
+    private final Element _childContainer;
 
     ScheduleData(final ScheduleDataPanel panel, final SchedulingOverviewPanel overviewPanel) {
         super(Document.get().createDivElement(), SchedulingOverviewPanel.PAGE_SIZE, null);
@@ -43,9 +43,9 @@ class ScheduleData extends AbstractHasData<ScheduleDefinition> {
         _panel = panel;
         _overviewPanel = overviewPanel;
 
-        childContainer = Document.get().createDivElement();
+        _childContainer = Document.get().createDivElement();
         final DivElement outerDiv = getElement().cast();
-        outerDiv.appendChild(childContainer);
+        outerDiv.appendChild(_childContainer);
     }
 
     @Override
@@ -55,7 +55,7 @@ class ScheduleData extends AbstractHasData<ScheduleDefinition> {
 
     @Override
     protected Element getChildContainer() {
-        return childContainer;
+        return _childContainer;
     }
 
     @Override

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleData.java
@@ -69,8 +69,8 @@ class ScheduleData extends AbstractHasData<ScheduleDefinition> {
     }
 
     @Override
-    protected void renderRowValues(SafeHtmlBuilder sb, List<ScheduleDefinition> values, int start,
-            SelectionModel<? super ScheduleDefinition> selectionModel) throws UnsupportedOperationException {
+    protected void renderRowValues(final SafeHtmlBuilder sb, final List<ScheduleDefinition> values, int start,
+            final SelectionModel<? super ScheduleDefinition> selectionModel) throws UnsupportedOperationException {
         _panel.clearGroupPanels();
 
         final Map<String, ScheduleGroupPanel> scheduleGroupPanels = new HashMap<>();
@@ -87,7 +87,7 @@ class ScheduleData extends AbstractHasData<ScheduleDefinition> {
     }
 
     @Override
-    protected void setKeyboardSelected(int index, boolean selected, boolean stealFocus) {
+    protected void setKeyboardSelected(final int index, final boolean selected, final boolean stealFocus) {
         // Do nothing.
     }
 }

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPager.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPager.java
@@ -1,0 +1,40 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.scheduling.widgets;
+
+import com.google.gwt.user.cellview.client.SimplePager;
+import com.google.gwt.view.client.HasRows;
+import com.google.gwt.view.client.Range;
+
+class ScheduleDataPager extends SimplePager {
+
+    @Override
+    public void setPageStart(final int index) {
+        final HasRows display = getDisplay();
+
+        if (display != null) {
+            final Range range = display.getVisibleRange();
+            final int newStartIndex = Math.max(0, index);
+            if (newStartIndex != range.getStart()) {
+                display.setVisibleRange(newStartIndex, range.getLength());
+            }
+        }
+    }
+}

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPager.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPager.java
@@ -24,6 +24,9 @@ import com.google.gwt.view.client.HasRows;
 import com.google.gwt.view.client.Range;
 
 class ScheduleDataPager extends SimplePager {
+    ScheduleDataPager() {
+        super(SimplePager.TextLocation.CENTER, false, true);
+    }
 
     @Override
     public void setPageStart(final int index) {

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPanel.java
@@ -1,0 +1,145 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.scheduling.widgets;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.view.client.HasData;
+import com.google.gwt.view.client.HasRows;
+import com.google.gwt.view.client.Range;
+import com.google.gwt.view.client.RangeChangeEvent.Handler;
+import com.google.gwt.view.client.SelectionModel;
+
+class ScheduleDataPanel extends FlowPanel implements HasRows, HasData<ScheduleDefinition> {
+    private final ScheduleData _data;
+
+    private final Set<ScheduleGroupPanel> _groupPanels = new HashSet<>();
+
+    ScheduleDataPanel(final SchedulingOverviewPanel overviewPanel) {
+        super();
+
+        _data = new ScheduleData(this, overviewPanel);
+    }
+
+    @Override
+    public HandlerRegistration addRangeChangeHandler(Handler handler) {
+        return _data.addRangeChangeHandler(handler);
+    }
+
+    @Override
+    public HandlerRegistration addRowCountChangeHandler(
+            com.google.gwt.view.client.RowCountChangeEvent.Handler handler) {
+        return _data.addRowCountChangeHandler(handler);
+    }
+
+    @Override
+    public int getRowCount() {
+        return _data.getRowCount();
+    }
+
+    @Override
+    public Range getVisibleRange() {
+        return _data.getVisibleRange();
+    }
+
+    @Override
+    public boolean isRowCountExact() {
+        return _data.isRowCountExact();
+    }
+
+    @Override
+    public void setRowCount(int count) {
+        _data.setRowCount(count);
+    }
+
+    @Override
+    public void setRowCount(int count, boolean isExact) {
+        _data.setRowCount(count, isExact);
+    }
+
+    @Override
+    public void setVisibleRange(int start, int length) {
+        _data.setVisibleRange(start, length);
+    }
+
+    @Override
+    public void setVisibleRange(Range range) {
+        _data.setVisibleRange(range);
+    }
+
+    @Override
+    public HandlerRegistration addCellPreviewHandler(
+            com.google.gwt.view.client.CellPreviewEvent.Handler<ScheduleDefinition> handler) {
+        return _data.addCellPreviewHandler(handler);
+    }
+
+    @Override
+    public SelectionModel<? super ScheduleDefinition> getSelectionModel() {
+        return _data.getSelectionModel();
+    }
+
+    @Override
+    public ScheduleDefinition getVisibleItem(int indexOnPage) {
+        return _data.getVisibleItem(indexOnPage);
+    }
+
+    @Override
+    public int getVisibleItemCount() {
+        return _data.getVisibleItemCount();
+    }
+
+    @Override
+    public Iterable<ScheduleDefinition> getVisibleItems() {
+        return _data.getVisibleItems();
+    }
+
+    @Override
+    public void setRowData(int start, List<? extends ScheduleDefinition> values) {
+        _data.setRowData(start, values);
+    }
+
+    @Override
+    public void setSelectionModel(SelectionModel<? super ScheduleDefinition> selectionModel) {
+        _data.setSelectionModel(selectionModel);
+    }
+
+    @Override
+    public void setVisibleRangeAndClearData(Range range, boolean forceRangeChangeEvent) {
+        _data.setVisibleRangeAndClearData(range, forceRangeChangeEvent);
+    }
+
+    void registerGroupPanel(ScheduleGroupPanel groupPanel) {
+        _groupPanels.add(groupPanel);
+    }
+
+    void clearGroupPanels() {
+        for (ScheduleGroupPanel groupPanel : _groupPanels) {
+            remove(groupPanel);
+        }
+
+        _groupPanels.clear();
+    }
+}

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataPanel.java
@@ -45,13 +45,13 @@ class ScheduleDataPanel extends FlowPanel implements HasRows, HasData<ScheduleDe
     }
 
     @Override
-    public HandlerRegistration addRangeChangeHandler(Handler handler) {
+    public HandlerRegistration addRangeChangeHandler(final Handler handler) {
         return _data.addRangeChangeHandler(handler);
     }
 
     @Override
     public HandlerRegistration addRowCountChangeHandler(
-            com.google.gwt.view.client.RowCountChangeEvent.Handler handler) {
+            final com.google.gwt.view.client.RowCountChangeEvent.Handler handler) {
         return _data.addRowCountChangeHandler(handler);
     }
 
@@ -71,28 +71,28 @@ class ScheduleDataPanel extends FlowPanel implements HasRows, HasData<ScheduleDe
     }
 
     @Override
-    public void setRowCount(int count) {
+    public void setRowCount(final int count) {
         _data.setRowCount(count);
     }
 
     @Override
-    public void setRowCount(int count, boolean isExact) {
+    public void setRowCount(final int count, final boolean isExact) {
         _data.setRowCount(count, isExact);
     }
 
     @Override
-    public void setVisibleRange(int start, int length) {
+    public void setVisibleRange(final int start, final int length) {
         _data.setVisibleRange(start, length);
     }
 
     @Override
-    public void setVisibleRange(Range range) {
+    public void setVisibleRange(final Range range) {
         _data.setVisibleRange(range);
     }
 
     @Override
     public HandlerRegistration addCellPreviewHandler(
-            com.google.gwt.view.client.CellPreviewEvent.Handler<ScheduleDefinition> handler) {
+            final com.google.gwt.view.client.CellPreviewEvent.Handler<ScheduleDefinition> handler) {
         return _data.addCellPreviewHandler(handler);
     }
 
@@ -102,7 +102,7 @@ class ScheduleDataPanel extends FlowPanel implements HasRows, HasData<ScheduleDe
     }
 
     @Override
-    public ScheduleDefinition getVisibleItem(int indexOnPage) {
+    public ScheduleDefinition getVisibleItem(final int indexOnPage) {
         return _data.getVisibleItem(indexOnPage);
     }
 
@@ -117,21 +117,21 @@ class ScheduleDataPanel extends FlowPanel implements HasRows, HasData<ScheduleDe
     }
 
     @Override
-    public void setRowData(int start, List<? extends ScheduleDefinition> values) {
+    public void setRowData(final int start, final List<? extends ScheduleDefinition> values) {
         _data.setRowData(start, values);
     }
 
     @Override
-    public void setSelectionModel(SelectionModel<? super ScheduleDefinition> selectionModel) {
+    public void setSelectionModel(final SelectionModel<? super ScheduleDefinition> selectionModel) {
         _data.setSelectionModel(selectionModel);
     }
 
     @Override
-    public void setVisibleRangeAndClearData(Range range, boolean forceRangeChangeEvent) {
+    public void setVisibleRangeAndClearData(final Range range, final boolean forceRangeChangeEvent) {
         _data.setVisibleRangeAndClearData(range, forceRangeChangeEvent);
     }
 
-    void registerGroupPanel(ScheduleGroupPanel groupPanel) {
+    void registerGroupPanel(final ScheduleGroupPanel groupPanel) {
         _groupPanels.add(groupPanel);
     }
 

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataProvider.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/ScheduleDataProvider.java
@@ -1,0 +1,70 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.scheduling.widgets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.datacleaner.monitor.scheduling.SchedulingServiceAsync;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+import org.datacleaner.monitor.shared.ClientConfig;
+import org.datacleaner.monitor.shared.model.JobIdentifier;
+import org.datacleaner.monitor.util.DCAsyncCallback;
+
+import com.google.gwt.view.client.AsyncDataProvider;
+import com.google.gwt.view.client.HasData;
+import com.google.gwt.view.client.Range;
+
+class ScheduleDataProvider extends AsyncDataProvider<ScheduleDefinition> {
+    private final List<JobIdentifier> _jobs;
+
+    private final ClientConfig _clientConfig;
+    private final SchedulingServiceAsync _service;
+
+    ScheduleDataProvider(final ClientConfig clientConfig, final SchedulingServiceAsync service,
+            final List<JobIdentifier> jobs) {
+        super();
+
+        _clientConfig = clientConfig;
+        _service = service;
+        _jobs = jobs;
+    }
+
+    @Override
+    protected void onRangeChanged(final HasData<ScheduleDefinition> display) {
+        final Range range = display.getVisibleRange();
+
+        final int rangeStart = range.getStart();
+        int rangeEnd = rangeStart + range.getLength();
+
+        if (rangeEnd > _jobs.size()) {
+            rangeEnd = _jobs.size();
+        }
+
+        final List<JobIdentifier> jobsInRange = new ArrayList<>(_jobs.subList(rangeStart, rangeEnd));
+
+        _service.getSchedules(_clientConfig.getTenant(), jobsInRange, new DCAsyncCallback<List<ScheduleDefinition>>() {
+                @Override
+            public void onSuccess(List<ScheduleDefinition> result) {
+                updateRowData(rangeStart, result);
+                }
+            });
+    }
+}

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.datacleaner.monitor.scheduling.SchedulingServiceAsync;
 import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
@@ -30,6 +31,7 @@ import org.datacleaner.monitor.shared.ClientConfig;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
 import org.datacleaner.monitor.util.DCAsyncCallback;
 
+import com.google.gwt.core.shared.GWT;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DecoratedTabPanel;
@@ -38,6 +40,7 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.view.client.ListDataProvider;
 
 /**
  * Presents an overview of all scheduled activity in DC monitor.
@@ -47,6 +50,9 @@ public class SchedulingOverviewPanel extends Composite {
 
     static final int PAGE_SIZE = 10;
 
+    private static final boolean USE_TAB_PANEL = false;
+
+    private static final String CATEGORY = "Category";
     private static final String OTHERS = "(Other)";
     private final ClientConfig _clientConfig;
     private final SchedulingServiceAsync _service;
@@ -57,50 +63,106 @@ public class SchedulingOverviewPanel extends Composite {
     }
 
     public void initialize(final Runnable listener) {
-        _service.getJobsGroupedByCategory(_clientConfig.getTenant(),
-                new DCAsyncCallback<Map<String, List<JobIdentifier>>>() {
-                    @Override
-                    public void onSuccess(final Map<String, List<JobIdentifier>> categoryAndGroupMapForJobs) {
+        if (USE_TAB_PANEL) {
+            _service.getSchedules(_clientConfig.getTenant(), false, new DCAsyncCallback<List<ScheduleDefinition>>() {
+                @Override
+                public void onSuccess(final List<ScheduleDefinition> result) {
 
-                final int categoryCount = categoryAndGroupMapForJobs.size();
+                    final Map<String, List<ScheduleDefinition>> categoryAndGroupMapForJobs =
+                            createCategoryAndGroupMapForJobs(result);
 
-                if (categoryCount == 0) {
-                    final HorizontalPanel panel = new HorizontalPanel();
-                    panel.add(new Label("There are no jobs available."));
-                    initWidget(panel);
-                } else if (categoryCount == 1) {
-                            getPagedPanel(categoryAndGroupMapForJobs
-                                    .get(categoryAndGroupMapForJobs.keySet().iterator().next()));
-                } else {
-                    final DecoratedTabPanel tabPanel = new DecoratedTabPanel();
-                    tabPanel.setWidth("100%");
-                    Collection<String> jobCategories = categoryAndGroupMapForJobs.keySet();
-                    jobCategories = sortJobCategories(jobCategories);
+                    final int categoryCount = categoryAndGroupMapForJobs.size();
 
-                    for (final String jobCategory : jobCategories) {
-                                final List<JobIdentifier> list = categoryAndGroupMapForJobs.get(jobCategory);
-                        final ComplexPanel panel = getPagedPanel(list);
-                        tabPanel.add(panel, jobCategory);
+                    if (categoryCount == 0) {
+                        final HorizontalPanel panel = new HorizontalPanel();
+                        panel.add(new Label("There are no jobs available."));
+                        initWidget(panel);
+                    } else if (categoryCount == 1) {
+                        getSynchronousPagedPanel(result);
+                    } else {
+                        final DecoratedTabPanel tabPanel = new DecoratedTabPanel();
+                        tabPanel.setWidth("100%");
+                        Collection<String> jobCategories = categoryAndGroupMapForJobs.keySet();
+                        jobCategories = sortJobCategories(jobCategories);
+
+                        for (final String jobCategory : jobCategories) {
+                            final List<ScheduleDefinition> list = categoryAndGroupMapForJobs.get(jobCategory);
+                            final ComplexPanel panel = getSynchronousPagedPanel(list);
+                            tabPanel.add(panel, jobCategory);
+                        }
+                        tabPanel.selectTab(0);
+                        tabPanel.ensureDebugId("cwTabPanel");
+                        initWidget(tabPanel);
                     }
-                    tabPanel.selectTab(0);
-                    tabPanel.ensureDebugId("cwTabPanel");
-                    initWidget(tabPanel);
-                }
-                listener.run();
-            }
-
-            private Collection<String> sortJobCategories(final Collection<String> jobCategories) {
-                final List<String> result = new ArrayList<>(jobCategories);
-
-                // move OTHERS to the end
-                final boolean removed = result.remove(OTHERS);
-                if (removed) {
-                    result.add(OTHERS);
+                    listener.run();
                 }
 
-                return result;
-            }
-        });
+                private Collection<String> sortJobCategories(final Collection<String> jobCategories) {
+                    final List<String> result = new ArrayList<>(jobCategories);
+
+                    // move OTHERS to the end
+                    final boolean removed = result.remove(OTHERS);
+                    if (removed) {
+                        result.add(OTHERS);
+                    }
+
+                    return result;
+                }
+
+                private Map<String, List<ScheduleDefinition>> createCategoryAndGroupMapForJobs(
+                        final List<ScheduleDefinition> result) {
+                    final Map<String, List<ScheduleDefinition>> categoryAndGroupMap = new TreeMap<>();
+
+                    for (final ScheduleDefinition scheduleDefinition : result) {
+                        final Map<String, String> jobMetadataProperties = scheduleDefinition.getJobMetadataProperties();
+
+                        GWT.log("Job '" + scheduleDefinition.getJob().getName() + "' metadata: "
+                                + jobMetadataProperties);
+
+                        final String categoryName;
+                        if (jobMetadataProperties == null) {
+                            categoryName = OTHERS;
+                        } else {
+                            final String metadataValue = jobMetadataProperties.get(CATEGORY);
+                            if (metadataValue != null && !"".equals(metadataValue.trim())) {
+                                categoryName = metadataValue;
+                            } else {
+                                categoryName = OTHERS;
+                            }
+                        }
+
+                        List<ScheduleDefinition> listOfJobWithSameCategory;
+                        listOfJobWithSameCategory = categoryAndGroupMap.get(categoryName);
+
+                        if (listOfJobWithSameCategory == null) {
+                            listOfJobWithSameCategory = new ArrayList<>();
+
+                            categoryAndGroupMap.put(categoryName, listOfJobWithSameCategory);
+                        }
+                        listOfJobWithSameCategory.add(scheduleDefinition);
+
+                    }
+                    return categoryAndGroupMap;
+
+                }
+
+            });
+        } else {
+            _service.getJobs(_clientConfig.getTenant(), new DCAsyncCallback<List<JobIdentifier>>() {
+
+                @Override
+                public void onSuccess(final List<JobIdentifier> jobs) {
+                    if (jobs.size() == 0) {
+                        final HorizontalPanel panel = new HorizontalPanel();
+                        panel.add(new Label("There are no jobs available."));
+                        initWidget(panel);
+                    } else {
+                        getAsyncPagedPanel(jobs);
+                    }
+                    listener.run();
+                }
+            });
+        }
     }
 
     public void addSchedule(final ScheduleDefinition schedule, final String jobGroupingCategory, final FlowPanel panel,
@@ -163,19 +225,24 @@ public class SchedulingOverviewPanel extends Composite {
         return label;
     }
 
-    private ComplexPanel getPagedPanel(final List<JobIdentifier> result) {
-        final ScheduleDataPanel dataFlowPanel = new ScheduleDataPanel(this);
-        dataFlowPanel.add(createHeaderPanel());
-        dataFlowPanel.addStyleName("SchedulingOverviewPanel");
+    private ComplexPanel getSynchronousPagedPanel(final List<ScheduleDefinition> result) {
+        final ScheduleDataPanel dataFlowPanel = getScheduleDataPanel();
 
-        final ScheduleDataProvider dataProvider = new ScheduleDataProvider(_clientConfig, _service, result);
-        dataProvider.updateRowCount(result.size(), true);
+        final ListDataProvider<ScheduleDefinition> dataProvider = new ListDataProvider<>();
+        final List<ScheduleDefinition> data = dataProvider.getList();
 
+        for (ScheduleDefinition definition : result) {
+            data.add(definition);
+        }
+        dataProvider.addDataDisplay(dataFlowPanel);
+
+        return getPagedPanel(dataFlowPanel);
+    }
+
+    private ComplexPanel getPagedPanel(final ScheduleDataPanel dataFlowPanel) {
         final ScheduleDataPager pager = new ScheduleDataPager();
         pager.setDisplay(dataFlowPanel);
         pager.setPageSize(PAGE_SIZE);
-
-        dataProvider.addDataDisplay(dataFlowPanel);
 
         final VerticalPanel pagedPanel = new VerticalPanel();
         pagedPanel.setWidth("100%");
@@ -184,5 +251,22 @@ public class SchedulingOverviewPanel extends Composite {
         initWidget(pagedPanel);
 
         return pagedPanel;
+    }
+
+    private ComplexPanel getAsyncPagedPanel(final List<JobIdentifier> result) {
+        final ScheduleDataPanel dataFlowPanel = getScheduleDataPanel();
+
+        final ScheduleDataProvider dataProvider = new ScheduleDataProvider(_clientConfig, _service, result);
+        dataProvider.updateRowCount(result.size(), true);
+        dataProvider.addDataDisplay(dataFlowPanel);
+
+        return getPagedPanel(dataFlowPanel);
+    }
+
+    private ScheduleDataPanel getScheduleDataPanel() {
+        final ScheduleDataPanel dataFlowPanel = new ScheduleDataPanel(this);
+        dataFlowPanel.add(createHeaderPanel());
+        dataFlowPanel.addStyleName("SchedulingOverviewPanel");
+        return dataFlowPanel;
     }
 }

--- a/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
+++ b/monitor/widgets/src/main/java/org/datacleaner/monitor/scheduling/widgets/SchedulingOverviewPanel.java
@@ -231,7 +231,7 @@ public class SchedulingOverviewPanel extends Composite {
         final ListDataProvider<ScheduleDefinition> dataProvider = new ListDataProvider<>();
         final List<ScheduleDefinition> data = dataProvider.getList();
 
-        for (ScheduleDefinition definition : result) {
+        for (final ScheduleDefinition definition : result) {
             data.add(definition);
         }
         dataProvider.addDataDisplay(dataFlowPanel);


### PR DESCRIPTION
Fixes #1645.

Added ScheduleDataPager, which is an extension of GWT's SimplePager used for adding paging functionality to DataCleaner monitor's scheduling page, which shows the deployed jobs.

Implemented an extensions of the FlowPanel class which implements GWT's HasRows and HasData interfaces to be able to use the ScheduleDataPager.