### PR TITLE
Update multimapped combobox visibility

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedComboBoxPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedComboBoxPropertyWidget.java
@@ -139,7 +139,8 @@ public class MultipleMappedComboBoxPropertyWidget extends MultipleInputColumnsPr
         return false;
     }
 
-    protected DCGroupComboBox createComboBox(final InputColumn<?> inputColumn, final HasColumnMeaning mappedValue) {
+    protected DCGroupComboBox createComboBox(final InputColumn<?> inputColumn,
+            final HasColumnMeaning mappedValue) {
         final DCGroupComboBox comboBox = new DCGroupComboBox();
         fillComboBox(comboBox);
         _mappedComboBoxes.put(inputColumn, comboBox);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedComboBoxPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/MultipleMappedComboBoxPropertyWidget.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 
@@ -138,8 +139,7 @@ public class MultipleMappedComboBoxPropertyWidget extends MultipleInputColumnsPr
         return false;
     }
 
-    protected DCGroupComboBox createComboBox(final InputColumn<?> inputColumn,
-            final HasColumnMeaning mappedValue) {
+    protected DCGroupComboBox createComboBox(final InputColumn<?> inputColumn, final HasColumnMeaning mappedValue) {
         final DCGroupComboBox comboBox = new DCGroupComboBox();
         fillComboBox(comboBox);
         _mappedComboBoxes.put(inputColumn, comboBox);
@@ -226,6 +226,12 @@ public class MultipleMappedComboBoxPropertyWidget extends MultipleInputColumnsPr
         panel.add(checkBox, BorderLayout.CENTER);
         panel.add(comboBox, BorderLayout.EAST);
         return panel;
+    }
+
+    @Override
+    protected void onValuesBatchSelected(final List<InputColumn<?>> values) {
+        _mappedComboBoxes.values().forEach(cb -> cb.setVisible(false));
+        values.stream().map(_mappedComboBoxes::get).filter(Objects::nonNull).forEach(cb -> cb.setVisible(true));
     }
 
     @Override


### PR DESCRIPTION
This overrides the `onValuesBatchSelected` method, ensuring that combobox visibility is properly updated on batch updates.

Fixes #1700 
