### PR TITLE
XML config and job deserialization optimization

### DIFF
--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -145,9 +145,18 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
 
     private static final Logger logger = LoggerFactory.getLogger(JaxbConfigurationReader.class);
 
-    private final JAXBContext _jaxbContext;
+    private static final JAXBContext _jaxbContext;
     private final ConfigurationReaderInterceptor _interceptor;
     private final Deque<String> _variablePathBuilder;
+
+    static {
+        try {
+            _jaxbContext = JAXBContext
+                    .newInstance(ObjectFactory.class.getPackage().getName(), ObjectFactory.class.getClassLoader());
+        } catch (final JAXBException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 
     public JaxbConfigurationReader() {
         this(null);
@@ -159,12 +168,6 @@ public final class JaxbConfigurationReader implements ConfigurationReader<InputS
         }
         _interceptor = interceptor;
         _variablePathBuilder = new ArrayDeque<>(4);
-        try {
-            _jaxbContext = JAXBContext
-                    .newInstance(ObjectFactory.class.getPackage().getName(), ObjectFactory.class.getClassLoader());
-        } catch (final JAXBException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     /**

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -105,20 +105,23 @@ public class JaxbJobReader implements JobReader<InputStream> {
 
     private static final Logger logger = LoggerFactory.getLogger(JaxbJobReader.class);
 
-    private final JAXBContext _jaxbContext;
+    private static final JAXBContext _jaxbContext;
     private final DataCleanerConfiguration _configuration;
 
-    public JaxbJobReader(final DataCleanerConfiguration configuration) {
-        if (configuration == null) {
-            throw new IllegalArgumentException("Configuration cannot be null");
-        }
-        _configuration = configuration;
+    static {
         try {
             _jaxbContext = JAXBContext
                     .newInstance(ObjectFactory.class.getPackage().getName(), ObjectFactory.class.getClassLoader());
         } catch (final JAXBException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public JaxbJobReader(final DataCleanerConfiguration configuration) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("Configuration cannot be null");
+        }
+        _configuration = configuration;
     }
 
     private static void processRemovedProperties(final ComponentBuilder builder, final StringConverter stringConverter,


### PR DESCRIPTION
Changed jaxb context as static field to safe its repeated useless and pricy initialization. It is a usual way to re-use it. BTW, marshaller and unmarshaller are not thread safe and cannot be shared in this way.