### PR TITLE
Workspace chooser at startup

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/bootstrap/WindowContext.java
+++ b/desktop/api/src/main/java/org/datacleaner/bootstrap/WindowContext.java
@@ -99,7 +99,17 @@ public interface WindowContext {
     boolean showExitDialog();
 
     /**
-     * Requests the application to exit.
+     * Requests the application to exit with exit code 0.
      */
     void exit();
+
+    /**
+     * Requests the application to exit.
+     */
+    void exit(int exitCode);
+
+    /**
+     * Exits without asking
+     */
+    void forceExit(int exitCode);
 }

--- a/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
+++ b/desktop/api/src/main/java/org/datacleaner/util/WidgetFactory.java
@@ -317,6 +317,7 @@ public final class WidgetFactory {
 
         b.setUI(new MetalButtonUI());
         b.setBackground(WidgetUtils.COLOR_WELL_BACKGROUND);
+        b.setContentAreaFilled(false);
 
         final MatteBorder outerBorder = new MatteBorder(1, 1, 1, 1, WidgetUtils.BG_COLOR_LESS_BRIGHT);
         b.setBorder(new CompoundBorder(outerBorder, new EmptyBorder(2, 4, 2, 4)));

--- a/desktop/api/src/main/java/org/datacleaner/widgets/DarkButtonUI.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/DarkButtonUI.java
@@ -52,6 +52,7 @@ public class DarkButtonUI extends MetalButtonUI {
         b.setBackground(COLOR_BG_DEFAULT);
         b.setForeground(WidgetUtils.BG_COLOR_BRIGHTEST);
         b.setFocusPainted(false);
+        b.setContentAreaFilled(false);
         b.setBorder(WidgetUtils.BORDER_BUTTON_DARK);
         b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }

--- a/desktop/api/src/main/java/org/datacleaner/widgets/DefaultButtonUI.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/DefaultButtonUI.java
@@ -50,6 +50,7 @@ public class DefaultButtonUI extends MetalButtonUI {
         b.setBackground(WidgetUtils.BG_COLOR_BRIGHT);
         b.setForeground(WidgetUtils.BG_COLOR_DARK);
         b.setBorder(WidgetUtils.BORDER_BUTTON_DEFAULT);
+        b.setContentAreaFilled(false);
         b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 

--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractDialog.java
@@ -285,4 +285,9 @@ public abstract class AbstractDialog extends JDialog implements DCWindow, Window
     public Component toComponent() {
         return this;
     }
+
+    @Override
+    public boolean canClose() {
+        return true;
+    }
 }

--- a/desktop/api/src/main/java/org/datacleaner/windows/AbstractWindow.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/AbstractWindow.java
@@ -210,4 +210,8 @@ public abstract class AbstractWindow extends JFrame implements DCWindow, WindowL
     public Component toComponent() {
         return this;
     }
+
+    public boolean canClose() {
+        return true;
+    }
 }

--- a/desktop/api/src/main/java/org/datacleaner/windows/DCWindow.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/DCWindow.java
@@ -45,4 +45,6 @@ public interface DCWindow {
     void close();
 
     Component toComponent();
+
+    boolean canClose();
 }

