### PR TITLE
Issue #1786: Improved file textfield's resizing capabilities

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/AbstractResourceTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/AbstractResourceTextField.java
@@ -19,10 +19,11 @@
  */
 package org.datacleaner.widgets;
 
-import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
@@ -52,9 +53,10 @@ public abstract class AbstractResourceTextField<R extends Resource> extends DCPa
     protected int _fileSelectionMode = JFileChooser.FILES_ONLY;
 
     public AbstractResourceTextField() {
-        setLayout(new GridBagLayout());
-        WidgetUtils.addToGridBag(_textField, this, 0, 0, 0.75d, 1d);
-        WidgetUtils.addToGridBag(_browseButton, this, 1, 0, 0.25d, 1d);
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        add(_textField);
+        add(Box.createHorizontalStrut(WidgetUtils.DEFAULT_PADDING));
+        add(_browseButton);
 
         _textField.getDocument().addDocumentListener(new DCDocumentListener() {
             @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/AbstractResourceTextField.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/AbstractResourceTextField.java
@@ -19,11 +19,10 @@
  */
 package org.datacleaner.widgets;
 
-import java.awt.FlowLayout;
+import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
@@ -35,6 +34,7 @@ import org.datacleaner.panels.DCPanel;
 import org.datacleaner.util.DCDocumentListener;
 import org.datacleaner.util.IconUtils;
 import org.datacleaner.util.WidgetFactory;
+import org.datacleaner.util.WidgetUtils;
 import org.jdesktop.swingx.JXTextField;
 
 
@@ -52,10 +52,9 @@ public abstract class AbstractResourceTextField<R extends Resource> extends DCPa
     protected int _fileSelectionMode = JFileChooser.FILES_ONLY;
 
     public AbstractResourceTextField() {
-        setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        add(_textField);
-        add(Box.createHorizontalStrut(4));
-        add(_browseButton);
+        setLayout(new GridBagLayout());
+        WidgetUtils.addToGridBag(_textField, this, 0, 0, 0.75d, 1d);
+        WidgetUtils.addToGridBag(_browseButton, this, 1, 0, 0.25d, 1d);
 
         _textField.getDocument().addDocumentListener(new DCDocumentListener() {
             @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
@@ -19,13 +19,14 @@
  */
 package org.datacleaner.widgets;
 
-import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.filechooser.FileFilter;
 
@@ -40,8 +41,7 @@ import org.datacleaner.util.convert.ResourceConverter.ResourceStructure;
 import org.datacleaner.util.convert.ResourceConverter.ResourceTypeHandler;
 
 /**
- * A widget which allows the user to select/enter a {@link Resource} to use for
- * some file-like operation.
+ * A widget which allows the user to select/enter a {@link Resource} to use for some file-like operation.
  */
 public class ResourceSelector extends DCPanel implements ResourceTypePresenter<Resource> {
     private static final long serialVersionUID = 1L;
@@ -82,10 +82,11 @@ public class ResourceSelector extends DCPanel implements ResourceTypePresenter<R
 
         setScheme("file");
 
-        setLayout(new GridBagLayout());
-        WidgetUtils.addToGridBag(_resourceTypeComboBox, this, 0, 0, 0.2d, 1d);
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        add(_resourceTypeComboBox);
+        add(Box.createHorizontalStrut(WidgetUtils.DEFAULT_PADDING));
         for (final ResourceTypePresenter<?> presenter : getResourceTypePresenters()) {
-            WidgetUtils.addToGridBag(presenter.getWidget(), this, 1, 0, 0.8d, 1d);
+            add(presenter.getWidget());
         }
     }
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
@@ -19,14 +19,13 @@
  */
 package org.datacleaner.widgets;
 
-import java.awt.FlowLayout;
+import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.filechooser.FileFilter;
 
@@ -35,6 +34,7 @@ import org.datacleaner.configuration.DataCleanerConfiguration;
 import org.datacleaner.configuration.ServerInformationCatalog;
 import org.datacleaner.panels.DCPanel;
 import org.datacleaner.user.UserPreferences;
+import org.datacleaner.util.WidgetUtils;
 import org.datacleaner.util.convert.ResourceConverter;
 import org.datacleaner.util.convert.ResourceConverter.ResourceStructure;
 import org.datacleaner.util.convert.ResourceConverter.ResourceTypeHandler;
@@ -82,12 +82,11 @@ public class ResourceSelector extends DCPanel implements ResourceTypePresenter<R
 
         setScheme("file");
 
-        setLayout(new FlowLayout(Alignment.LEFT.getFlowLayoutAlignment(), 0, 0));
-        add(_resourceTypeComboBox);
-        add(Box.createHorizontalStrut(4));
-        for (final ResourceTypePresenter<?> presenter : getResourceTypePresenters()) {
-            add(presenter.getWidget());
-        }
+		setLayout(new GridBagLayout());
+		WidgetUtils.addToGridBag(_resourceTypeComboBox, this, 0, 0, 0.2d, 1d);
+		for (final ResourceTypePresenter<?> presenter : getResourceTypePresenters()) {
+			WidgetUtils.addToGridBag(presenter.getWidget(), this, 1, 0, 0.8d, 1d);
+		}
     }
 
     protected ResourceTypePresenter<?> createResourceTypePresenter(final String scheme,

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/ResourceSelector.java
@@ -82,11 +82,11 @@ public class ResourceSelector extends DCPanel implements ResourceTypePresenter<R
 
         setScheme("file");
 
-		setLayout(new GridBagLayout());
-		WidgetUtils.addToGridBag(_resourceTypeComboBox, this, 0, 0, 0.2d, 1d);
-		for (final ResourceTypePresenter<?> presenter : getResourceTypePresenters()) {
-			WidgetUtils.addToGridBag(presenter.getWidget(), this, 1, 0, 0.8d, 1d);
-		}
+        setLayout(new GridBagLayout());
+        WidgetUtils.addToGridBag(_resourceTypeComboBox, this, 0, 0, 0.2d, 1d);
+        for (final ResourceTypePresenter<?> presenter : getResourceTypePresenters()) {
+            WidgetUtils.addToGridBag(presenter.getWidget(), this, 1, 0, 0.8d, 1d);
+        }
     }
 
     protected ResourceTypePresenter<?> createResourceTypePresenter(final String scheme,


### PR DESCRIPTION
Now resizing (specially making the window smaller) does not hide the text box used in a file selector:

![image](https://user-images.githubusercontent.com/291450/40291405-bec27fa8-5c79-11e8-8d93-73b819d7e86b.png)

Fixes #1786 
