### PR TITLE
Bump MetaModel to latest stable version, 4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<httpcomponents.version>4.4.1</httpcomponents.version>
 		<guava.version>16.0.1</guava.version>
 		<curator.version>2.6.0</curator.version>
-		<metamodel.version>4.5.4</metamodel.version>
+		<metamodel.version>4.6.0</metamodel.version>
 		<metamodel.extras.version>4.4.0</metamodel.extras.version>
 		<gwt.version>2.7.0</gwt.version>
 		<spring.core.version>4.1.9.RELEASE</spring.core.version>


### PR DESCRIPTION
This will update to latest stable MetaModel version, 4.6.0.

Fixes #1734 