### PR TITLE
fixed URLs in DataHub connector according DataHub 9.0

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/metamodel/datahub/DataHubRepoConnection.java
+++ b/engine/core/src/main/java/org/datacleaner/metamodel/datahub/DataHubRepoConnection.java
@@ -40,8 +40,8 @@ import org.datacleaner.util.http.MonitorHttpClient;
  */
 public class DataHubRepoConnection {
     private static final String DATASTORES_PATH = "/datastores";
-    private static final String CONTEXT_PATH = "/ui";
-    private static final String REPOSITORY_PATH = "/repository";
+    private static final String CONTEXT_PATH = "/datahub";
+    private static final String REPOSITORY_PATH = "/api/dc-monitor";
     private static final String SCHEMA_EXTENSION = ".schemas";
     private static final String QUERY_EXTENSION = ".query?";
     private static final String USERINFO_PATH = "/_user";


### PR DESCRIPTION
To be sure I compared the path engine/core/src/main/java/org/datacleaner/metamodel/datahub - master vs. release/5.1 and it seems to be aligned now.