### PR TITLE
#1748: Skipping cobertura (and other unnecesary stuff) on -DskipTests

### DIFF
--- a/engine/xml-config/pom.xml
+++ b/engine/xml-config/pom.xml
@@ -12,6 +12,7 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<configuration>
+					<skip>${skipTests}</skip>
 					<instrumentation>
 						<excludes>
 							<exclude>org/datacleaner/**/jaxb/**/*.class</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,7 @@
 							<goal>checkstyle</goal>
 						</goals>
 						<configuration>
+							<skip>${skipTests}</skip>
 							<configLocation>checkstyle.xml</configLocation>
 							<suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
 							<consoleOutput>true</consoleOutput>


### PR DESCRIPTION
Fixes #1748 

Seems that cobertura was the culprit here. And in addition to cobertura I felt that we should probably skip checkstyle when `-DskipTests` is set so that it really becomes more of a compile-only style build.