### PR TITLE
Tweaked High DPI rendering of editable tables and syntax textarea

### DIFF
--- a/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
+++ b/desktop/api/src/main/java/org/datacleaner/widgets/table/DCTable.java
@@ -40,6 +40,7 @@ import javax.swing.table.TableModel;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.ImageManager;
 import org.datacleaner.util.LabelUtils;
+import org.datacleaner.util.WidgetScreenResolutionAdjuster;
 import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.widgets.Alignment;
 import org.slf4j.Logger;
@@ -51,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DCTable extends DCBaseTable implements MouseListener {
 
-    public static final int EDITABLE_TABLE_ROW_HEIGHT = 30;
+    public static final int EDITABLE_TABLE_ROW_HEIGHT = WidgetScreenResolutionAdjuster.get().adjust(30);
     private static final Logger logger = LoggerFactory.getLogger(DCTable.class);
     private static final long serialVersionUID = -5376226138423224572L;
     private final transient DCTableCellRenderer _tableCellRenderer;

--- a/desktop/api/src/main/java/org/datacleaner/windows/QueryWindow.java
+++ b/desktop/api/src/main/java/org/datacleaner/windows/QueryWindow.java
@@ -74,6 +74,7 @@ public class QueryWindow extends AbstractWindow {
         super(windowContext);
         _datastore = datastore;
         _queryTextArea = new RSyntaxTextArea(5, 17);
+        _queryTextArea.setFont(WidgetUtils.FONT_MONOSPACE);
         _queryTextArea.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_SQL);
         _queryTextArea.setText(query);
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleStringPropertyWidget.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/properties/SingleStringPropertyWidget.java
@@ -35,6 +35,7 @@ import org.datacleaner.descriptors.ConfiguredPropertyDescriptor;
 import org.datacleaner.job.builder.ComponentBuilder;
 import org.datacleaner.util.DCDocumentListener;
 import org.datacleaner.util.WidgetFactory;
+import org.datacleaner.util.WidgetUtils;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 
@@ -82,6 +83,7 @@ public class SingleStringPropertyWidget extends AbstractPropertyWidget<String> {
         if (multiline) {
             if (mimeType != null) {
                 final RSyntaxTextArea syntaxArea = new RSyntaxTextArea(8, 17);
+                syntaxArea.setFont(WidgetUtils.FONT_MONOSPACE);
                 syntaxArea.setTabSize(2);
                 syntaxArea.setSyntaxEditingStyle(mimeType);
                 textComponent = syntaxArea;


### PR DESCRIPTION
Some minor, but pretty visible tweaks, to the high DPI support:

* The syntax text area's fonts (used in Query windows and e.g. JavaScript or Groovy code editors)
* The editable table's row height. Visible in e.g. transformers' "output columns" table.