### PR TITLE
#1679 Job execution progress always visible

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
@@ -63,6 +63,7 @@ import org.jdesktop.swingx.JXStatusBar;
 import org.jdesktop.swingx.JXTaskPane;
 import org.jdesktop.swingx.JXTextArea;
 import org.jdesktop.swingx.JXTextField;
+import org.jdesktop.swingx.JXTitledPanel;
 import org.jdesktop.swingx.plaf.basic.BasicStatusBarUI;
 import org.jdesktop.swingx.plaf.metal.MetalStatusBarUI;
 import org.jdesktop.swingx.prompt.PromptSupport.FocusBehavior;
@@ -348,6 +349,17 @@ public final class WidgetFactory {
             taskPane.setIcon(icon);
         }
         return taskPane;
+    }
+
+    public static JXTitledPanel createTitledPanel(final String title, final JComponent content) {
+        final JXTitledPanel titlePanel = new JXTitledPanel(title, content);
+        titlePanel.setFocusable(false);
+        titlePanel.setTitlePainter((graphics2D, panel, width, height) -> {
+            graphics2D.setColor(WidgetUtils.BG_COLOR_LESS_DARK);
+            graphics2D.fillRect(0, 0, width, height);
+        });
+
+        return titlePanel;
     }
 
     public static JXTextField createTextField() {

--- a/desktop/api/src/main/java/org/datacleaner/widgets/DCTaskPaneContainer.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/DCTaskPaneContainer.java
@@ -86,7 +86,7 @@ public class DCTaskPaneContainer extends JXTaskPaneContainer {
 
     @Override
     public void add(final Component comp, final Object constraints) {
-        throw new UnsupportedOperationException();
+        super.add(comp, constraints);
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -20,7 +20,6 @@
 package org.datacleaner.panels.result;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -31,9 +30,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.ScrollPaneConstants;
 
 import org.apache.metamodel.schema.Table;
 import org.datacleaner.api.RestrictedFunctionalityCallToAction;
@@ -100,11 +99,9 @@ public class ProgressInformationPanel extends DCPanel {
         add(WidgetUtils.scrolleable(taskPaneContainer), BorderLayout.CENTER);
     }
 
-    private JScrollPane addScrollBar(final Component component) {
-        final JScrollPane scrollBar = new JScrollPane(component);
-        scrollBar.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+    private JScrollPane addScrollBar(final JComponent component) {
+        final JScrollPane scrollBar = WidgetUtils.scrolleable(component);
         final Dimension size = new Dimension(800, 600);
-        scrollBar.setMinimumSize(size);
         scrollBar.setPreferredSize(size);
         scrollBar.setMaximumSize(size);
 

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -20,6 +20,8 @@
 package org.datacleaner.panels.result;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
@@ -29,7 +31,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.ScrollPaneConstants;
 
 import org.apache.metamodel.schema.Table;
 import org.datacleaner.api.RestrictedFunctionalityCallToAction;
@@ -85,7 +89,7 @@ public class ProgressInformationPanel extends DCPanel {
         progressTaskPane.add(_progressBarPanel);
 
         final JXTaskPane executionLogTaskPane = WidgetFactory.createTaskPane("Execution log", IconUtils.ACTION_LOG);
-        executionLogTaskPane.add(_executionLogTextArea);
+        executionLogTaskPane.add(addScrollBar(_executionLogTextArea));
 
         final DCTaskPaneContainer taskPaneContainer = WidgetFactory.createTaskPaneContainer();
         if (running) {
@@ -94,6 +98,17 @@ public class ProgressInformationPanel extends DCPanel {
         taskPaneContainer.add(executionLogTaskPane);
 
         add(WidgetUtils.scrolleable(taskPaneContainer), BorderLayout.CENTER);
+    }
+
+    private JScrollPane addScrollBar(final Component component) {
+        final JScrollPane scrollBar = new JScrollPane(component);
+        scrollBar.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        final Dimension size = new Dimension(800, 600);
+        scrollBar.setMinimumSize(size);
+        scrollBar.setPreferredSize(size);
+        scrollBar.setMaximumSize(size);
+
+        return scrollBar;
     }
 
     public String getTextAreaText() {

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -62,6 +62,7 @@ public class ProgressInformationPanel extends DCPanel {
     private static final long serialVersionUID = 1L;
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormat.forPattern("HH:mm:ss");
+    private static final int MARGIN = 10;
 
     private final JTextArea _executionLogTextArea;
     private final DCPanel _progressBarPanel;
@@ -90,14 +91,13 @@ public class ProgressInformationPanel extends DCPanel {
                 WidgetFactory.createTitledPanel("Execution log", WidgetUtils.scrolleable(_executionLogTextArea));
         executionLogPanel.setBorder(new MatteBorder(1, 1, 1, 1, WidgetUtils.COLOR_ALTERNATIVE_BACKGROUND));
         final DCTaskPaneContainer taskPaneContainer = WidgetFactory.createTaskPaneContainer();
-        final int margin = 10;
-        taskPaneContainer.setLayout(new BorderLayout(margin, margin));
+        taskPaneContainer.setLayout(new BorderLayout(MARGIN, MARGIN));
 
         if (running) {
             taskPaneContainer.add(progressTaskPane, BorderLayout.NORTH);
         }
 
-        setBorder(new MatteBorder(0, 0, margin, 0, WidgetUtils.COLOR_DEFAULT_BACKGROUND));
+        setBorder(new MatteBorder(0, 0, MARGIN, 0, WidgetUtils.COLOR_DEFAULT_BACKGROUND));
         taskPaneContainer.add(executionLogPanel, BorderLayout.CENTER);
         add(taskPaneContainer, BorderLayout.CENTER);
     }

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -19,8 +19,10 @@
  */
 package org.datacleaner.panels.result;
 
+import static javax.swing.WindowConstants.DISPOSE_ON_CLOSE;
+
 import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.Dimension;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
@@ -30,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import javax.swing.BorderFactory;
+import javax.swing.JFrame;
 import javax.swing.JTextArea;
 
 import org.apache.metamodel.schema.Table;
@@ -45,6 +47,7 @@ import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.DCTaskPaneContainer;
 import org.datacleaner.windows.ResultWindow;
 import org.jdesktop.swingx.JXTaskPane;
+import org.jdesktop.swingx.JXTitledPanel;
 import org.jdesktop.swingx.VerticalLayout;
 import org.joda.time.LocalTime;
 import org.joda.time.format.DateTimeFormat;
@@ -86,19 +89,16 @@ public class ProgressInformationPanel extends DCPanel {
         final JXTaskPane progressTaskPane = WidgetFactory.createTaskPane("Progress", IconUtils.ACTION_EXECUTE);
         progressTaskPane.add(_progressBarPanel);
 
-        final JXTaskPane executionLogTaskPane = WidgetFactory.createTaskPane("Execution log", IconUtils.ACTION_LOG);
-        executionLogTaskPane.setLayout(new BorderLayout());
-        executionLogTaskPane.setBorder(BorderFactory.createMatteBorder(0, 0, 10, 0, (Color) null));
-        executionLogTaskPane.add(WidgetUtils.scrolleable(_executionLogTextArea), BorderLayout.CENTER);
-
+        final JXTitledPanel executionLogPanel =
+                WidgetFactory.createTitledPanel("Execution log", WidgetUtils.scrolleable(_executionLogTextArea));
         final DCTaskPaneContainer taskPaneContainer = WidgetFactory.createTaskPaneContainer();
-        taskPaneContainer.setLayout(new BorderLayout());
+        taskPaneContainer.setLayout(new BorderLayout(10, 10));
 
         if (running) {
             taskPaneContainer.add(progressTaskPane, BorderLayout.NORTH);
         }
 
-        taskPaneContainer.add(executionLogTaskPane, BorderLayout.CENTER);
+        taskPaneContainer.add(executionLogPanel, BorderLayout.CENTER);
         add(taskPaneContainer, BorderLayout.CENTER);
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -19,7 +19,6 @@
  */
 package org.datacleaner.panels.result;
 
-
 import java.awt.BorderLayout;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -20,7 +20,7 @@
 package org.datacleaner.panels.result;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
+import java.awt.Color;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
@@ -30,8 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import javax.swing.JComponent;
-import javax.swing.JScrollPane;
+import javax.swing.BorderFactory;
 import javax.swing.JTextArea;
 
 import org.apache.metamodel.schema.Table;
@@ -88,24 +87,19 @@ public class ProgressInformationPanel extends DCPanel {
         progressTaskPane.add(_progressBarPanel);
 
         final JXTaskPane executionLogTaskPane = WidgetFactory.createTaskPane("Execution log", IconUtils.ACTION_LOG);
-        executionLogTaskPane.add(addScrollBar(_executionLogTextArea));
+        executionLogTaskPane.setLayout(new BorderLayout());
+        executionLogTaskPane.setBorder(BorderFactory.createMatteBorder(0, 0, 10, 0, (Color) null));
+        executionLogTaskPane.add(WidgetUtils.scrolleable(_executionLogTextArea), BorderLayout.CENTER);
 
         final DCTaskPaneContainer taskPaneContainer = WidgetFactory.createTaskPaneContainer();
+        taskPaneContainer.setLayout(new BorderLayout());
+
         if (running) {
-            taskPaneContainer.add(progressTaskPane);
+            taskPaneContainer.add(progressTaskPane, BorderLayout.NORTH);
         }
-        taskPaneContainer.add(executionLogTaskPane);
 
-        add(WidgetUtils.scrolleable(taskPaneContainer), BorderLayout.CENTER);
-    }
-
-    private JScrollPane addScrollBar(final JComponent component) {
-        final JScrollPane scrollBar = WidgetUtils.scrolleable(component);
-        final Dimension size = new Dimension(800, 600);
-        scrollBar.setPreferredSize(size);
-        scrollBar.setMaximumSize(size);
-
-        return scrollBar;
+        taskPaneContainer.add(executionLogTaskPane, BorderLayout.CENTER);
+        add(taskPaneContainer, BorderLayout.CENTER);
     }
 
     public String getTextAreaText() {

--- a/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/result/ProgressInformationPanel.java
@@ -19,10 +19,8 @@
  */
 package org.datacleaner.panels.result;
 
-import static javax.swing.WindowConstants.DISPOSE_ON_CLOSE;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
@@ -32,8 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import javax.swing.JFrame;
 import javax.swing.JTextArea;
+import javax.swing.border.MatteBorder;
 
 import org.apache.metamodel.schema.Table;
 import org.datacleaner.api.RestrictedFunctionalityCallToAction;
@@ -91,13 +89,16 @@ public class ProgressInformationPanel extends DCPanel {
 
         final JXTitledPanel executionLogPanel =
                 WidgetFactory.createTitledPanel("Execution log", WidgetUtils.scrolleable(_executionLogTextArea));
+        executionLogPanel.setBorder(new MatteBorder(1, 1, 1, 1, WidgetUtils.COLOR_ALTERNATIVE_BACKGROUND));
         final DCTaskPaneContainer taskPaneContainer = WidgetFactory.createTaskPaneContainer();
-        taskPaneContainer.setLayout(new BorderLayout(10, 10));
+        final int margin = 10;
+        taskPaneContainer.setLayout(new BorderLayout(margin, margin));
 
         if (running) {
             taskPaneContainer.add(progressTaskPane, BorderLayout.NORTH);
         }
 
+        setBorder(new MatteBorder(0, 0, margin, 0, WidgetUtils.COLOR_DEFAULT_BACKGROUND));
         taskPaneContainer.add(executionLogPanel, BorderLayout.CENTER);
         add(taskPaneContainer, BorderLayout.CENTER);
     }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/tabs/VerticalTabbedPane.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/tabs/VerticalTabbedPane.java
@@ -135,6 +135,10 @@ public class VerticalTabbedPane extends DCPanel {
     }
 
     public void setSelectedIndex(final int index) {
+        setSelectedIndex(index, true);
+    }
+
+    public void setSelectedIndex(final int index, final boolean scrollable) {
         // reset other components
         for (final VerticalTab<?> tab : _tabs) {
             final JButton button = tab.getButton();
@@ -156,11 +160,15 @@ public class VerticalTabbedPane extends DCPanel {
         // set component as content
         final JComponent panel = tab.getContents();
 
-        final JScrollPane scroll = WidgetUtils.scrolleable(panel);
-        scroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-
-        add(scroll, BorderLayout.CENTER);
-        _currentContent = scroll;
+        if (scrollable) {
+            final JScrollPane scroll = WidgetUtils.scrolleable(panel);
+            scroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+            add(scroll, BorderLayout.CENTER);
+            _currentContent = scroll;
+        } else {
+            add(panel, BorderLayout.CENTER);
+            _currentContent = panel;
+        }
 
         for (final Listener listener : changeListeners) {
             listener.stateChanged(index, tab);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/ResultWindow.java
@@ -203,6 +203,11 @@ public final class ResultWindow extends AbstractWindow implements WindowListener
                 wrappedPanel.add(buttonPanel, BorderLayout.SOUTH);
                 return super.wrapInCollapsiblePane(wrappedPanel);
             }
+
+            @Override
+            public void setSelectedIndex(final int index) {
+                super.setSelectedIndex(index, false);
+            }
         };
 
         final Dimension size = getDefaultWindowSize();


### PR DESCRIPTION
Resolves #1679 

Job execution page: the progress bar is not any more moved from visible screen by long log output.

Before:
![before](https://cloud.githubusercontent.com/assets/13213915/22594677/5ac1d83c-ea24-11e6-865d-c4890ea1bea4.png)

After:
![after](https://cloud.githubusercontent.com/assets/13213915/22594676/5ac034aa-ea24-11e6-9512-0c05541caaf6.png)