--- a/desktop/ui/src/main/java/org/datacleaner/Main.java
+++ b/desktop/ui/src/main/java/org/datacleaner/Main.java
@@ -155,7 +155,7 @@ public final class Main {
             final boolean initializeLogging) {
         final BootstrapOptions bootstrapOptions = new DefaultBootstrapOptions(args);
 
-        if(!bootstrapOptions.isCommandLineMode()) {
+        if (!bootstrapOptions.isCommandLineMode()) {
 
             try {
                 new WorkspaceConfigStarter().start();

--- a/desktop/ui/src/main/java/org/datacleaner/Main.java
+++ b/desktop/ui/src/main/java/org/datacleaner/Main.java
@@ -154,26 +154,28 @@ public final class Main {
     public static void main(final String[] args, final boolean initializeSystemProperties,
             final boolean initializeLogging) {
         final BootstrapOptions bootstrapOptions = new DefaultBootstrapOptions(args);
+        try {
 
-        if (!bootstrapOptions.isCommandLineMode()) {
-
-            try {
-                new WorkspaceConfigStarter().start();
-            } catch (Exception e) {
-                e.printStackTrace();
+            if (!bootstrapOptions.isCommandLineMode()) {
+                if (!new WorkspaceConfigStarter().start()) {
+                    return;
+                }
             }
+
+            if (initializeSystemProperties) {
+                initializeSystemProperties(args);
+            }
+
+            if (initializeLogging) {
+                initializeLogging();
+            }
+
+            final Bootstrap bootstrap = new Bootstrap(bootstrapOptions);
+            bootstrap.run();
+
+        } catch (Exception e) {
+            throw (e instanceof RuntimeException) ? ((RuntimeException)e) : new RuntimeException(e);
         }
 
-        if (initializeSystemProperties) {
-            initializeSystemProperties(args);
-        }
-
-        if (initializeLogging) {
-            initializeLogging();
-        }
-
-
-        final Bootstrap bootstrap = new Bootstrap(bootstrapOptions);
-        bootstrap.run();
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/Main.java
+++ b/desktop/ui/src/main/java/org/datacleaner/Main.java
@@ -33,6 +33,7 @@ import org.datacleaner.bootstrap.Bootstrap;
 import org.datacleaner.bootstrap.BootstrapOptions;
 import org.datacleaner.bootstrap.DefaultBootstrapOptions;
 import org.datacleaner.extensions.ClassLoaderUtils;
+import org.datacleaner.tenantloader.WorkspaceConfigStarter;
 import org.datacleaner.user.DataCleanerHome;
 
 /**
@@ -152,6 +153,17 @@ public final class Main {
 
     public static void main(final String[] args, final boolean initializeSystemProperties,
             final boolean initializeLogging) {
+        final BootstrapOptions bootstrapOptions = new DefaultBootstrapOptions(args);
+
+        if(!bootstrapOptions.isCommandLineMode()) {
+
+            try {
+                new WorkspaceConfigStarter().start();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
         if (initializeSystemProperties) {
             initializeSystemProperties(args);
         }
@@ -160,7 +172,7 @@ public final class Main {
             initializeLogging();
         }
 
-        final BootstrapOptions bootstrapOptions = new DefaultBootstrapOptions(args);
+
         final Bootstrap bootstrap = new Bootstrap(bootstrapOptions);
         bootstrap.run();
     }

--- a/desktop/ui/src/main/java/org/datacleaner/Main.java
+++ b/desktop/ui/src/main/java/org/datacleaner/Main.java
@@ -157,7 +157,7 @@ public final class Main {
         try {
 
             if (!bootstrapOptions.isCommandLineMode()) {
-                if (!new WorkspaceConfigStarter().start()) {
+                if (!new WorkspaceConfigStarter(bootstrapOptions.getCommandLineArguments()).start()) {
                     return;
                 }
             }

--- a/desktop/ui/src/main/java/org/datacleaner/bootstrap/DCWindowContext.java
+++ b/desktop/ui/src/main/java/org/datacleaner/bootstrap/DCWindowContext.java
@@ -149,7 +149,7 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
         // Ask existing windows if can exit (Asks to save opened work etc.)
         final List<DCWindow> windowsCopy = new ArrayList<>(getWindows());
         for (final DCWindow window : windowsCopy) {
-            if(!window.canClose()) {
+            if (!window.canClose()) {
                 _exiting = false;
                 return;
             }
@@ -161,7 +161,7 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
     @Override
     public void forceExit(int exitCode) {
         // ensure that exit actions only occur once.
-        if(_exiting) {
+        if (_exiting) {
             return;
         }
         _exiting = true;
@@ -188,7 +188,7 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
         for (final DCWindow window : windowsCopy) {
             window.close();
         }
-        if(exitCode != 0) {
+        if (exitCode != 0) {
             // system exit after currently planned events
             SwingUtilities.invokeLater(() -> {
                 System.exit(exitCode);

--- a/desktop/ui/src/main/java/org/datacleaner/bootstrap/DCWindowContext.java
+++ b/desktop/ui/src/main/java/org/datacleaner/bootstrap/DCWindowContext.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 
 import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.user.UsageLogger;
@@ -106,7 +107,7 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
         if (!_exiting) {
             if (getWindows().isEmpty()) {
                 logger.info("All DataCleaner windows closed");
-                exit();
+                forceExit(0);
             }
         }
     }
@@ -138,13 +139,38 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
     }
 
     @Override
-    public void exit() {
+    public void exit(int exitCode) {
         // ensure that exit actions only occur once.
         if (_exiting) {
             return;
         }
         _exiting = true;
 
+        // Ask existing windows if can exit (Asks to save opened work etc.)
+        final List<DCWindow> windowsCopy = new ArrayList<>(getWindows());
+        for (final DCWindow window : windowsCopy) {
+            if(!window.canClose()) {
+                _exiting = false;
+                return;
+            }
+        }
+
+        doForceExit(exitCode);
+    }
+
+    @Override
+    public void forceExit(int exitCode) {
+        // ensure that exit actions only occur once.
+        if(_exiting) {
+            return;
+        }
+        _exiting = true;
+
+        doForceExit(exitCode);
+    }
+
+    private void doForceExit(int exitCode) {
+        _exiting = true;
         if (_userPreferences != null) {
             _userPreferences.save();
         }
@@ -155,12 +181,18 @@ public final class DCWindowContext extends SimpleWindowContext implements Window
             _configuration.getEnvironment().getTaskRunner().shutdown();
         }
         for (final ExitActionListener actionListener : _exitActionListeners) {
-            actionListener.exit(0);
+            actionListener.exit(exitCode);
         }
 
         final List<DCWindow> windowsCopy = new ArrayList<>(getWindows());
         for (final DCWindow window : windowsCopy) {
             window.close();
+        }
+        if(exitCode != 0) {
+            // system exit after currently planned events
+            SwingUtilities.invokeLater(() -> {
+                System.exit(exitCode);
+            });
         }
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/bootstrap/SimpleWindowContext.java
+++ b/desktop/ui/src/main/java/org/datacleaner/bootstrap/SimpleWindowContext.java
@@ -85,6 +85,14 @@ public class SimpleWindowContext implements WindowContext {
 
     @Override
     public void exit() {
+        exit(0);
     }
 
+    @Override
+    public void exit(int exitCode) {
+    }
+
+    @Override
+    public void forceExit(int exitCode) {
+    }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
@@ -69,7 +69,7 @@ public class CliArguments {
     @Option(name = "-v", aliases = { "-var", "--variable" }, multiValued = true)
     private Map<String, String> variableOverrides;
 
-    @Option(name="-ws", aliases = {"--workspace-selection"})
+    @Option(name = "-ws", aliases = { "--workspace-selection" })
     private boolean workspaceSelection;
 
     private boolean usageMode;

--- a/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
+++ b/desktop/ui/src/main/java/org/datacleaner/cli/CliArguments.java
@@ -68,6 +68,10 @@ public class CliArguments {
     private String outputFile;
     @Option(name = "-v", aliases = { "-var", "--variable" }, multiValued = true)
     private Map<String, String> variableOverrides;
+
+    @Option(name="-ws", aliases = {"--workspace-selection"})
+    private boolean workspaceSelection;
+
     private boolean usageMode;
     private boolean versionMode;
 
@@ -202,6 +206,10 @@ public class CliArguments {
             return CliRunType.LOCAL;
         }
         return runType;
+    }
+
+    public boolean isWorkspaceSelection() {
+        return workspaceSelection;
     }
 
     /**

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/GlobalConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/GlobalConfiguration.java
@@ -1,0 +1,19 @@
+package org.datacleaner.tenantloader;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "datacleanerConfiguration")
+public class GlobalConfiguration {
+
+    private WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration();
+
+    public WorkspaceConfiguration getWorkspaceConfiguration() {
+        return workspaceConfiguration;
+    }
+
+    @XmlElement(name = "workspaceConfiguration")
+    public void setWorkspaceConfiguration(WorkspaceConfiguration workspaceConfiguration) {
+        this.workspaceConfiguration = workspaceConfiguration;
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/GlobalConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/GlobalConfiguration.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.tenantloader;
 
 import javax.xml.bind.annotation.XmlElement;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.tenantloader;
 
 import java.awt.event.WindowAdapter;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
@@ -50,17 +50,17 @@ public class WorkspaceConfigStarter {
             DataCleanerHome.reInit();
             return;
         }
-        Object lock = new Object();
+        final Object lock = new Object();
         WidgetUtils.invokeSwingAction(() -> {
-            JFrame frame = new JFrame();
-            WorkspaceConfigDialog workspaceConfigDialog = new WorkspaceConfigDialog(frame, _workspaceManager);
+            final JFrame frame = new JFrame();
+            final WorkspaceConfigDialog workspaceConfigDialog = new WorkspaceConfigDialog(frame, _workspaceManager);
             workspaceConfigDialog.addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowClosed(WindowEvent e) {
                     try {
                         _workspaceManager.save();
-                    } catch (JAXBException e1) {
-                        e1.printStackTrace();
+                    } catch (JAXBException ex2) {
+                        ex2.printStackTrace();
                     }
                     DataCleanerHome.reInit();
                     synchronized (lock) {

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
@@ -1,0 +1,59 @@
+package org.datacleaner.tenantloader;
+
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import javax.swing.JFrame;
+import javax.xml.bind.JAXBException;
+
+import org.datacleaner.user.DataCleanerHome;
+import org.datacleaner.util.WidgetUtils;
+import org.datacleaner.windows.WorkspaceConfigDialog;
+
+/**
+ * Class check of workspace configuration and start Workspace dialog.
+ */
+public class WorkspaceConfigStarter {
+
+    private WorkspaceManager _workspaceManager;
+
+    public WorkspaceConfigStarter() throws JAXBException {
+        _workspaceManager = new WorkspaceManager(DataCleanerHome.getAsDataCleanerHomeFolder());
+    }
+
+    /**
+     * Start workspace dialog or set default workspace.
+     * @throws InterruptedException
+     */
+    public void start() throws InterruptedException {
+        if (!_workspaceManager.showDialog()) {
+            _workspaceManager.setWorkspaceToRun(_workspaceManager.getDefaultWorkspace());
+            DataCleanerHome.reInit();
+            return;
+        }
+        Object lock = new Object();
+        WidgetUtils.invokeSwingAction(() -> {
+            JFrame frame = new JFrame();
+            WorkspaceConfigDialog workspaceConfigDialog = new WorkspaceConfigDialog(frame, _workspaceManager);
+            workspaceConfigDialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosed(WindowEvent e) {
+                    try {
+                        _workspaceManager.save();
+                    } catch (JAXBException e1) {
+                        e1.printStackTrace();
+                    }
+                    DataCleanerHome.reInit();
+                    synchronized (lock) {
+                        lock.notifyAll();
+                    }
+                    frame.dispose();
+                }
+            });
+
+        });
+        synchronized (lock) {
+            lock.wait();
+        }
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
@@ -51,13 +51,13 @@ public class WorkspaceConfigStarter {
         }
         // Show the "workspace chooser" dialog
         final WorkspaceConfigDialog workspaceConfigDialog = new WorkspaceConfigDialog(null, _workspaceManager);
-        if(workspaceConfigDialog.isShouldStart()) {
+        if (workspaceConfigDialog.isShouldStart()) {
             try {
                 _workspaceManager.save();
                 DataCleanerHome.reInit();
                 return true;
-            } catch (JAXBException ex2) {
-                throw new RuntimeException(ex2);
+            } catch (JAXBException e) {
+                throw new RuntimeException(e);
             }
         } else {
             return false;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfigStarter.java
@@ -21,6 +21,7 @@ package org.datacleaner.tenantloader;
 
 import javax.xml.bind.JAXBException;
 
+import org.datacleaner.cli.CliArguments;
 import org.datacleaner.user.DataCleanerHome;
 import org.datacleaner.windows.WorkspaceConfigDialog;
 
@@ -30,9 +31,11 @@ import org.datacleaner.windows.WorkspaceConfigDialog;
 public class WorkspaceConfigStarter {
 
     private WorkspaceManager _workspaceManager;
+    private CliArguments cliArguments;
 
-    public WorkspaceConfigStarter() throws JAXBException {
+    public WorkspaceConfigStarter(CliArguments cliArguments) throws JAXBException {
         _workspaceManager = new WorkspaceManager();
+        this.cliArguments = cliArguments;
     }
 
     /**
@@ -41,7 +44,7 @@ public class WorkspaceConfigStarter {
      */
     public boolean start() throws InterruptedException {
         // If "Don't show again" was chosen in the past
-        if (!_workspaceManager.showDialog()) {
+        if (!_workspaceManager.showDialog() && !cliArguments.isWorkspaceSelection()) {
             _workspaceManager.setWorkspaceToRun(_workspaceManager.getDefaultWorkspace());
             DataCleanerHome.reInit();
             return true;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
@@ -1,0 +1,56 @@
+package org.datacleaner.tenantloader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Datacleaner workspaces - file.
+ */
+@XmlRootElement
+public class WorkspaceConfiguration {
+    List<String> workspaces = new ArrayList<>();
+    String defaultWorkspace;
+    boolean showDialog = true;
+
+    /**
+     * Returns list of home paths
+     * @return
+     */
+    @XmlElementWrapper(name = "workspaces")
+    @XmlElement(name = "workspace")
+    public List<String> getWorkspaces() {
+        return workspaces;
+    }
+
+    /**
+     * Info about start with default.
+     *
+     * @return
+     */
+    public String getDefaultWorkspace() {
+        return defaultWorkspace;
+    }
+
+    /**
+     * Set default start.
+     *
+     * @param defaultWorkspace
+     */
+    @XmlElement
+    public void setDefaultWorkspace(final String defaultWorkspace) {
+        this.defaultWorkspace = defaultWorkspace;
+    }
+
+    public boolean isShowDialog() {
+        return showDialog;
+    }
+
+    @XmlElement
+    public void setShowDialog(final boolean showDialog) {
+        this.showDialog = showDialog;
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.tenantloader;
 
 import java.util.ArrayList;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceConfiguration.java
@@ -29,7 +29,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Datacleaner workspaces - file.
  */
-@XmlRootElement
 public class WorkspaceConfiguration {
     List<String> workspaces = new ArrayList<>();
     String defaultWorkspace;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.tenantloader;
 
 import java.io.File;

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
@@ -39,11 +39,11 @@ import static org.datacleaner.user.DataCleanerHome.HOME_PROPERTY_NAME;
 public class WorkspaceManager {
     private static final String GLOBAL_CONFIG_FILE_NAME = "global_config.xml";
 
-    private WorkspaceConfiguration _workspaceConfiguration;
+    private GlobalConfiguration globalConfig;
     private JAXBContext _jaxbContext;
 
     public WorkspaceManager() throws JAXBException {
-        _jaxbContext = JAXBContext.newInstance(WorkspaceConfiguration.class);
+        _jaxbContext = JAXBContext.newInstance(GlobalConfiguration.class);
         loadConfiguration();
     }
 
@@ -51,21 +51,21 @@ public class WorkspaceManager {
         final File confFile = getConfigurationFile();
         if (!confFile.isFile()) {
             final String defaultHomePath = DataCleanerHome.getAsDataCleanerHomeFolder().toFile().getAbsolutePath();
-            _workspaceConfiguration = new WorkspaceConfiguration();
-            _workspaceConfiguration.getWorkspaces().add(defaultHomePath);
+            globalConfig = new GlobalConfiguration();
+            globalConfig.getWorkspaceConfiguration().getWorkspaces().add(defaultHomePath);
             // in previous version, there were sub-folders with version numbers.
             // Provide them as option to choose from.
             final File homeBase = DataCleanerHome.getDefaultHomeBase();
             if (homeBase.isDirectory()) {
                 for (File subFolder: homeBase.listFiles()) {
                     if (subFolder.getName().matches("[0-9\\.]*")) {
-                        _workspaceConfiguration.getWorkspaces().add(subFolder.getAbsolutePath());
+                        globalConfig.getWorkspaceConfiguration().getWorkspaces().add(subFolder.getAbsolutePath());
                     }
                 }
             }
         } else {
             final Unmarshaller jaxbUnmarshaller = _jaxbContext.createUnmarshaller();
-            _workspaceConfiguration = (WorkspaceConfiguration) jaxbUnmarshaller.unmarshal(confFile);
+            globalConfig = (GlobalConfiguration) jaxbUnmarshaller.unmarshal(confFile);
         }
     }
 
@@ -75,7 +75,7 @@ public class WorkspaceManager {
      * @return
      */
     public String getDefaultWorkspace() {
-        return _workspaceConfiguration.getDefaultWorkspace();
+        return globalConfig.getWorkspaceConfiguration().getDefaultWorkspace();
     }
 
     /**
@@ -84,7 +84,7 @@ public class WorkspaceManager {
      * @param path
      */
     public void setDefaultWorkspace(String path) {
-        _workspaceConfiguration.setDefaultWorkspace(path);
+        globalConfig.getWorkspaceConfiguration().setDefaultWorkspace(path);
         addWorkspacePath(path);
     }
 
@@ -94,7 +94,7 @@ public class WorkspaceManager {
      * @param path
      */
     public void addWorkspacePath(String path) {
-        final List<String> paths = _workspaceConfiguration.getWorkspaces();
+        final List<String> paths = globalConfig.getWorkspaceConfiguration().getWorkspaces();
         if (!paths.contains(path)) {
             paths.add(path);
         }
@@ -106,7 +106,7 @@ public class WorkspaceManager {
      * @return
      */
     public List<String> getWorkspacePaths() {
-        return _workspaceConfiguration.getWorkspaces();
+        return globalConfig.getWorkspaceConfiguration().getWorkspaces();
     }
 
     /**
@@ -115,7 +115,7 @@ public class WorkspaceManager {
      * @param show
      */
     public void setShowDialog(boolean show) {
-        _workspaceConfiguration.setShowDialog(show);
+        globalConfig.getWorkspaceConfiguration().setShowDialog(show);
     }
 
     /**
@@ -124,7 +124,7 @@ public class WorkspaceManager {
      * @return
      */
     public boolean showDialog() {
-        return _workspaceConfiguration.isShowDialog();
+        return globalConfig.getWorkspaceConfiguration().isShowDialog();
     }
 
     /**
@@ -136,10 +136,10 @@ public class WorkspaceManager {
         if (StringUtils.isNullOrEmpty(path)) {
             return;
         }
-        if (path.equals(_workspaceConfiguration.getDefaultWorkspace())) {
-            _workspaceConfiguration.setDefaultWorkspace(null);
+        if (path.equals(globalConfig.getWorkspaceConfiguration().getDefaultWorkspace())) {
+            globalConfig.getWorkspaceConfiguration().setDefaultWorkspace(null);
         }
-        _workspaceConfiguration.getWorkspaces().remove(path);
+        globalConfig.getWorkspaceConfiguration().getWorkspaces().remove(path);
     }
 
     /**
@@ -166,7 +166,7 @@ public class WorkspaceManager {
             configurationFile.delete();
         }
         new FileRepositoryFolder(null, configurationFile.getParentFile()).createFile(GLOBAL_CONFIG_FILE_NAME, out -> {
-            jaxbMarshaller.marshal(_workspaceConfiguration, out);
+            jaxbMarshaller.marshal(globalConfig, out);
         });
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
@@ -50,15 +50,15 @@ public class WorkspaceManager {
     private void loadConfiguration() throws JAXBException {
         final File confFile = getConfigurationFile();
         if (!confFile.isFile()) {
-            String defaultHomePath = DataCleanerHome.getAsDataCleanerHomeFolder().toFile().getAbsolutePath();
+            final String defaultHomePath = DataCleanerHome.getAsDataCleanerHomeFolder().toFile().getAbsolutePath();
             _workspaceConfiguration = new WorkspaceConfiguration();
             _workspaceConfiguration.getWorkspaces().add(defaultHomePath);
             // in previous version, there were sub-folders with version numbers.
             // Provide them as option to choose from.
-            File homeBase = DataCleanerHome.getDefaultHomeBase();
-            if(homeBase.isDirectory()) {
-                for(File subFolder: homeBase.listFiles()) {
-                    if(subFolder.getName().matches("[0-9\\.]*")) {
+            final File homeBase = DataCleanerHome.getDefaultHomeBase();
+            if (homeBase.isDirectory()) {
+                for (File subFolder: homeBase.listFiles()) {
+                    if (subFolder.getName().matches("[0-9\\.]*")) {
                         _workspaceConfiguration.getWorkspaces().add(subFolder.getAbsolutePath());
                     }
                 }

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
@@ -1,0 +1,154 @@
+package org.datacleaner.tenantloader;
+
+import java.io.File;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+import org.datacleaner.configuration.DataCleanerHomeFolder;
+import org.datacleaner.repository.RepositoryFile;
+import org.datacleaner.repository.file.FileRepositoryFile;
+import org.datacleaner.util.StringUtils;
+
+import static org.datacleaner.user.DataCleanerHome.HOME_PROPERTY_NAME;
+
+/**
+ * Manager for work with workspace configuration file
+ */
+public class WorkspaceManager {
+    private static final String TENANT_CONFIGURATION_FILE_NAME = ".datacleaner_workspace";
+
+    private DataCleanerHomeFolder _defaultHomeFolder;
+    private WorkspaceConfiguration _workspaceConfiguration;
+    private JAXBContext _jaxbContext;
+
+    public WorkspaceManager(final DataCleanerHomeFolder defaultHomeFolder) throws JAXBException {
+        _defaultHomeFolder = defaultHomeFolder;
+        _jaxbContext = JAXBContext.newInstance(WorkspaceConfiguration.class);
+        loadConfiguration(defaultHomeFolder.toFile().getAbsolutePath());
+    }
+
+    private void loadConfiguration(String basicHomePath) throws JAXBException {
+        final File confFile = getConfigurationFile();
+        if (confFile == null) {
+            _workspaceConfiguration = new WorkspaceConfiguration();
+            _workspaceConfiguration.getWorkspaces().add(basicHomePath);
+        } else {
+            Unmarshaller jaxbUnmarshaller = _jaxbContext.createUnmarshaller();
+            _workspaceConfiguration = (WorkspaceConfiguration) jaxbUnmarshaller.unmarshal(confFile);
+        }
+    }
+
+    /**
+     * Returns default workspace to start without dialog
+     * 
+     * @return
+     */
+    public String getDefaultWorkspace() {
+        return _workspaceConfiguration.getDefaultWorkspace();
+    }
+
+    /**
+     * Set default workspace to start without dialog
+     *
+     * @param path
+     */
+    public void setDefaultWorkspace(String path) {
+        _workspaceConfiguration.setDefaultWorkspace(path);
+        addWorkspacePath(path);
+    }
+
+    /**
+     * Add workspace path to list
+     *
+     * @param path
+     */
+    public void addWorkspacePath(String path) {
+        final List<String> paths = _workspaceConfiguration.getWorkspaces();
+        if (!paths.contains(path)) {
+            paths.add(path);
+        }
+    }
+
+    /**
+     * Return all workspaces
+     *
+     * @return
+     */
+    public List<String> getWorkspacePaths() {
+        return _workspaceConfiguration.getWorkspaces();
+    }
+
+    /**
+     * Will be show dialog after next start?
+     *
+     * @param show
+     */
+    public void setShowDialog(boolean show) {
+        _workspaceConfiguration.setShowDialog(show);
+    }
+
+    /**
+     * Can be show dialog?
+     *
+     * @return
+     */
+    public boolean showDialog() {
+        return _workspaceConfiguration.isShowDialog();
+    }
+
+    /**
+     * Removes workspace from list
+     * 
+     * @param path
+     */
+    public void removeWorkspace(String path) {
+        if (StringUtils.isNullOrEmpty(path)) {
+            return;
+        }
+        if (path.equals(_workspaceConfiguration.getDefaultWorkspace())) {
+            _workspaceConfiguration.setDefaultWorkspace(null);
+        }
+        _workspaceConfiguration.getWorkspaces().remove(path);
+    }
+
+    /**
+     * Sets env variable to start of Datacleaner
+     * 
+     * @param workspace
+     */
+    public void setWorkspaceToRun(String workspace) {
+        if (!StringUtils.isNullOrEmpty(workspace)) {
+            System.setProperty(HOME_PROPERTY_NAME, workspace);
+        }
+    }
+
+    /**
+     * Save current configuration to file in base workspace
+     *
+     * @throws JAXBException
+     */
+    public void save() throws JAXBException {
+        Marshaller jaxbMarshaller = _jaxbContext.createMarshaller();
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        final File configurationFile = getConfigurationFile();
+        if (configurationFile != null) {
+            configurationFile.delete();
+        }
+        _defaultHomeFolder.toRepositoryFolder().createFile(TENANT_CONFIGURATION_FILE_NAME, out -> {
+            jaxbMarshaller.marshal(_workspaceConfiguration, out);
+        });
+    }
+
+    private File getConfigurationFile() {
+        final RepositoryFile conf = _defaultHomeFolder.toRepositoryFolder().getFile(TENANT_CONFIGURATION_FILE_NAME);
+        if (conf == null || !(conf instanceof FileRepositoryFile)) {
+            return null;
+        } else {
+            return ((FileRepositoryFile) conf).getFile();
+        }
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
+++ b/desktop/ui/src/main/java/org/datacleaner/tenantloader/WorkspaceManager.java
@@ -56,7 +56,7 @@ public class WorkspaceManager {
             _workspaceConfiguration = new WorkspaceConfiguration();
             _workspaceConfiguration.getWorkspaces().add(basicHomePath);
         } else {
-            Unmarshaller jaxbUnmarshaller = _jaxbContext.createUnmarshaller();
+            final Unmarshaller jaxbUnmarshaller = _jaxbContext.createUnmarshaller();
             _workspaceConfiguration = (WorkspaceConfiguration) jaxbUnmarshaller.unmarshal(confFile);
         }
     }
@@ -151,7 +151,7 @@ public class WorkspaceManager {
      * @throws JAXBException
      */
     public void save() throws JAXBException {
-        Marshaller jaxbMarshaller = _jaxbContext.createMarshaller();
+        final Marshaller jaxbMarshaller = _jaxbContext.createMarshaller();
         jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
         final File configurationFile = getConfigurationFile();
         if (configurationFile != null) {

--- a/desktop/ui/src/main/java/org/datacleaner/user/DataCleanerHome.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/DataCleanerHome.java
@@ -294,8 +294,12 @@ public final class DataCleanerHome {
     }
 
     private static String getUserHomeCandidatePath() {
+        return getDefaultHomeBase().getPath();
+    }
+
+    public static File getDefaultHomeBase() {
         final String userHomePath = System.getProperty("user.home");
-        return userHomePath + File.separatorChar + ".datacleaner" + File.separatorChar + Version.getVersion();
+        return new File(userHomePath + File.separatorChar + ".datacleaner");
     }
 
     private static boolean isUsable(final FileObject candidate) throws FileSystemException {

--- a/desktop/ui/src/main/java/org/datacleaner/user/DataCleanerHome.java
+++ b/desktop/ui/src/main/java/org/datacleaner/user/DataCleanerHome.java
@@ -76,7 +76,7 @@ public final class DataCleanerHome {
         reInit();
     }
 
-    public static void reInit(){
+    public static void reInit() {
         logger.info("Initializing {}", HOME_PROPERTY_NAME);
         try {
             _dataCleanerHome = findDataCleanerHome();

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -605,53 +605,17 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow
         if (!super.onWindowClosing()) {
             return false;
         }
-
         switch (_currentPanelType) {
-        case WELCOME:
-            final int count = getWindowContext().getWindowCount(AnalysisJobBuilderWindow.class);
-            if (count == 1) {
-                if (getWindowContext().showExitDialog()) {
-                    cleanupForWindowClose();
-                    getWindowContext().exit();
+            case WELCOME:
+                final int count = getWindowContext().getWindowCount(AnalysisJobBuilderWindow.class);
+                if(canClose() && count == 1) {
+                    getWindowContext().forceExit(0);
+                    return true;
                 }
-            } else {
-                cleanupForWindowClose();
-                return true;
-            }
-            break;
-        case EDITING_CONTEXT:
-            // if datastore is set and datastore selection is enabled,
-            // return to datastore selection.
-
-            if (isJobUnsaved(getJobFile(), _analysisJobBuilder) && (_saveButton.isEnabled())) {
-
-                final Object[] buttons = { "Save changes", "Discard changes", "Cancel" };
-                final int unsavedChangesChoice = JOptionPane
-                        .showOptionDialog(this, "The job has unsaved changes. What would you like to do?",
-                                "Unsaved changes detected", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
-                                null, buttons, buttons[1]);
-
-                if (unsavedChangesChoice == 0) { // save changes
-                    _saveButton.doClick();
-                    final ActionListener[] actionListeners = _saveButton.getActionListeners();
-                    if (actionListeners[0] instanceof SaveAnalysisJobActionListener) {
-                        final SaveAnalysisJobActionListener saveAnalysisJobActionListener =
-                                (SaveAnalysisJobActionListener) actionListeners[0];
-                        if (!saveAnalysisJobActionListener.isSaved()) {
-                            return false;
-                        }
-                    }
-                } else if (unsavedChangesChoice != 1) { // cancel closing
-                    return false;
-                }
-            }
-
-            resetJob();
-            break;
-        default:
-            changePanel(AnalysisWindowPanelType.WELCOME);
+                break;
+            default:
+                canClose();
         }
-
         return false;
     }
 
@@ -1017,5 +981,53 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow
     @Override
     public DCModule getDCModule() {
         return _dcModule;
+    }
+
+    @Override
+    public boolean canClose() {
+        switch (_currentPanelType) {
+            case WELCOME:
+                final int count = getWindowContext().getWindowCount(AnalysisJobBuilderWindow.class);
+                if (count == 1) {
+                    if (!getWindowContext().showExitDialog()) {
+                        return false;
+                    }
+                }
+                cleanupForWindowClose();
+                return true;
+            case EDITING_CONTEXT:
+                // if datastore is set and datastore selection is enabled,
+                // return to datastore selection.
+
+                if (isJobUnsaved(getJobFile(), _analysisJobBuilder) && (_saveButton.isEnabled())) {
+
+                    final Object[] buttons = { "Save changes", "Discard changes", "Cancel" };
+                    final int unsavedChangesChoice = JOptionPane
+                            .showOptionDialog(this, "The job has unsaved changes. What would you like to do?",
+                                    "Unsaved changes detected", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
+                                    null, buttons, buttons[1]);
+
+                    if (unsavedChangesChoice == 0) { // save changes
+                        _saveButton.doClick();
+                        final ActionListener[] actionListeners = _saveButton.getActionListeners();
+                        if (actionListeners[0] instanceof SaveAnalysisJobActionListener) {
+                            final SaveAnalysisJobActionListener saveAnalysisJobActionListener =
+                                    (SaveAnalysisJobActionListener) actionListeners[0];
+                            if (!saveAnalysisJobActionListener.isSaved()) {
+                                return false;
+                            }
+                        }
+                    } else if (unsavedChangesChoice != 1) { // cancel closing
+                        return false;
+                    }
+                }
+
+                resetJob();
+                break;
+            default:
+                changePanel(AnalysisWindowPanelType.WELCOME);
+        }
+
+        return true;
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/AnalysisJobBuilderWindowImpl.java
@@ -608,7 +608,7 @@ public final class AnalysisJobBuilderWindowImpl extends AbstractWindow
         switch (_currentPanelType) {
             case WELCOME:
                 final int count = getWindowContext().getWindowCount(AnalysisJobBuilderWindow.class);
-                if(canClose() && count == 1) {
+                if (canClose() && count == 1) {
                     getWindowContext().forceExit(0);
                     return true;
                 }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
@@ -127,14 +127,16 @@ public class OptionsDialog extends AbstractWindow {
         saveDatastoreDirectoryField.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         saveDatastoreDirectoryField.addFileSelectionListener(
                 (filenameTextField, file) -> _userPreferences.setSaveDatastoreDirectory(file));
-        JButton changeWorkspaceBut = WidgetFactory.createDefaultButton("Restart and change workspace", IconUtils.ACTION_RESET);
-        changeWorkspaceBut.addActionListener((e)->{
+        final JButton changeWorkspaceBut = WidgetFactory.createDefaultButton(
+                "Restart and change workspace",
+                IconUtils.ACTION_RESET);
+        changeWorkspaceBut.addActionListener((e) -> {
             getWindowContext().exit(3);
         });
 
         final DCPanel directoriesPanel = new DCPanel().setTitledBorder("Files & directories");
-        DCPanel p1 = new DCPanel();
-        DCPanel p2 = new DCPanel();
+        final DCPanel p1 = new DCPanel();
+        final DCPanel p2 = new DCPanel();
         p1.setLayout(new VerticalLayout(4));
         p2.add(DCLabel.dark("Written datastores:"));
         p2.add(saveDatastoreDirectoryField);

--- a/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/OptionsDialog.java
@@ -127,10 +127,20 @@ public class OptionsDialog extends AbstractWindow {
         saveDatastoreDirectoryField.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         saveDatastoreDirectoryField.addFileSelectionListener(
                 (filenameTextField, file) -> _userPreferences.setSaveDatastoreDirectory(file));
+        JButton changeWorkspaceBut = WidgetFactory.createDefaultButton("Restart and change workspace", IconUtils.ACTION_RESET);
+        changeWorkspaceBut.addActionListener((e)->{
+            getWindowContext().exit(3);
+        });
 
         final DCPanel directoriesPanel = new DCPanel().setTitledBorder("Files & directories");
-        directoriesPanel.add(DCLabel.dark("Written datastores:"));
-        directoriesPanel.add(saveDatastoreDirectoryField);
+        DCPanel p1 = new DCPanel();
+        DCPanel p2 = new DCPanel();
+        p1.setLayout(new VerticalLayout(4));
+        p2.add(DCLabel.dark("Written datastores:"));
+        p2.add(saveDatastoreDirectoryField);
+        p1.add(p2);
+        p1.add(changeWorkspaceBut);
+        directoriesPanel.add(p1);
 
         final DCPanel panel = new DCPanel(WidgetUtils.COLOR_DEFAULT_BACKGROUND);
         panel.setLayout(new VerticalLayout(4));

--- a/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
@@ -1,0 +1,134 @@
+package org.datacleaner.windows;
+
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.util.List;
+import java.util.Vector;
+
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
+import javax.swing.WindowConstants;
+
+import org.datacleaner.tenantloader.WorkspaceManager;
+import org.datacleaner.util.WidgetFactory;
+
+/**
+ * Workspace dialog. User can select workspace for start of DataCleaner
+ */
+public class WorkspaceConfigDialog extends JDialog {
+
+    private static final long serialVersionUID = 1L;
+    private final WorkspaceManager _workspaceManager;
+
+    private JList<String> _workspaceList;
+    private JButton _buttonRemove;
+    private JButton _buttonSelectFolder;
+    private JButton _buttonStart;
+    private JCheckBox _checkBoxDontShowIt;
+
+    public WorkspaceConfigDialog(JFrame owner, final WorkspaceManager workspaceManager) {
+        super(owner);
+        _workspaceManager = workspaceManager;
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        setLocationRelativeTo(null);
+
+        createLayout();
+        loadData();
+        pack();
+        setVisible(true);
+    }
+
+    private void createLayout() {
+        createButtons();
+        setLayout(new FlowLayout());
+        add(new JScrollPane(createList()));
+        add(_buttonSelectFolder);
+        add(_buttonRemove);
+        add(_buttonStart);
+        _checkBoxDontShowIt = new JCheckBox("Don't show it again.");
+        add(_checkBoxDontShowIt);
+
+    }
+
+    private void loadData() {
+        final List<String> workspacePaths = _workspaceManager.getWorkspacePaths();
+        final Vector<String> vector = new Vector<>();
+        vector.addAll(workspacePaths);
+        _workspaceList.setListData(vector);
+        if (workspacePaths.isEmpty()) {
+            _buttonRemove.setEnabled(false);
+            _buttonStart.setEnabled(false);
+        } else {
+            _buttonRemove.setEnabled(true);
+            _buttonStart.setEnabled(true);
+            _workspaceList.setSelectedIndex(0);
+        }
+        _workspaceList.repaint();
+    }
+
+    private JList<String> createList() {
+        _workspaceList = new JList<>();
+        _workspaceList.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
+        _workspaceList.setFixedCellHeight(80);
+        _workspaceList.setFixedCellWidth(500);
+        _workspaceList.setVisibleRowCount(10);
+        return _workspaceList;
+    }
+
+    private void createButtons() {
+        _buttonRemove = WidgetFactory.createDefaultButton("remove");
+        _buttonRemove.addActionListener(new AbstractAction() {
+            @Override
+            public void actionPerformed(final ActionEvent e) {
+                final String selectedValue = _workspaceList.getSelectedValue();
+                _workspaceManager.removeWorkspace(selectedValue);
+                loadData();
+            }
+        });
+
+        _buttonSelectFolder = WidgetFactory.createDefaultButton("Select new workspace");
+        _buttonSelectFolder.addActionListener(new FileChooserAction("Workspace selector", this));
+
+        _buttonStart = WidgetFactory.createDefaultButton("Start");
+        _buttonStart.addActionListener(new AbstractAction() {
+            @Override
+            public void actionPerformed(final ActionEvent e) {
+                final String selectedValue = _workspaceList.getSelectedValue();
+                _workspaceManager.setWorkspaceToRun(selectedValue);
+                if (_checkBoxDontShowIt.isSelected()) {
+                    _workspaceManager.setDefaultWorkspace(selectedValue);
+                    _workspaceManager.setShowDialog(false);
+                }
+                dispose();
+            }
+        });
+    }
+
+    private static class FileChooserAction extends AbstractAction {
+        private final WorkspaceConfigDialog _parent;
+
+        public FileChooserAction(final String name, final WorkspaceConfigDialog parent) {
+            super(name);
+            _parent = parent;
+        }
+
+        @Override
+        public void actionPerformed(final ActionEvent e) {
+            JFileChooser jFileChooser = new JFileChooser();
+            jFileChooser.setCurrentDirectory(new java.io.File("."));
+            jFileChooser.setDialogTitle("Select workspace");
+            jFileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+            if (jFileChooser.showOpenDialog(_parent) == JFileChooser.APPROVE_OPTION) {
+                _parent._workspaceManager.addWorkspacePath(jFileChooser.getSelectedFile().getAbsolutePath());
+                _parent.loadData();
+            }
+        }
+    }
+}

--- a/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
@@ -119,9 +119,7 @@ public class WorkspaceConfigDialog extends JDialog {
         final String selectedValue = workspaceList.getSelectedValue();
         _workspaceManager.setWorkspaceToRun(selectedValue);
         _workspaceManager.setDefaultWorkspace(selectedValue);
-        if (checkBoxDontShowIt.isSelected()) {
-            _workspaceManager.setShowDialog(false);
-        }
+        _workspaceManager.setShowDialog(!checkBoxDontShowIt.isSelected());
         shouldStart = true;
         dispose();
     }
@@ -137,6 +135,7 @@ public class WorkspaceConfigDialog extends JDialog {
         label = new JXLabel("Previously selected workspaces");
 
         checkBoxDontShowIt.setFont(WidgetUtils.FONT_NORMAL);
+        checkBoxDontShowIt.setOpaque(false);
         label.setFont(WidgetUtils.FONT_NORMAL);
         workspaceList.setFont(WidgetUtils.FONT_NORMAL);
         buttonStart.setFont(WidgetUtils.FONT_BUTTON);
@@ -199,10 +198,12 @@ public class WorkspaceConfigDialog extends JDialog {
             String valueToSelect = _workspaceManager.getDefaultWorkspace();
             if(StringUtils.isNotBlank(valueToSelect)) {
                 workspaceList.setSelectedValue(valueToSelect, true);
-            } else {
+            }
+            if(workspaceList.getSelectedIndex() < 0) {
                 workspaceList.setSelectedIndex(0);
             }
         }
+        checkBoxDontShowIt.setSelected(!_workspaceManager.showDialog());
     }
 
     public boolean isShouldStart() {

--- a/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
@@ -1,3 +1,22 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Neopost - Customer Information Management
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.datacleaner.windows;
 
 import java.awt.FlowLayout;

--- a/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
@@ -86,7 +86,7 @@ public class WorkspaceConfigDialog extends JDialog {
         workspaceList.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                if(e.getClickCount() >= 2) {
+                if (e.getClickCount() >= 2) {
                     start();
                 }
             }
@@ -142,21 +142,21 @@ public class WorkspaceConfigDialog extends JDialog {
     }
 
     private void createLayout() {
-        JComponent panel = new JPanel();
+        final JComponent panel = new JPanel();
         getRootPane().setLayout(new BorderLayout());
         getRootPane().add(panel);
-        GroupLayout l = new GroupLayout(panel);
-        panel.setLayout(l);
+        final GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
         panel.setBackground(Color.WHITE);
         panel.setOpaque(true);
         panel.setBorder(new EmptyBorder(10, 10, 10, 10));
-        JScrollPane workspaceScroll = new JScrollPane(workspaceList);
-        l.setHorizontalGroup(l.createParallelGroup()
+        final JScrollPane workspaceScroll = new JScrollPane(workspaceList);
+        layout.setHorizontalGroup(layout.createParallelGroup()
                 .addComponent(label)
-                .addGroup(l.createSequentialGroup()
+                .addGroup(layout.createSequentialGroup()
                         .addComponent(workspaceScroll, GroupLayout.DEFAULT_SIZE, 450, GroupLayout.DEFAULT_SIZE)
                         .addGap(4)
-                        .addGroup(l.createParallelGroup()
+                        .addGroup(layout.createParallelGroup()
                                 .addComponent(buttonSelectFolder)
                                 .addComponent(buttonRemove)
                         )
@@ -165,12 +165,12 @@ public class WorkspaceConfigDialog extends JDialog {
                 .addComponent(buttonStart, GroupLayout.Alignment.CENTER)
 
         );
-        l.setVerticalGroup(l.createSequentialGroup()
+        layout.setVerticalGroup(layout.createSequentialGroup()
                 .addComponent(label)
                 .addGap(4)
-                .addGroup(l.createParallelGroup()
+                .addGroup(layout.createParallelGroup()
                         .addComponent(workspaceScroll)
-                        .addGroup(l.createSequentialGroup()
+                        .addGroup(layout.createSequentialGroup()
                                 .addComponent(buttonSelectFolder)
                                 .addGap(3)
                                 .addComponent(buttonRemove)
@@ -195,11 +195,11 @@ public class WorkspaceConfigDialog extends JDialog {
         } else {
             buttonRemove.setEnabled(true);
             buttonStart.setEnabled(true);
-            String valueToSelect = _workspaceManager.getDefaultWorkspace();
-            if(StringUtils.isNotBlank(valueToSelect)) {
-                workspaceList.setSelectedValue(valueToSelect, true);
+            final String selectedWorkspace = _workspaceManager.getDefaultWorkspace();
+            if (StringUtils.isNotBlank(selectedWorkspace)) {
+                workspaceList.setSelectedValue(selectedWorkspace, true);
             }
-            if(workspaceList.getSelectedIndex() < 0) {
+            if (workspaceList.getSelectedIndex() < 0) {
                 workspaceList.setSelectedIndex(0);
             }
         }

--- a/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/windows/WorkspaceConfigDialog.java
@@ -140,12 +140,12 @@ public class WorkspaceConfigDialog extends JDialog {
 
         @Override
         public void actionPerformed(final ActionEvent e) {
-            JFileChooser jFileChooser = new JFileChooser();
-            jFileChooser.setCurrentDirectory(new java.io.File("."));
-            jFileChooser.setDialogTitle("Select workspace");
-            jFileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-            if (jFileChooser.showOpenDialog(_parent) == JFileChooser.APPROVE_OPTION) {
-                _parent._workspaceManager.addWorkspacePath(jFileChooser.getSelectedFile().getAbsolutePath());
+            final JFileChooser fileChooser = new JFileChooser();
+            fileChooser.setCurrentDirectory(new java.io.File("."));
+            fileChooser.setDialogTitle("Select workspace");
+            fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+            if (fileChooser.showOpenDialog(_parent) == JFileChooser.APPROVE_OPTION) {
+                _parent._workspaceManager.addWorkspacePath(fileChooser.getSelectedFile().getAbsolutePath());
                 _parent.loadData();
             }
         }


### PR DESCRIPTION
When started, DataCleaner desktop asks for workspace. By default it offers $HOME/.datacleaner.
And if there are some sub-folders matching pattern "[0-9\.]*" - it means workspace locations from previous versions, they are offered too.
![screenshot from 2017-07-11 11-51-35](https://user-images.githubusercontent.com/1188613/28062800-54b459ba-662f-11e7-9413-6142ed5ae5a2.png)

The configuration of this dialog is in $HOME/.datacleaner/global_config.xml:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<datacleanerConfiguration>
    <workspaceConfiguration>
        <defaultWorkspace>/home/jakub/.datacleaner</defaultWorkspace>
        <showDialog>true</showDialog>
        <workspaces>
            <workspace>/home/jakub/.datacleaner</workspace>
        </workspaces>
    </workspaceConfiguration>
</datacleanerConfiguration>
```
If the option "Don't show again" is checked, the dialog will be not shown on next application start. However, the user can force it from Options dialog:

![screenshot from 2017-07-11 11-53-43](https://user-images.githubusercontent.com/1188613/28062961-e915b2ca-662f-11e7-8e18-e4c67be52530.png)

Clicking the button exits the application with exit code 3 and the startup script will be responsible to restart with the new option:

There is a new commandline option `-ws` which will enforce showing the workspace chooser dialog.
