### PR TITLE
Instantiate EnumerationValue array with null objects

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/descriptors/EnumerationValue.java
+++ b/engine/core/src/main/java/org/datacleaner/descriptors/EnumerationValue.java
@@ -98,7 +98,11 @@ public class EnumerationValue implements HasName, JsonSerializable, Serializable
                 final Enum<?>[] values = (Enum[]) value;
                 final EnumerationValue[] result = new EnumerationValue[values.length];
                 for (int i = 0; i < result.length; i++) {
-                    result[i] = new EnumerationValue(values[i]);
+                    if (values[i] == null) {
+                        result[i] = null;
+                    } else {
+                        result[i] = new EnumerationValue(values[i]);
+                    }
                 }
                 return result;
             }

--- a/engine/core/src/test/java/org/datacleaner/descriptors/EnumerationValueTest.java
+++ b/engine/core/src/test/java/org/datacleaner/descriptors/EnumerationValueTest.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.descriptors;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/engine/core/src/test/java/org/datacleaner/descriptors/EnumerationValueTest.java
+++ b/engine/core/src/test/java/org/datacleaner/descriptors/EnumerationValueTest.java
@@ -1,0 +1,20 @@
+package org.datacleaner.descriptors;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class EnumerationValueTest {
+    enum TestEnum {
+        a, b
+    }
+    
+    @Test
+    public void testFromArray() {
+        assertArrayEquals(new EnumerationValue[] { new EnumerationValue(TestEnum.a), new EnumerationValue(TestEnum.b) },
+                EnumerationValue.fromArray(new TestEnum[] { TestEnum.a, TestEnum.b }));
+
+        assertArrayEquals(new EnumerationValue[] { new EnumerationValue(TestEnum.a), null },
+                EnumerationValue.fromArray(new TestEnum[] { TestEnum.a, null }));
+    }
+}


### PR DESCRIPTION
Fixes #1711.

Instead of trying to instantiate an EnumerationValue object with a null argument just add a null value to the array which is created.