### PR TITLE
Issue #1768: Don't upload shaded jars to Central repo during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.0.0</version>
+					<configuration>
+						<attach>false</attach>
+					</configuration>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
I believe this fixes #1768. Although testing it will have to wait for the next release I guess :)