### PR TITLE
#1684 PlainSearchReplaceTransformer case-insensitive mode

### DIFF
--- a/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/PlainSearchReplaceTransformer.java
+++ b/components/basic-transformers/src/main/java/org/datacleaner/beans/transform/PlainSearchReplaceTransformer.java
@@ -56,6 +56,8 @@ public class PlainSearchReplaceTransformer implements Transformer {
 
     private static final String SEARCH_STRING_PROPERTY_NAME = "Search string";
 
+    private static final String CASE_SENSITIVE_PROPERTY_NAME = "Case sensitive";
+
     @Configured(value = "Value", order = 1)
     InputColumn<String> valueColumn;
 
@@ -67,9 +69,9 @@ public class PlainSearchReplaceTransformer implements Transformer {
     @Description("Replace the entire string when the search string is found.")
     boolean replaceEntireString = false;
 
-    @Configured(order = 4)
-    @Description("Case sensitivity will be ignored during searching and replacing. ")
-    boolean ignoreCaseSensitivity = false;
+    @Configured(value = CASE_SENSITIVE_PROPERTY_NAME, order = 4)
+    @Description("Case sensitivity mode. ")
+    boolean caseSensitive = true;
 
     public static void processRemovedProperties(final ComponentBuilder builder, final StringConverter stringConverter,
             final ComponentDescriptor<?> descriptor, final Map<String, String> removedProperties) {
@@ -133,11 +135,11 @@ public class PlainSearchReplaceTransformer implements Transformer {
             final String replacementString = entry.getValue();
             final String searchString = entry.getKey();
 
-            if (ignoreCaseSensitivity == true) {
-                if (value.toLowerCase().indexOf(searchString.toLowerCase()) != -1) {
+            if (caseSensitive) {
+                if (value.contains(searchString)) {
                     return replacementString;
                 }
-            } else if (value.indexOf(searchString) != -1) {
+            } else if (value.toLowerCase().contains(searchString.toLowerCase())) {
                 return replacementString;
             }
         }
@@ -151,8 +153,8 @@ public class PlainSearchReplaceTransformer implements Transformer {
         for (final Entry<String, String> entry : replacements.entrySet()) {
             final String replacementString = entry.getValue();
             final String searchString = entry.getKey();
-            final Pattern pattern = ignoreCaseSensitivity ? Pattern.compile(searchString, Pattern.CASE_INSENSITIVE)
-                    : Pattern.compile(searchString);
+            final Pattern pattern = caseSensitive ? Pattern.compile(searchString)
+                    : Pattern.compile(searchString, Pattern.CASE_INSENSITIVE);
             result = pattern.matcher(result).replaceAll(replacementString);
         }
 

--- a/components/basic-transformers/src/test/java/org/datacleaner/beans/transform/PlainSearchReplaceTransformerTest.java
+++ b/components/basic-transformers/src/test/java/org/datacleaner/beans/transform/PlainSearchReplaceTransformerTest.java
@@ -39,7 +39,7 @@ public class PlainSearchReplaceTransformerTest {
         final PlainSearchReplaceTransformer transformer = createTransformer();
         transformer.replacements.put("foo", "bar");
         transformer.replaceEntireString = true;
-        transformer.ignoreCaseSensitivity = true;
+        transformer.caseSensitive = false;
 
         final Map<String, String> testData = new LinkedHashMap<>();
         testData.put("this is foo value", "[bar]");
@@ -53,7 +53,7 @@ public class PlainSearchReplaceTransformerTest {
     public void testCaseSensitivity() throws Exception {
         final PlainSearchReplaceTransformer transformer = createTransformer();
         transformer.replacements.put("foo", "bar");
-        transformer.ignoreCaseSensitivity = true;
+        transformer.caseSensitive = false;
 
         final Map<String, String> testData = new LinkedHashMap<>();
         testData.put("foo", "[bar]");


### PR DESCRIPTION
Resolves #1684 

PlainSearchReplaceTransformer can work in case-insensitive mode.

![case-insensitive](https://cloud.githubusercontent.com/assets/13213915/23022301/57b82020-f450-11e6-9b58-b2597a1c777a.png)
