### PR TITLE
#1724 HttpRequestTransformer: variables support in headers.

### DIFF
--- a/components/http/src/main/java/org/datacleaner/components/http/HttpRequestTransformer.java
+++ b/components/http/src/main/java/org/datacleaner/components/http/HttpRequestTransformer.java
@@ -150,7 +150,8 @@ public class HttpRequestTransformer implements Transformer {
         if (headers != null) {
             final Set<Entry<String, String>> entries = headers.entrySet();
             for (final Entry<String, String> entry : entries) {
-                request.setHeader(entry.getKey(), entry.getValue());
+                final String finalValue = applyVariablesToString(entry.getValue(), inputRow).trim();
+                request.setHeader(entry.getKey(), finalValue);
             }
         }
 


### PR DESCRIPTION
Resolves #1724 

In HttpRequestTransformer you can now use variables in headers.

![variables-in-headers](https://cloud.githubusercontent.com/assets/13213915/26003772/f64be322-3733-11e7-8098-5da797cad0d6.png)

