### PR TITLE
Reroute link to CE website's discussion forum

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
@@ -148,7 +148,7 @@ public class WelcomePanel extends DCSplashPanel {
                         WidgetFactory.createDefaultButton("Visit the discussion forum", "images/menu/forum.png");
                 discussionForumButton
                         .setToolTipText("Visit the online discussion forum for questions and answers in the community");
-                final OpenBrowserAction forumActionListener = new OpenBrowserAction("https://datacleaner.org/forum");
+                final OpenBrowserAction forumActionListener = new OpenBrowserAction("https://datacleaner.github.io/discuss");
                 discussionForumButton.addActionListener(forumActionListener);
 
                 final JButton twitterButton = WidgetFactory.createDefaultButton(null, "images/menu/twitter.png");


### PR DESCRIPTION
Since datacleaner.org's discussion forum is no longer being exposed in menus or anything like that, I've set up the CE website to host specifically labeled issues as discussion topics. This PR will change the button to route people to the new destination where we can hopefully foster a more sustainable community experience.