### PR TITLE
Fixes #1755

### DIFF
--- a/desktop/ui/src/assembly/bin/datacleaner.sh
+++ b/desktop/ui/src/assembly/bin/datacleaner.sh
@@ -21,4 +21,4 @@ if $macos; then
 fi
 echo "Using DATACLEANER_JAVA_OPTS: $DATACLEANER_JAVA_OPTS"
 
-exec java $DATACLEANER_JAVA_OPTS -jar $DATACLEANER_LIB_HOME/DataCleaner.jar
+exec java $DATACLEANER_JAVA_OPTS -jar $DATACLEANER_LIB_HOME/DataCleaner.jar $@

--- a/desktop/ui/src/assembly/bin/datacleaner.sh
+++ b/desktop/ui/src/assembly/bin/datacleaner.sh
@@ -21,4 +21,4 @@ if $macos; then
 fi
 echo "Using DATACLEANER_JAVA_OPTS: $DATACLEANER_JAVA_OPTS"
 
-exec java $DATACLEANER_JAVA_OPTS -jar $DATACLEANER_LIB_HOME/DataCleaner.jar $@
+exec java $DATACLEANER_JAVA_OPTS -jar $DATACLEANER_LIB_HOME/DataCleaner.jar "$@"


### PR DESCRIPTION
Fixes #1755.

Here's a test case console dump:

```
$ ./datacleaner.sh -ds orderdb -t customers -list columns
Using DATACLEANER_HOME: /c/Users/kasper/git/datacleaner/desktop/ui/target/DataCleaner
Using DATACLEANER_LIB_HOME: /c/Users/kasper/git/datacleaner/desktop/ui/target/DataCleaner
Using DATACLEANER_JAVA_OPTS:  -Xmx1024m
INFO  20:02:21 DataCleanerHome - Initializing DATACLEANER_HOME
INFO  20:02:22 DataCleanerHome - Resolved env. variable DATACLEANER_HOME: C:/Users/kasper/git/datacleaner/desktop/ui/target/DataCleaner
Using default log configuration: jar:file:/C:/Users/kasper/git/DataCleaner/desktop/ui/target/DataCleaner/DataCleaner.jar!/org/datacleaner/log4j-default.xml
Failed to load DataCleaner version from manifest: null
Failed to load DataCleaner version from manifest: null
Columns:
--------
CUSTOMERNUMBER
CUSTOMERNAME
CONTACTLASTNAME
...
```