### PR TITLE
Execute hot folder jobs without an existing data store

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/Dropzone.java
@@ -42,6 +42,7 @@ import javax.swing.border.EmptyBorder;
 
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.HdfsResource;
+import org.apache.metamodel.util.Resource;
 import org.datacleaner.bootstrap.WindowContext;
 import org.datacleaner.configuration.ServerInformationCatalog;
 import org.datacleaner.connection.Datastore;
@@ -51,6 +52,7 @@ import org.datacleaner.panels.DCPanel;
 import org.datacleaner.server.EnvironmentBasedHadoopClusterInformation;
 import org.datacleaner.server.HadoopClusterInformation;
 import org.datacleaner.user.DatastoreSelectedListener;
+import org.datacleaner.user.MutableDatastoreCatalog;
 import org.datacleaner.user.UserPreferences;
 import org.datacleaner.util.DatastoreCreationUtil;
 import org.datacleaner.util.FileFilters;
@@ -150,8 +152,7 @@ public class Dropzone extends DCPanel {
                                 (HadoopClusterInformation) serverInformationCatalog.getServer(selectedServer);
                         final HdfsResource resource =
                                 new HadoopResource(selectedFile, server.getConfiguration(), selectedServer);
-                        final Datastore datastore = DatastoreCreationUtil
-                                .createAndAddUniqueDatastoreFromResource(_datastoreCatalog, resource);
+                        final Datastore datastore = createAndAddDatastore(resource);
                         _datastoreSelectListener.datastoreSelected(datastore);
                     }
                 }
@@ -167,6 +168,17 @@ public class Dropzone extends DCPanel {
         });
 
         makeDroppable();
+    }
+
+    private Datastore createAndAddDatastore(final Resource resource) {
+        final Datastore datastore =
+                DatastoreCreationUtil.createUniqueDatastoreFromResource(_datastoreCatalog, resource);
+
+        if (_datastoreCatalog instanceof MutableDatastoreCatalog) {
+            ((MutableDatastoreCatalog) _datastoreCatalog).addDatastore(datastore);
+        }
+
+        return datastore;
     }
 
     protected void showFileChooser() {
@@ -194,8 +206,7 @@ public class Dropzone extends DCPanel {
                     }
                 }
                 if (datastore == null) {
-                    datastore = DatastoreCreationUtil
-                            .createAndAddUniqueDatastoreFromResource(_datastoreCatalog, new FileResource(file));
+                    datastore = createAndAddDatastore(new FileResource(file));
                 }
                 _datastoreSelectListener.datastoreSelected(datastore);
 
@@ -255,8 +266,7 @@ public class Dropzone extends DCPanel {
                     return false;
                 }
 
-                final Datastore datastore = DatastoreCreationUtil
-                        .createAndAddUniqueDatastoreFromResource(_datastoreCatalog, new FileResource(file));
+                final Datastore datastore = createAndAddDatastore(new FileResource(file));
                 _datastoreSelectListener.datastoreSelected(datastore);
                 return true;
             }
@@ -264,5 +274,4 @@ public class Dropzone extends DCPanel {
         };
         setTransferHandler(handler);
     }
-
 }

--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -15,6 +15,12 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-engine-utils</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.metamodel</groupId>
 			<artifactId>MetaModel-full</artifactId>
 		</dependency>

--- a/engine/core/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
+++ b/engine/core/src/main/java/org/datacleaner/util/DatastoreCreationUtil.java
@@ -38,7 +38,6 @@ import org.datacleaner.connection.JsonDatastore;
 import org.datacleaner.connection.OdbDatastore;
 import org.datacleaner.connection.SasDatastore;
 import org.datacleaner.connection.XmlDatastore;
