### PR TITLE
REST endpoint to schedule job on Monitor with Hot Folder

### DIFF
--- a/engine/core/src/test/java/org/datacleaner/metamodel/datahub/DataHubUpdateBuilderTest.java
+++ b/engine/core/src/test/java/org/datacleaner/metamodel/datahub/DataHubUpdateBuilderTest.java
@@ -61,7 +61,6 @@ public class DataHubUpdateBuilderTest {
 
     @Before
     public void init() {
-        Mockito.when(table.getName()).thenReturn("person");
         Mockito.when(table.getColumns()).thenReturn(new Column[] { new MutableColumn("_trackcode", ColumnType.CHAR),
                 new MutableColumn("name", ColumnType.CHAR), new MutableColumn("age", ColumnType.CHAR) });
         rowUpdationBuilder = new DataHubUpdateBuilder(callback, table);

--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
@@ -1,0 +1,37 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.scheduling.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ScheduleDefinitionModel {
+    private final String _hotFolder;
+
+    @JsonCreator
+    public ScheduleDefinitionModel(@JsonProperty("hotFolder") final String hotFolder) {
+        _hotFolder = hotFolder;
+    }
+
+    public String getHotFolder() {
+        return _hotFolder;
+    }
+
+}

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ScheduleDefinitionsController.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/controllers/ScheduleDefinitionsController.java
@@ -1,0 +1,103 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.server.controllers;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
+
+import org.datacleaner.monitor.scheduling.SchedulingService;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinitionModel;
+import org.datacleaner.monitor.shared.model.JobIdentifier;
+import org.datacleaner.monitor.shared.model.SecurityRoles;
+import org.datacleaner.monitor.shared.model.TenantIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping(value = "/{tenant}/schedules/{jobname}")
+public class ScheduleDefinitionsController {
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    private class NoSuchResourceException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ScheduleDefinitionsController.class);
+
+    private final SchedulingService _schedulingService;
+
+    @Autowired
+    public ScheduleDefinitionsController(final SchedulingService schedulingService) {
+        _schedulingService = schedulingService;
+    }
+
+    @RolesAllowed(SecurityRoles.VIEWER)
+    @RequestMapping(method = { RequestMethod.GET, RequestMethod.HEAD }, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ScheduleDefinitionModel getSchedule(@PathVariable("tenant") final String tenant,
+            @PathVariable("jobname") final String jobName, final HttpServletRequest request) {
+
+        final ScheduleDefinition scheduleDefinition = getScheduleDefinition(tenant, jobName);
+
+        if (request.getMethod().equals(RequestMethod.HEAD.name())) {
+            return null;
+        }
+
+        return new ScheduleDefinitionModel(scheduleDefinition.getHotFolder());
+    }
+
+    @RolesAllowed(SecurityRoles.SCHEDULE_EDITOR)
+    @RequestMapping(method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> putSchedule(@PathVariable("tenant") final String tenant,
+            @PathVariable("jobname") final String jobName,
+            @RequestBody final ScheduleDefinitionModel scheduleDefinitionModel) {
+        final TenantIdentifier tenantIdentifier = new TenantIdentifier(tenant);
+
+        final ScheduleDefinition scheduleDefinition = getScheduleDefinition(tenant, jobName);
+
+        scheduleDefinition.setHotFolder(scheduleDefinitionModel.getHotFolder());
+
+        _schedulingService.updateSchedule(tenantIdentifier, scheduleDefinition);
+
+        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUri()).build();
+    }
+
+    private ScheduleDefinition getScheduleDefinition(final String tenant, final String jobName) {
+        final TenantIdentifier tenantIdentifier = new TenantIdentifier(tenant);
+        final ScheduleDefinition scheduleDefinition =
+                _schedulingService.getSchedule(tenantIdentifier, new JobIdentifier(jobName));
+
+        if (scheduleDefinition == null) {
+            logger.warn("Could not get schedule for job \"{}\"", jobName);
+            throw new NoSuchResourceException();
+        }
+        return scheduleDefinition;
+    }
+}

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/JobsFolderControllerTest.java
@@ -20,13 +20,27 @@
 package org.datacleaner.monitor.server.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.ws.rs.core.MediaType;
 
 import org.datacleaner.configuration.DataCleanerEnvironmentImpl;
+import org.datacleaner.monitor.configuration.TenantContext;
 import org.datacleaner.monitor.configuration.TenantContextFactory;
 import org.datacleaner.monitor.configuration.TenantContextFactoryImpl;
+import org.datacleaner.monitor.scheduling.SchedulingService;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
 import org.datacleaner.monitor.server.job.MockJobEngineManager;
+import org.datacleaner.repository.RepositoryFile;
+import org.datacleaner.repository.RepositoryFolder;
 import org.datacleaner.repository.file.FileRepository;
 import org.junit.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class JobsFolderControllerTest {
 
@@ -71,5 +85,42 @@ public class JobsFolderControllerTest {
         final String resultsMetadata4 = controller.getFolderJobsByMetadataProperty("tenant6", "", "").toString();
         assertEquals("[]", resultsMetadata4);
 
+    }
+
+    @Test
+    public void testUploadAnalysisJobToFolderJson() throws Exception {
+        final String jobFileName = "myjob.analysis.xml";
+
+        final TenantContext context = mock(TenantContext.class);
+        final TenantContextFactory contextFactory = mock(TenantContextFactory.class);
+        final RepositoryFolder jobFolder = mock(RepositoryFolder.class);
+        final RepositoryFile jobFile = mock(RepositoryFile.class);
+        final SchedulingService schedulingService = mock(SchedulingService.class);
+        final ScheduleDefinition scheduleDefinition = mock(ScheduleDefinition.class);
+
+        when(contextFactory.getContext("test")).thenReturn(context);
+        when(context.getJobFolder()).thenReturn(jobFolder);
+        when(jobFolder.createFile(eq(jobFileName), any())).thenReturn(jobFile);
+        when(schedulingService.getSchedule(argThat(tenant -> tenant.getId().equals("test")),
+                argThat(job -> job.getName().equals("myjob")))).thenReturn(scheduleDefinition);
+        when(jobFile.getType()).thenReturn(RepositoryFile.Type.ANALYSIS_JOB);
+        when(jobFile.getName()).thenReturn(jobFileName);
+        when(jobFile.getQualifiedPath()).thenReturn("/");
+
+        final JobsFolderController jobsFolderController = new JobsFolderController();
+        jobsFolderController._contextFactory = contextFactory;
+        jobsFolderController._schedulingService = schedulingService;
+
+        final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(jobsFolderController).build();
+
+        final MockMultipartFile multipartFile =
+                new MockMultipartFile("file", jobFileName, MediaType.TEXT_PLAIN, "dummy".getBytes());
+
+        mockMvc.perform(fileUpload("/test/jobs").file(multipartFile).param("hotfolder", "/test"))
+                .andExpect(status().isOk());
+
+        verify(schedulingService, times(1)).updateSchedule(argThat(tenant -> tenant.getId().equals("test")),
+                eq(scheduleDefinition));
+        verify(scheduleDefinition, times(1)).setHotFolder("/test");
     }
 }

--- a/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ScheduleDefinitionsControllerTest.java
+++ b/monitor/services/src/test/java/org/datacleaner/monitor/server/controllers/ScheduleDefinitionsControllerTest.java
@@ -1,0 +1,87 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.monitor.server.controllers;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.datacleaner.monitor.scheduling.SchedulingService;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinition;
+import org.datacleaner.monitor.scheduling.model.ScheduleDefinitionModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ScheduleDefinitionsControllerTest {
+    private MockMvc _mockMvc;
+
+    private SchedulingService _schedulingService;
+
+    @Before
+    public void setUp() throws Exception {
+        _schedulingService = mock(SchedulingService.class);
+        
+        final ScheduleDefinitionsController scheduleDefinitionsController =
+                new ScheduleDefinitionsController(_schedulingService);
+
+        _mockMvc = MockMvcBuilders.standaloneSetup(scheduleDefinitionsController).build();
+    }
+
+    @Test
+    public void testGetSchedule() throws Exception {
+        final ScheduleDefinition scheduleDefinition = new ScheduleDefinition();
+        scheduleDefinition.setHotFolder("/hotfolder");
+
+        when(_schedulingService.getSchedule(argThat(tenant -> tenant.getId().equals("test")),
+                argThat(job -> job.getName().equals("myjob"))))
+                .thenReturn(scheduleDefinition);
+
+        _mockMvc.perform(get("/test/schedules/myjob")).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[?(@.hotFolder=='/hotfolder')]", hasSize(1)));
+    }
+
+    @Test
+    public void testPutSchedule() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ScheduleDefinition scheduleDefinition = new ScheduleDefinition();
+        final ScheduleDefinitionModel scheduleDefinitionModel = new ScheduleDefinitionModel("/hotfolder");
+
+        when(_schedulingService.getSchedule(argThat(tenant -> tenant.getId().equals("test")),
+                argThat(job -> job.getName().equals("myjob")))).thenReturn(scheduleDefinition);
+
+        _mockMvc.perform(put("/test/schedules/myjob").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(scheduleDefinitionModel))).andExpect(status().isCreated())
+                .andExpect(header().string("Location", is("http://localhost/test/schedules/myjob"))).andReturn();
+
+        verify(_schedulingService, times(1)).updateSchedule(argThat(tenant -> tenant.getId().equals("test")),
+                eq(scheduleDefinition));
+    }
+}

--- a/testware/pom.xml
+++ b/testware/pom.xml
@@ -48,8 +48,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
+			<artifactId>mockito-core</artifactId>
+			<version>2.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>


### PR DESCRIPTION
Resolves #1677 

Added an option to the JobsFolderController, so you can directly define a hot folder for a job which is posted to it. Also added a scheduling endpoint which you can use to schedule an existing job so it uses a hot folder.

I didn't add a DELETE option to the new REST endpoint, because deleting a schedule implicitly deletes the scheduled job, which can already be done through a "jobs" REST endpoint.

Next to that I updated the dependency on mockito to the latest version to be able to make use of java 8 lambda expressions in the unit tests.