### PR TITLE
Add option to configure metrics export option when scheduling job

### DIFF
--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
@@ -19,24 +19,23 @@
  */
 package org.datacleaner.monitor.scheduling.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ScheduleDefinitionModel {
-    private final String _hotFolder;
+    @JsonProperty("hotFolder")
+    private String _hotFolder;
     
     @JsonProperty("exportMetrics")
     private boolean _exportMetrics;
-
-    @JsonCreator
-    public ScheduleDefinitionModel(@JsonProperty("hotFolder") final String hotFolder) {
-        _hotFolder = hotFolder;
-    }
 
     public String getHotFolder() {
         return _hotFolder;
     }
 
+    public void setHotFolder(final String hotFolder) {
+        _hotFolder = hotFolder;
+    }
+    
     public boolean isExportMetrics() {
         return _exportMetrics;
     }

--- a/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
+++ b/monitor/api/src/main/java/org/datacleaner/monitor/scheduling/model/ScheduleDefinitionModel.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ScheduleDefinitionModel {
     private final String _hotFolder;
+    
+    @JsonProperty("exportMetrics")
+    private boolean _exportMetrics;
 
     @JsonCreator
     public ScheduleDefinitionModel(@JsonProperty("hotFolder") final String hotFolder) {
@@ -34,4 +37,11 @@ public class ScheduleDefinitionModel {
         return _hotFolder;
     }
 
+    public boolean isExportMetrics() {
+        return _exportMetrics;
+    }
+
+    public void setExportMetrics(boolean exportMetrics) {
+        _exportMetrics = exportMetrics;
+    }
 }


### PR DESCRIPTION
Add the option to active metrics export when scheduling jobs from DataCleaner desktop.