### PR TITLE
Export metrics options for schedule definition

### DIFF
--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinition.java
@@ -45,6 +45,7 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
     private Map<String, String> _jobMetadataProperties;
     private boolean _runOnHadoop;
     private String _hotFolder;
+    private boolean _exportMetrics;
 
     // no-args constructor
     public ScheduleDefinition() {
@@ -168,6 +169,14 @@ public class ScheduleDefinition implements Comparable<ScheduleDefinition>, Seria
 
     public void setHotFolder(final String hotFolder) {
         _hotFolder = hotFolder;
+    }
+
+    public Boolean isExportMetrics() {
+        return _exportMetrics;
+    }
+
+    public void setExportMetrics(boolean exportMetrics) {
+        _exportMetrics = exportMetrics;
     }
 
     @Override

--- a/monitor/api/src/main/resources/schedule.xsd
+++ b/monitor/api/src/main/resources/schedule.xsd
@@ -19,6 +19,7 @@
 				</choice>
 				<element name="distributed-execution" type="boolean" minOccurs="0" maxOccurs="1" />
 				<element name="run-on-hadoop" type="boolean" minOccurs="0" maxOccurs="1" />
+				<element name="export-metrics" type="boolean" minOccurs="0" maxOccurs="1" />
 				<element name="variable-provider" minOccurs="0" maxOccurs="1" type="schedule:variableProvider" />
 				<element name="alerts" minOccurs="0" maxOccurs="1">
 					<complexType>


### PR DESCRIPTION
Fixes #1707. 

Add export metrics field and getter and setter to ScheduleDefinition to make it possible to choose whether or not you want the metric of a job execution to be written to disk upon job execution.

Note that we may not want the exporting of metrics to be optional, but just do it by default, in which case this PR isn't needed.