### PR TITLE
Fix ConcurrentModificationException when closing job with output data stream

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
@@ -1045,7 +1045,8 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
 
         if (jobBuilder != null) {
             // notify job builder of removed source columns
-            for (final Column column : existingTable.getColumns()) {
+            final List<Column> currentColumns = new ArrayList<>(existingTable.getColumns());
+			for (final Column column : currentColumns) {
                 jobBuilder.removeSourceColumn(column);
             }
             // notify the job builder of added source columns

--- a/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
+++ b/engine/core/src/main/java/org/datacleaner/job/builder/AbstractComponentBuilder.java
@@ -1046,7 +1046,7 @@ public abstract class AbstractComponentBuilder<D extends ComponentDescriptor<E>,
         if (jobBuilder != null) {
             // notify job builder of removed source columns
             final List<Column> currentColumns = new ArrayList<>(existingTable.getColumns());
-			for (final Column column : currentColumns) {
+            for (final Column column : currentColumns) {
                 jobBuilder.removeSourceColumn(column);
             }
             // notify the job builder of added source columns


### PR DESCRIPTION
Fixes #1777

MutableTable#getColumns returns an unmodifiableList. Therefore wrap it in a local ArrayList, so we can remove columns.
  