### PR TITLE
Docker tomcat port change

### DIFF
--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-        <dockerTomcatPort>8080</dockerTomcatPort>
+        <dockerTomcatPort>8182</dockerTomcatPort>
 	</properties>
 
 	<build>
@@ -188,7 +188,7 @@
 
 									<run>
 										<ports>
-											<port>${dockerTomcatPort}:8182</port>
+											<port>${dockerTomcatPort}:8080</port>
 										</ports>
 										<wait>
 											<url>http://${docker.host.address}:${dockerTomcatPort}</url>

--- a/monitor/ui/pom.xml
+++ b/monitor/ui/pom.xml
@@ -188,7 +188,7 @@
 
 									<run>
 										<ports>
-											<port>${dockerTomcatPort}:8080</port>
+											<port>${dockerTomcatPort}:8182</port>
 										</ports>
 										<wait>
 											<url>http://${docker.host.address}:${dockerTomcatPort}</url>


### PR DESCRIPTION
(No issue) 

Our Jenkins environment already uses port 8080, let's change it to something more original.