### PR TITLE
1756 Links to the prof edition were updated.

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/actions/OpenAnalysisJobActionListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/actions/OpenAnalysisJobActionListener.java
@@ -196,8 +196,10 @@ public class OpenAnalysisJobActionListener implements ActionListener {
             final String message;
             if (Version.EDITION_COMMUNITY.equals(Version.getEdition())) {
                 message = "<html><p>Failed to open job because of a missing component:</p><pre>" + e.getMessage()
-                        + "</pre>"
-                        + "<p>This may happen if the job requires a <a href=\"https://datacleaner.org/editions\">Commercial Edition of DataCleaner</a>, or an extension that you do not have installed.</p></html>";
+                        + "</pre><p>This may happen if the job requires a "
+                        + "<a href=\"https://www.quadient.com/products/quadient-datacleaner#get-started-today\">"
+                        + "Commercial Edition of DataCleaner</a>, or an extension that you do not have installed.</p>"
+                        + "</html>";
             } else {
                 message = "<html>Failed to open job because of a missing component: " + e.getMessage() + "<br/><br/>"
                         + "This may happen if the job requires an extension that you do not have installed.</html>";

--- a/desktop/ui/src/main/java/org/datacleaner/panels/CommunityEditionInformationPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/CommunityEditionInformationPanel.java
@@ -64,13 +64,9 @@ public class CommunityEditionInformationPanel extends JPanel {
 
         final JButton tryProfessionalButton =
                 WidgetFactory.createDefaultButton("Try professional edition", IconUtils.APPLICATION_ICON);
-        tryProfessionalButton.addActionListener(new OpenBrowserAction("https://datacleaner.org/get_datacleaner"));
+        tryProfessionalButton.addActionListener(
+                new OpenBrowserAction("https://www.quadient.com/products/quadient-datacleaner#get-started-today"));
         add(DCPanel.around(tryProfessionalButton));
-
-        final JButton compareEditionsButton =
-                WidgetFactory.createDefaultButton("Compare the editions", IconUtils.WEBSITE);
-        compareEditionsButton.addActionListener(new OpenBrowserAction("https://datacleaner.org/editions"));
-        add(DCPanel.around(compareEditionsButton));
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
@@ -141,12 +141,8 @@ public class WelcomePanel extends DCSplashPanel {
 
                 final JButton tryProfessionalButton =
                         WidgetFactory.createDefaultButton("Try professional edition", IconUtils.APPLICATION_ICON);
-                tryProfessionalButton
-                        .addActionListener(new OpenBrowserAction("https://datacleaner.org/get_datacleaner"));
-
-                final JButton readMoreButton =
-                        WidgetFactory.createDefaultButton("Compare the editions", IconUtils.WEBSITE);
-                readMoreButton.addActionListener(new OpenBrowserAction("https://datacleaner.org/editions"));
+                tryProfessionalButton.addActionListener(new OpenBrowserAction(
+                        "https://www.quadient.com/products/quadient-datacleaner#get-started-today"));
 
                 final JButton discussionForumButton =
                         WidgetFactory.createDefaultButton("Visit the discussion forum", "images/menu/forum.png");
@@ -182,7 +178,7 @@ public class WelcomePanel extends DCSplashPanel {
                 innerPanel.setBorder(
                         new CompoundBorder(WidgetUtils.BORDER_LIST_ITEM_LEFT_ONLY, new EmptyBorder(0, 20, 0, 0)));
                 innerPanel.add(editorPane);
-                innerPanel.add(DCPanel.flow(tryProfessionalButton, readMoreButton));
+                innerPanel.add(DCPanel.flow(tryProfessionalButton));
                 innerPanel.add(Box.createVerticalStrut(80));
                 innerPanel.add(loveFeedbackAnimation);
                 innerPanel.add(Box.createVerticalStrut(20));


### PR DESCRIPTION
Resolves #1756. 

"Compare the editions" button has been removed, "Try professional edition" now leads to https://www.quadient.com/products/quadient-datacleaner#get-started-today. 

Before:

![community-panel](https://user-images.githubusercontent.com/13213915/31337107-198411b6-acfa-11e7-94a3-068e4fd13e36.png)

Now:

![oss](https://user-images.githubusercontent.com/13213915/31337098-13ede254-acfa-11e7-9b5f-b5bfcb52ff16.png)