-import org.datacleaner.user.MutableDatastoreCatalog;
 
 public class DatastoreCreationUtil {
 
@@ -79,7 +78,7 @@ public class DatastoreCreationUtil {
         return FileDatastoreEnum.getDatastoreTypeFromResource(resource);
     }
 
-    public static Datastore createAndAddUniqueDatastoreFromResource(final DatastoreCatalog catalog,
+    public static Datastore createUniqueDatastoreFromResource(final DatastoreCatalog catalog,
             final Resource resource) {
         String name = resource.getName();
         if (catalog.containsDatastore(name)) {
@@ -89,11 +88,7 @@ public class DatastoreCreationUtil {
                 name = originalName + "_" + prefix++;
             } while (catalog.containsDatastore(name));
         }
-        final Datastore datastore = createDatastoreFromResource(resource, name);
-        if (catalog instanceof MutableDatastoreCatalog) {
-            ((MutableDatastoreCatalog) catalog).addDatastore(datastore);
-        }
-        return datastore;
+        return createDatastoreFromResource(resource, name);
     }
 
     public static Datastore createDatastoreFromResource(final Resource resource, final String datastoreName) {

--- a/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
@@ -22,6 +22,7 @@ package org.datacleaner.monitor.job;
 import java.util.List;
 import java.util.Map;
 
+import org.datacleaner.connection.Datastore;
 import org.datacleaner.monitor.configuration.TenantContext;
 import org.datacleaner.monitor.scheduling.model.ExecutionLog;
 import org.datacleaner.monitor.shared.model.JobIdentifier;
@@ -76,6 +77,15 @@ public interface JobEngine<T extends JobContext> {
      */
     void executeJob(TenantContext tenantContext, ExecutionLog execution, ExecutionLogger executionLogger,
             Map<String, String> variables) throws Exception;
+
+    /**
+     * Executes a job using a certain datastore. Not supported by all engines.
+     *
+     */
+    default void executeJob(final TenantContext tenantContext, final ExecutionLog execution, final ExecutionLogger executionLogger,
+            final Map<String, String> variables, final Datastore datastore) throws Exception {
+        throw new UnsupportedOperationException("Not implemented by this engine");
+    }
 
     /**
      * Requests a cancellation of a running job.

--- a/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
@@ -79,13 +79,13 @@ public interface JobEngine<T extends JobContext> {
             Map<String, String> variables) throws Exception;
 
     /**
-     * Executes a job using a certain datastore. Not supported by all engines.
-     *
+     * Executes a job using overridden properties and/or datastore. Not supported by all engines, in which case
+     * overridden values will be silently ignored
      */
     default void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
-            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore)
-            throws Exception {
-        throw new UnsupportedOperationException("Not implemented by this engine");
+            final ExecutionLogger executionLogger, final Map<String, String> variables,
+            final Map<String, String> overrideProperties, final Datastore datastore) throws Exception {
+        executeJob(tenantContext, execution, executionLogger, variables);
     }
 
     /**

--- a/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/job/JobEngine.java
@@ -82,8 +82,9 @@ public interface JobEngine<T extends JobContext> {
      * Executes a job using a certain datastore. Not supported by all engines.
      *
      */
-    default void executeJob(final TenantContext tenantContext, final ExecutionLog execution, final ExecutionLogger executionLogger,
-            final Map<String, String> variables, final Datastore datastore) throws Exception {
+    default void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
+            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore)
+            throws Exception {
         throw new UnsupportedOperationException("Not implemented by this engine");
     }
 

--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
@@ -45,7 +45,6 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
     private Map<String, String> _jobMetadataProperties;
     private boolean _runOnHadoop;
     private String _hotFolder;
-    private Map<String, String> _overrideProperties;
 
     // no-args constructor
     public ScheduleDefinition() {
@@ -169,14 +168,6 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
 
     public void setHotFolder(final String hotFolder) {
         _hotFolder = hotFolder;
-    }
-
-    public Map<String, String> getOverrideProperties() {
-        return _overrideProperties;
-    }
-
-    public void setOverrideProperties(final Map<String, String> overrideProperties) {
-        _overrideProperties = overrideProperties;
     }
 
     @Override

--- a/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/quartz/ExecuteJob.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/scheduling/quartz/ExecuteJob.java
@@ -177,8 +177,7 @@ public class ExecuteJob extends AbstractQuartzJob {
             final VariableProviderDefinition variableProviderDef = execution.getSchedule().getVariableProvider();
             final Map<String, String> variables = overrideVariables(variableProviderDef, job, execution, configuration);
 
-            jobEngine.executeJob(context, execution, executionLogger, variables, datastore);
-
+            jobEngine.executeJob(context, execution, executionLogger, variables, overrideProperties, datastore);
         } catch (final Throwable error) {
             // only initialization issues are catched here, eg. failing to load
             // job or configuration. Other issues will be reported to the

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -544,11 +544,6 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
 
     @Override
     public ScheduleDefinition getSchedule(final TenantIdentifier tenant, final JobIdentifier jobIdentifier) {
-        return getSchedule(tenant, jobIdentifier, null);
-    }
-
-    private ScheduleDefinition getSchedule(final TenantIdentifier tenant, final JobIdentifier jobIdentifier,
-            final Map<String, String> overrideProperties) {
         final TenantContext context = _tenantContextFactory.getContext(tenant);
 
         final String jobName = jobIdentifier.getName();
@@ -581,7 +576,6 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
         }
 
         schedule.setJobMetadataProperties(jobMetadataProperties);
-        schedule.setOverrideProperties(overrideProperties);
 
         return schedule;
     }
@@ -748,7 +742,7 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     private ExecutionLog triggerExecution(final TenantIdentifier tenant, final JobIdentifier job,
             final Map<String, String> overrideProperties, final Datastore datastore, final TriggerType triggerType) {
         final String jobNameToBeTriggered = job.getName();
-        final ScheduleDefinition schedule = getSchedule(tenant, job, overrideProperties);
+        final ScheduleDefinition schedule = getSchedule(tenant, job);
         final ExecutionLog execution = new ExecutionLog(schedule, triggerType);
         execution.setJobBeginDate(new Date());
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/SchedulingServiceImpl.java
@@ -49,9 +49,7 @@ import org.apache.commons.io.monitor.FileAlterationObserver;
 import org.apache.metamodel.util.Action;
 import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.FileResource;
-import org.datacleaner.connection.CsvDatastore;
 import org.datacleaner.connection.Datastore;
-import org.datacleaner.connection.ExcelDatastore;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.JaxbJobReader;
 import org.datacleaner.job.JaxbJobWriter;
@@ -73,7 +71,6 @@ import org.datacleaner.monitor.server.hotfolder.DefaultWaitForCompleteFileStrate
 import org.datacleaner.monitor.server.hotfolder.HotFolderPreferences;
 import org.datacleaner.monitor.server.hotfolder.IncompleteFileException;
 import org.datacleaner.monitor.server.hotfolder.WaitForCompleteFileStrategy;
-import org.datacleaner.monitor.server.hotfolder.WrongInputException;
 import org.datacleaner.monitor.server.jaxb.JaxbException;
 import org.datacleaner.monitor.server.jaxb.JaxbExecutionLogReader;
 import org.datacleaner.monitor.server.jaxb.JaxbScheduleReader;
@@ -88,6 +85,7 @@ import org.datacleaner.monitor.shared.model.TenantIdentifier;
 import org.datacleaner.repository.Repository;
 import org.datacleaner.repository.RepositoryFile;
 import org.datacleaner.repository.RepositoryFolder;
+import org.datacleaner.util.DatastoreCreationUtil;
 import org.datacleaner.util.FileFilters;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
@@ -170,53 +168,9 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
 
         private void executeJobWithFileInNewThread(final File inputFile) {
             new Thread(() -> {
-                try {
-                    checkInputFile(inputFile);
                     fillJobVariables(inputFile);
                     executeJobWithFile(inputFile);
-                } catch (final WrongInputException e) {
-                    logger.error("File '{}' does not contain required columns. " + e.getMessage(), inputFile.getName());
-                }
             }).start();
-        }
-
-        private void checkInputFile(final File inputFile) throws WrongInputException {
-            final TenantContext tenantContext = _tenantContextFactory.getContext(tenant);
-            final Datastore oldDataStore = tenantContext.getConfiguration().getDatastoreCatalog()
-                    .getDatastore(getDataStoreName());
-            final Datastore newDataStore = getNewDataStore(inputFile, oldDataStore);
-            final String[] oldColumnNames = oldDataStore.openConnection().getSchemaNavigator().getDefaultSchema()
-                    .getTable(0).getColumnNames();
-            final String[] newColumnNames = newDataStore.openConnection().getSchemaNavigator().getDefaultSchema()
-                    .getTable(0).getColumnNames();
-
-            if (oldColumnNames.length != newColumnNames.length) {
-                throw new WrongInputException("The file does not have correct number of input columns ("
-                        + oldColumnNames.length + " required, " + newColumnNames.length + " present). ");
-            }
-
-            for (int i = 0; i < oldColumnNames.length; i++) {
-                if (!oldColumnNames[i].equals(newColumnNames[i])) {
-                    throw new WrongInputException("The file does not have a correct input column at position " + i
-                            + " ('" + oldColumnNames[i] + "' required, '" + newColumnNames[i] + "' present). ");
-                }
-            }
-        }
-
-        private Datastore getNewDataStore(final File inputFile, final Datastore oldDataStore)
-                throws WrongInputException {
-            final Datastore newDataStore;
-
-            if (oldDataStore instanceof CsvDatastore) {
-                newDataStore = new CsvDatastore(inputFile.getName(), inputFile.getAbsolutePath());
-            } else if (oldDataStore instanceof ExcelDatastore) {
-                newDataStore = new ExcelDatastore(inputFile.getName(), new FileResource(inputFile),
-                        inputFile.getAbsolutePath());
-            } else {
-                throw new WrongInputException("Unsupported data store type (" + inputFile.getAbsolutePath() + "). ");
-            }
-
-            return newDataStore;
         }
 
         private void fillJobVariables(final File file) {
@@ -284,7 +238,9 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
 
                 final Map<String, String> propertiesMap = new HashMap<>();
                 propertiesMap.put("datastoreCatalog." + getDataStoreName() + ".filename", file.getAbsolutePath());
-                triggerExecution(tenant, job, propertiesMap, TriggerType.HOTFOLDER);
+                triggerExecution(tenant, job, propertiesMap,
+                        DatastoreCreationUtil.createDatastoreFromResource(new FileResource(file), dataStoreName),
+                        TriggerType.HOTFOLDER);
             } else {
                 logger.error("Hot folder job execution was cancelled because datastore name is missing. ");
             }
@@ -785,10 +741,15 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
     }
 
     private ExecutionLog triggerExecution(final TenantIdentifier tenant, final JobIdentifier job,
-            final Map<String, String> overrideProperties, final TriggerType manual) {
+            final Map<String, String> overrideProperties, final TriggerType triggerType) {
+        return triggerExecution(tenant, job, overrideProperties, null, triggerType);
+    }
+
+    private ExecutionLog triggerExecution(final TenantIdentifier tenant, final JobIdentifier job,
+            final Map<String, String> overrideProperties, final Datastore datastore, final TriggerType triggerType) {
         final String jobNameToBeTriggered = job.getName();
         final ScheduleDefinition schedule = getSchedule(tenant, job, overrideProperties);
-        final ExecutionLog execution = new ExecutionLog(schedule, manual);
+        final ExecutionLog execution = new ExecutionLog(schedule, triggerType);
         execution.setJobBeginDate(new Date());
 
         try {
@@ -823,6 +784,8 @@ public class SchedulingServiceImpl implements SchedulingService, ApplicationCont
 
             final JobDataMap jobDataMap = new JobDataMap();
             jobDataMap.put(ExecuteJob.DETAIL_EXECUTION_LOG, execution);
+            jobDataMap.put(ExecuteJob.DETAIL_OVERRIDE_PROPERTIES, overrideProperties);
+            jobDataMap.put(ExecuteJob.DETAIL_OVERRIDE_DATASTORE, datastore);
 
             _scheduler.triggerJob(new JobKey(jobNameToBeTriggered, tenant.getId()), jobDataMap);
         } catch (final SchedulerException e) {

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContext.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContext.java
@@ -22,6 +22,7 @@ package org.datacleaner.monitor.server.job;
 import java.util.List;
 import java.util.Map;
 
+import org.datacleaner.connection.Datastore;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.monitor.job.JobContext;
 import org.datacleaner.monitor.job.MetricJobContext;
@@ -38,6 +39,8 @@ public interface DataCleanerJobContext extends XmlJobContext, MetricJobContext {
     AnalysisJob getAnalysisJob(Map<String, String> variableOverrides);
 
     AnalysisJob getAnalysisJob(Map<String, String> variableOverrides, Map<String, String> overrideProperties);
+
+    AnalysisJob getAnalysisJob(Map<String, String> variableOverrides, Map<String, String> overrideProperties, Datastore datastore);
 
     AnalysisJob getAnalysisJob();
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContext.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContext.java
@@ -40,7 +40,8 @@ public interface DataCleanerJobContext extends XmlJobContext, MetricJobContext {
 
     AnalysisJob getAnalysisJob(Map<String, String> variableOverrides, Map<String, String> overrideProperties);
 
-    AnalysisJob getAnalysisJob(Map<String, String> variableOverrides, Map<String, String> overrideProperties, Datastore datastore);
+    AnalysisJob getAnalysisJob(Map<String, String> variableOverrides, Map<String, String> overrideProperties,
+            Datastore datastore);
 
     AnalysisJob getAnalysisJob();
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContextImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContextImpl.java
@@ -120,7 +120,7 @@ public class DataCleanerJobContextImpl implements DataCleanerJobContext {
 
         final DataCleanerConfiguration configuration = _tenantContext.getConfiguration(overrideProperties);
         final MonitorJobReader reader = new MonitorJobReader(configuration, _file);
-        final AnalysisJob job = reader.readJob(variableOverrides);
+        final AnalysisJob job = reader.readJob(variableOverrides, datastore);
         _sourceDatastoreName = job.getDatastore().getName();
         return job;
     }

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContextImpl.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobContextImpl.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.metamodel.util.FileHelper;
 import org.datacleaner.configuration.DataCleanerConfiguration;
+import org.datacleaner.connection.Datastore;
 import org.datacleaner.job.AnalysisJob;
 import org.datacleaner.job.AnalysisJobMetadata;
 import org.datacleaner.job.JaxbJobReader;
@@ -92,7 +93,13 @@ public class DataCleanerJobContextImpl implements DataCleanerJobContext {
     @Override
     public AnalysisJob getAnalysisJob(final Map<String, String> variableOverrides,
             final Map<String, String> overrideProperties) {
-        if ((variableOverrides == null || variableOverrides.isEmpty()) && overrideProperties == null) {
+        return getAnalysisJob(variableOverrides, overrideProperties, null);
+    }
+
+    @Override
+    public AnalysisJob getAnalysisJob(final Map<String, String> variableOverrides,
+            final Map<String, String> overrideProperties, final Datastore datastore) {
+        if ((variableOverrides == null || variableOverrides.isEmpty()) && overrideProperties == null && datastore == null) {
             // cached job definition may be used, if not outdated
             final long configurationLastModified = _tenantContext.getConfigurationFile().getLastModified();
             long lastModified = Math.max(_file.getLastModified(), configurationLastModified);

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
@@ -166,7 +166,7 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
 
         preLoadJob(configuration, job);
 
-        final AnalysisJob analysisJob = job.getAnalysisJob(variables, overrideProperties);
+        final AnalysisJob analysisJob = job.getAnalysisJob(variables, overrideProperties, datastore);
 
         if (execution.getSchedule().isRunOnHadoop()) {
             runJobOnHadoop(configuration, execution, analysisJob, tenantContext, analysisListener, executionLogger,
@@ -374,7 +374,7 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
     /**
      * Validates a job before loading it with a concrete datastore.
      *
-     * @param context
+     * @param configuration
      * @param job
      *
      * @throws FileNotFoundException

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
@@ -153,14 +153,13 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
     @Override
     public void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
             final ExecutionLogger executionLogger, final Map<String, String> variables) throws Exception {
-        executeJob(tenantContext, execution, executionLogger, variables, null);
+        executeJob(tenantContext, execution, executionLogger, variables, null, null);
     }
 
     @Override
     public void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
-            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore)
-            throws Exception {
-
+            final ExecutionLogger executionLogger, final Map<String, String> variables,
+            final Map<String, String> overrideProperties, final Datastore overrideDatastore) throws Exception {
         final AnalysisListener analysisListener = createAnalysisListener(execution, executionLogger);
 
         final DataCleanerJobContext job = (DataCleanerJobContext) tenantContext.getJob(execution.getJob());
@@ -168,12 +167,11 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
             throw new IllegalStateException("No such job: " + execution.getJob());
         }
 
-        final Map<String, String> overrideProperties = execution.getSchedule().getOverrideProperties();
         final DataCleanerConfiguration configuration = tenantContext.getConfiguration(overrideProperties);
 
         preLoadJob(configuration, job);
 
-        final AnalysisJob analysisJob = job.getAnalysisJob(variables, overrideProperties, datastore);
+        final AnalysisJob analysisJob = job.getAnalysisJob(variables, overrideProperties, overrideDatastore);
 
         if (execution.getSchedule().isRunOnHadoop()) {
             runJobOnHadoop(configuration, execution, analysisJob, tenantContext, analysisListener, executionLogger,

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.swing.SwingWorker;
-import javax.xml.crypto.Data;
 
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.HdfsResource;
@@ -159,7 +158,8 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
 
     @Override
     public void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
-            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore) throws Exception {
+            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore)
+            throws Exception {
 
         final AnalysisListener analysisListener = createAnalysisListener(execution, executionLogger);
 

--- a/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
+++ b/monitor/services/src/main/java/org/datacleaner/monitor/server/job/DataCleanerJobEngine.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.swing.SwingWorker;
+import javax.xml.crypto.Data;
 
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.HdfsResource;
@@ -153,6 +154,12 @@ public class DataCleanerJobEngine extends AbstractJobEngine<DataCleanerJobContex
     @Override
     public void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
             final ExecutionLogger executionLogger, final Map<String, String> variables) throws Exception {
+        executeJob(tenantContext, execution, executionLogger, variables, null);
+    }
+
+    @Override
+    public void executeJob(final TenantContext tenantContext, final ExecutionLog execution,
+            final ExecutionLogger executionLogger, final Map<String, String> variables, final Datastore datastore) throws Exception {
 
         final AnalysisListener analysisListener = createAnalysisListener(execution, executionLogger);
 

--- a/monitor/ui/src/test/java/org/datacleaner/monitor/JobServicesIT.java
+++ b/monitor/ui/src/test/java/org/datacleaner/monitor/JobServicesIT.java
@@ -49,6 +49,7 @@ public class JobServicesIT {
     @Before
     public void setup() throws IOException {
         RestAssured.authentication = basic(USER_NAME, USER_PASSWORD);
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
     @Test(timeout = 5 * ONE_MINUTE)


### PR DESCRIPTION
This makes hot folder jobs to execute, even if there is no existing data store.

It also remove the pre-flight testing of hot folder jobs to make sure that errors shows up in the execution log of jobs.

Fixes #1690
