### PR TITLE
Fix bitrot exposed by JDK 10

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/connection/DatastoreDescriptors.java
+++ b/desktop/ui/src/main/java/org/datacleaner/connection/DatastoreDescriptors.java
@@ -276,7 +276,7 @@ public class DatastoreDescriptors {
         }
 
         // composite datastore
-        if (!alreadyAddedDatabaseNames.contains(COMPOSITE_DATASTORE_DESCRIPTOR)) {
+        if (!alreadyAddedDatabaseNames.contains(COMPOSITE_DATASTORE_DESCRIPTOR.getName())) {
             datastoreDescriptors.add(COMPOSITE_DATASTORE_DESCRIPTOR);
         }
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import org.datacleaner.descriptors.ComponentDescriptor;
 
@@ -31,9 +32,11 @@ public class SortedDefaultMutableTreeModel extends DefaultMutableTreeNode {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Comparator<DefaultMutableTreeNode> comp = (o1, o2) -> {
-        final ComponentDescriptor<?> descriptor1 = (ComponentDescriptor<?>) o1.getUserObject();
-        final ComponentDescriptor<?> descriptor2 = (ComponentDescriptor<?>) o2.getUserObject();
+    private static final Comparator<? super TreeNode> comp = (o1, o2) -> {
+    	final DefaultMutableTreeNode node1 = (DefaultMutableTreeNode) o1;
+    	final DefaultMutableTreeNode node2 = (DefaultMutableTreeNode) o2;
+        final ComponentDescriptor<?> descriptor1 = (ComponentDescriptor<?>) node1.getUserObject();
+        final ComponentDescriptor<?> descriptor2 = (ComponentDescriptor<?>) node2.getUserObject();
         return descriptor1.getDisplayName().compareTo(descriptor2.getDisplayName());
     };
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
@@ -33,8 +33,8 @@ public class SortedDefaultMutableTreeModel extends DefaultMutableTreeNode {
     private static final long serialVersionUID = 1L;
 
     private static final Comparator<? super TreeNode> comp = (o1, o2) -> {
-    	final DefaultMutableTreeNode node1 = (DefaultMutableTreeNode) o1;
-    	final DefaultMutableTreeNode node2 = (DefaultMutableTreeNode) o2;
+        final DefaultMutableTreeNode node1 = (DefaultMutableTreeNode) o1;
+        final DefaultMutableTreeNode node2 = (DefaultMutableTreeNode) o2;
         final ComponentDescriptor<?> descriptor1 = (ComponentDescriptor<?>) node1.getUserObject();
         final ComponentDescriptor<?> descriptor2 = (ComponentDescriptor<?>) node2.getUserObject();
         return descriptor1.getDisplayName().compareTo(descriptor2.getDisplayName());
@@ -44,7 +44,6 @@ public class SortedDefaultMutableTreeModel extends DefaultMutableTreeNode {
         super(object);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void insert(final MutableTreeNode newChild, final int childIndex) {
         super.insert(newChild, childIndex);


### PR DESCRIPTION
Tried building DataCleaner using JDK 10 and the compiler (1) doesn't allow one of our casts because of a generalization in the `DefaultMutableTreeNode` class, and (2) made me aware of a wrong key we're using when looking up a key (of wrong type) in a map.