### PR TITLE
JUNG graph API 2.1.1 upgrade

### DIFF
--- a/desktop/ui/pom.xml
+++ b/desktop/ui/pom.xml
@@ -181,23 +181,14 @@
 		<dependency>
 			<groupId>net.sf.jung</groupId>
 			<artifactId>jung-visualization</artifactId>
-			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.jung</groupId>
 			<artifactId>jung-graph-impl</artifactId>
-			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.jung</groupId>
 			<artifactId>jung-io</artifactId>
-			<version>2.0.1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>stax</groupId>
-					<artifactId>stax-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.simpleframework</groupId>

--- a/desktop/ui/src/main/java/org/datacleaner/connection/DatastoreDescriptors.java
+++ b/desktop/ui/src/main/java/org/datacleaner/connection/DatastoreDescriptors.java
@@ -276,7 +276,7 @@ public class DatastoreDescriptors {
         }
 
         // composite datastore
-        if (!alreadyAddedDatabaseNames.contains(COMPOSITE_DATASTORE_DESCRIPTOR)) {
+        if (!alreadyAddedDatabaseNames.contains(COMPOSITE_DATASTORE_DESCRIPTOR.getName())) {
             datastoreDescriptors.add(COMPOSITE_DATASTORE_DESCRIPTOR);
         }
 

--- a/desktop/ui/src/main/java/org/datacleaner/panels/ExtensionPackagesPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/ExtensionPackagesPanel.java
@@ -22,6 +22,7 @@ package org.datacleaner.panels;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.io.File;
+import java.util.Arrays;
 
 import javax.inject.Inject;
 import javax.swing.Box;
@@ -49,8 +50,6 @@ import org.jdesktop.swingx.VerticalLayout;
 import org.jdesktop.swingx.action.OpenBrowserAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import cern.colt.Arrays;
 
 /**
  * Panel for configuring extension packages.

--- a/desktop/ui/src/main/java/org/datacleaner/util/GraphUtils.java
+++ b/desktop/ui/src/main/java/org/datacleaner/util/GraphUtils.java
@@ -25,8 +25,9 @@ import java.awt.Shape;
 import java.awt.event.MouseWheelEvent;
 import java.util.Arrays;
 
-import org.apache.commons.collections15.Transformer;
 import org.apache.metamodel.util.HasName;
+
+import com.google.common.base.Function;
 
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.VisualizationViewer;
@@ -71,7 +72,7 @@ public class GraphUtils {
         visualizationViewer.setGraphMouse(graphMouse);
     }
 
-    private static <E> Transformer<E, Font> createFontTransformer() {
+    private static <E> Function<E, Font> createFontTransformer() {
         return input -> {
             final Font defaultFont = WidgetUtils.FONT_SMALL;
             if (input == null) {

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SortedDefaultMutableTreeModel.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import org.datacleaner.descriptors.ComponentDescriptor;
 
@@ -31,9 +32,11 @@ public class SortedDefaultMutableTreeModel extends DefaultMutableTreeNode {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Comparator<DefaultMutableTreeNode> comp = (o1, o2) -> {
-        final ComponentDescriptor<?> descriptor1 = (ComponentDescriptor<?>) o1.getUserObject();
-        final ComponentDescriptor<?> descriptor2 = (ComponentDescriptor<?>) o2.getUserObject();
+    private static final Comparator<? super TreeNode> comp = (o1, o2) -> {
+    	final DefaultMutableTreeNode node1 = (DefaultMutableTreeNode) o1;
+    	final DefaultMutableTreeNode node2 = (DefaultMutableTreeNode) o2;
+        final ComponentDescriptor<?> descriptor1 = (ComponentDescriptor<?>) node1.getUserObject();
+        final ComponentDescriptor<?> descriptor2 = (ComponentDescriptor<?>) node2.getUserObject();
         return descriptor1.getDisplayName().compareTo(descriptor2.getDisplayName());
     };
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraph.java
@@ -167,7 +167,7 @@ public final class JobGraph {
         final Collection<Object> vertices = graph.getVertices();
         for (final Object vertex : vertices) {
             // manually initialize all vertices
-            layout.transform(vertex);
+            layout.apply(vertex);
         }
 
         if (!vertices.isEmpty() && !layoutTransformer.isTransformed()) {
@@ -387,7 +387,7 @@ public final class JobGraph {
 
         final RenderContext<Object, JobGraphLink> renderContext = visualizationViewer.getRenderContext();
 
-        final JobGraphTransformers transformers = new JobGraphTransformers(_userPreferences, _highlighedVertexes);
+        final JobGraphTransformers transformers = new JobGraphTransformers(graph, _userPreferences, _highlighedVertexes);
 
         // instrument the render context with all our transformers and stuff
         renderContext.setVertexFontTransformer(transformers.getVertexFontTransformer());

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLayoutTransformer.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLayoutTransformer.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections15.Transformer;
 import org.apache.metamodel.schema.Table;
 import org.datacleaner.components.convert.ConvertToNumberTransformer;
 import org.datacleaner.job.builder.AnalysisJobBuilder;
@@ -41,6 +40,7 @@ import org.datacleaner.util.IconUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 
 import edu.uci.ics.jung.graph.DirectedGraph;
@@ -48,7 +48,7 @@ import edu.uci.ics.jung.graph.DirectedGraph;
 /**
  * Transformer that makes 2D points for each vertex in the graph.
  */
-public class JobGraphLayoutTransformer implements Transformer<Object, Point2D> {
+public class JobGraphLayoutTransformer implements Function<Object, Point2D> {
 
     private static final Logger logger = LoggerFactory.getLogger(JobGraphLayoutTransformer.class);
     private static final int X_STEP = 160;
@@ -204,9 +204,9 @@ public class JobGraphLayoutTransformer implements Transformer<Object, Point2D> {
         }
         return new Point(x * X_STEP + X_OFFSET, y * Y_STEP + Y_OFFSET);
     }
-
+    
     @Override
-    public Point2D transform(final Object vertex) {
+    public Point2D apply(final Object vertex) {
         Point point = _points.get(vertex);
         if (point == null) {
             logger.warn("Vertex {} has no assigned coordinate!", vertex);

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainterMousePlugin.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainterMousePlugin.java
@@ -51,11 +51,11 @@ public class JobGraphLinkPainterMousePlugin extends AbstractGraphMousePlugin
         _linkPainter = linkPainter;
         cursor = Cursor.getDefaultCursor();
     }
-    
+
     @Override
     public boolean checkModifiers(MouseEvent e) {
-    	// overrides the parent's call to deprecated e.getModifiers() method 
-    	return e.getModifiersEx() == modifiers;
+        // overrides the parent's call to deprecated e.getModifiers() method
+        return e.getModifiersEx() == modifiers;
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainterMousePlugin.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphLinkPainterMousePlugin.java
@@ -46,10 +46,16 @@ public class JobGraphLinkPainterMousePlugin extends AbstractGraphMousePlugin
     private final JobGraphContext _graphContext;
 
     public JobGraphLinkPainterMousePlugin(final JobGraphLinkPainter linkPainter, final JobGraphContext graphContext) {
-        super(MouseEvent.BUTTON1_MASK + MouseEvent.SHIFT_MASK);
+        super(MouseEvent.BUTTON1_DOWN_MASK + MouseEvent.SHIFT_DOWN_MASK);
         _graphContext = graphContext;
         _linkPainter = linkPainter;
         cursor = Cursor.getDefaultCursor();
+    }
+    
+    @Override
+    public boolean checkModifiers(MouseEvent e) {
+    	// overrides the parent's call to deprecated e.getModifiers() method 
+    	return e.getModifiersEx() == modifiers;
     }
 
     @Override

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphPreferencesPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphPreferencesPanel.java
@@ -69,8 +69,8 @@ public class JobGraphPreferencesPanel extends DCPanel {
         // the orthogonal line style does not work well enough for inclusion
         // yet.
 
-        // add(createLineStyleButton("images/menu/edge-orthogonal.png",
-        // JobGraphTransformers.EDGE_STYLE_NAME_ORTOGHONAL));
+         add(createLineStyleButton("images/menu/edge-orthogonal.png",
+         JobGraphTransformers.EDGE_STYLE_NAME_ORTOGHONAL));
 
         add(Box.createHorizontalStrut(10));
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphPreferencesPanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphPreferencesPanel.java
@@ -66,11 +66,9 @@ public class JobGraphPreferencesPanel extends DCPanel {
         add(createLineStyleButton("images/menu/edge-straight.png", JobGraphTransformers.EDGE_STYLE_NAME_STRAIGHT));
         add(createLineStyleButton("images/menu/edge-curved.png", JobGraphTransformers.EDGE_STYLE_NAME_CURVED));
 
-        // the orthogonal line style does not work well enough for inclusion
-        // yet.
-
-         add(createLineStyleButton("images/menu/edge-orthogonal.png",
-         JobGraphTransformers.EDGE_STYLE_NAME_ORTOGHONAL));
+        // the orthogonal line style does not work well enough for inclusion yet.
+        // add(createLineStyleButton("images/menu/edge-orthogonal.png",
+        // JobGraphTransformers.EDGE_STYLE_NAME_ORTOGHONAL));
 
         add(Box.createHorizontalStrut(10));
 

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphTransformers.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphTransformers.java
@@ -59,8 +59,7 @@ import edu.uci.ics.jung.visualization.decorators.EdgeShape;
 import edu.uci.ics.jung.visualization.renderers.EdgeLabelRenderer;
 
 /**
- * Collection of {@link Function} (and {@link Predicate} and so on) instances
- * to use in the {@link JobGraph}.
+ * Collection of {@link Function} (and {@link Predicate} and so on) instances to use in the {@link JobGraph}.
  */
 public class JobGraphTransformers {
 
@@ -71,14 +70,14 @@ public class JobGraphTransformers {
     public static final String EDGE_STYLE_NAME_STRAIGHT = "straight";
     public static final String EDGE_STYLE_NAME_CURVED = "curved";
     public static final String EDGE_STYLE_NAME_ORTOGHONAL = "orthogonal";
-    
+
     public static final Predicate<Context<Graph<Object, JobGraphLink>, JobGraphLink>> EDGE_ARROW_PREDICATE =
-    		(c -> true);
+            (c -> true);
     public static final Function<JobGraphLink, String> EDGE_LABEL_TRANSFORMER = JobGraphLink::getLinkLabel;
     public static final Function<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> EDGE_ARROW_TRANSFORMER =
             input -> GraphUtils.ARROW_SHAPE;
-    public static final Function<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Number>
-            EDGE_LABEL_CLOSENESS_TRANSFORMER = input -> 0.4d;
+    public static final Function<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Number> EDGE_LABEL_CLOSENESS_TRANSFORMER =
+            input -> 0.4d;
     public static final Function<Object, String> VERTEX_LABEL_TRANSFORMER = obj -> {
         if (obj instanceof InputColumn) {
             return ((InputColumn<?>) obj).getName();
@@ -142,8 +141,9 @@ public class JobGraphTransformers {
     private final Font _normalFont;
     private final Font _boldFont;
 
-    public JobGraphTransformers(DirectedGraph<Object, JobGraphLink> graph, final UserPreferences userPreferences, final Set<Object> highlighedVertexes) {
-    	_graph = graph;
+    public JobGraphTransformers(DirectedGraph<Object, JobGraphLink> graph, final UserPreferences userPreferences,
+            final Set<Object> highlighedVertexes) {
+        _graph = graph;
         _userPreferences = userPreferences;
         _highlighedVertexes = highlighedVertexes;
 
@@ -169,8 +169,7 @@ public class JobGraphTransformers {
 
     public Function<? super JobGraphLink, Shape> getEdgeShapeTransformer() {
         final String edgeStyle = _userPreferences.getAdditionalProperties().get(USER_PREFERENCES_PROPERTY_EDGE_STYLE);
-        final Function<? super JobGraphLink, Shape> baseTransformer =
-                getBaseEdgeShapeTransformer(edgeStyle);
+        final Function<? super JobGraphLink, Shape> baseTransformer = getBaseEdgeShapeTransformer(edgeStyle);
 
         return input -> {
             final Shape result = baseTransformer.apply(input);
@@ -178,7 +177,7 @@ public class JobGraphTransformers {
                 // make a double link (actually a wedge, but close
                 // enough) to show that there are more than one filter
                 // outcome coming from this source
-            	return EdgeShape.wedge(_graph, 10).apply(input);
+                return EdgeShape.wedge(_graph, 10).apply(input);
             }
             return result;
         };
@@ -196,8 +195,7 @@ public class JobGraphTransformers {
         return false;
     }
 
-    private Function<? super JobGraphLink, Shape> getBaseEdgeShapeTransformer(
-            final String edgeStyle) {
+    private Function<? super JobGraphLink, Shape> getBaseEdgeShapeTransformer(final String edgeStyle) {
         if (edgeStyle == null) {
             return EdgeShape.quadCurve(_graph);
         }

--- a/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphTransformers.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/visualization/JobGraphTransformers.java
@@ -31,9 +31,6 @@ import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 
-import org.apache.commons.collections15.Predicate;
-import org.apache.commons.collections15.Transformer;
-import org.apache.commons.collections15.functors.TruePredicate;
 import org.apache.metamodel.schema.Table;
 import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.InputColumn;
@@ -51,15 +48,18 @@ import org.datacleaner.util.LabelUtils;
 import org.datacleaner.util.ReflectionUtils;
 import org.datacleaner.util.WidgetUtils;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 
+import edu.uci.ics.jung.graph.DirectedGraph;
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.util.Context;
 import edu.uci.ics.jung.visualization.decorators.EdgeShape;
 import edu.uci.ics.jung.visualization.renderers.EdgeLabelRenderer;
 
 /**
- * Collection of {@link Transformer} (and {@link Predicate} and so on) instances
+ * Collection of {@link Function} (and {@link Predicate} and so on) instances
  * to use in the {@link JobGraph}.
  */
 public class JobGraphTransformers {
@@ -71,14 +71,15 @@ public class JobGraphTransformers {
     public static final String EDGE_STYLE_NAME_STRAIGHT = "straight";
     public static final String EDGE_STYLE_NAME_CURVED = "curved";
     public static final String EDGE_STYLE_NAME_ORTOGHONAL = "orthogonal";
+    
     public static final Predicate<Context<Graph<Object, JobGraphLink>, JobGraphLink>> EDGE_ARROW_PREDICATE =
-            TruePredicate.getInstance();
-    public static final Transformer<JobGraphLink, String> EDGE_LABEL_TRANSFORMER = JobGraphLink::getLinkLabel;
-    public static final Transformer<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> EDGE_ARROW_TRANSFORMER =
+    		(c -> true);
+    public static final Function<JobGraphLink, String> EDGE_LABEL_TRANSFORMER = JobGraphLink::getLinkLabel;
+    public static final Function<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> EDGE_ARROW_TRANSFORMER =
             input -> GraphUtils.ARROW_SHAPE;
-    public static final Transformer<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Number>
+    public static final Function<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Number>
             EDGE_LABEL_CLOSENESS_TRANSFORMER = input -> 0.4d;
-    public static final Transformer<Object, String> VERTEX_LABEL_TRANSFORMER = obj -> {
+    public static final Function<Object, String> VERTEX_LABEL_TRANSFORMER = obj -> {
         if (obj instanceof InputColumn) {
             return ((InputColumn<?>) obj).getName();
         }
@@ -100,13 +101,13 @@ public class JobGraphTransformers {
         }
         return obj.toString();
     };
-    public static final Transformer<Object, Shape> VERTEX_SHAPE_TRANSFORMER = input -> {
+    public static final Function<Object, Shape> VERTEX_SHAPE_TRANSFORMER = input -> {
         final int size = IconUtils.ICON_SIZE_LARGE;
         final int offset = -size / 2;
         return new Rectangle(new Point(offset, offset), new Dimension(size, size));
     };
     private static final ImageManager imageManager = ImageManager.get();
-    public static final Transformer<Object, Icon> VERTEX_ICON_TRANSFORMER = obj -> {
+    public static final Function<Object, Icon> VERTEX_ICON_TRANSFORMER = obj -> {
         if (obj == JobGraph.MORE_COLUMNS_VERTEX || obj instanceof InputColumn) {
             return imageManager.getImageIcon(IconUtils.MODEL_COLUMN, IconUtils.ICON_SIZE_MEDIUM);
         }
@@ -137,10 +138,12 @@ public class JobGraphTransformers {
     };
     private final UserPreferences _userPreferences;
     private final Set<Object> _highlighedVertexes;
+    private final DirectedGraph<Object, JobGraphLink> _graph;
     private final Font _normalFont;
     private final Font _boldFont;
 
-    public JobGraphTransformers(final UserPreferences userPreferences, final Set<Object> highlighedVertexes) {
+    public JobGraphTransformers(DirectedGraph<Object, JobGraphLink> graph, final UserPreferences userPreferences, final Set<Object> highlighedVertexes) {
+    	_graph = graph;
         _userPreferences = userPreferences;
         _highlighedVertexes = highlighedVertexes;
 
@@ -164,19 +167,18 @@ public class JobGraphTransformers {
         return font.deriveFont(font.getSize() * fontFactor);
     }
 
-    public Transformer<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> getEdgeShapeTransformer() {
+    public Function<? super JobGraphLink, Shape> getEdgeShapeTransformer() {
         final String edgeStyle = _userPreferences.getAdditionalProperties().get(USER_PREFERENCES_PROPERTY_EDGE_STYLE);
-        final Transformer<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> baseTransformer =
+        final Function<? super JobGraphLink, Shape> baseTransformer =
                 getBaseEdgeShapeTransformer(edgeStyle);
 
         return input -> {
-            final Shape result = baseTransformer.transform(input);
-            final JobGraphLink link = input.element;
-            if (isCompoundRequirementLink(link)) {
+            final Shape result = baseTransformer.apply(input);
+            if (isCompoundRequirementLink(input)) {
                 // make a double link (actually a wedge, but close
                 // enough) to show that there are more than one filter
                 // outcome coming from this source
-                return new EdgeShape.Wedge<Object, JobGraphLink>(10).transform(input);
+            	return EdgeShape.wedge(_graph, 10).apply(input);
             }
             return result;
         };
@@ -194,20 +196,20 @@ public class JobGraphTransformers {
         return false;
     }
 
-    private Transformer<Context<Graph<Object, JobGraphLink>, JobGraphLink>, Shape> getBaseEdgeShapeTransformer(
+    private Function<? super JobGraphLink, Shape> getBaseEdgeShapeTransformer(
             final String edgeStyle) {
         if (edgeStyle == null) {
-            return new EdgeShape.QuadCurve<>();
+            return EdgeShape.quadCurve(_graph);
         }
         switch (edgeStyle) {
         case EDGE_STYLE_NAME_STRAIGHT:
-            return new EdgeShape.Line<>();
+            return EdgeShape.line(_graph);
         case EDGE_STYLE_NAME_CURVED:
-            return new EdgeShape.QuadCurve<>();
+            return EdgeShape.quadCurve(_graph);
         case EDGE_STYLE_NAME_ORTOGHONAL:
-            return new EdgeShape.Orthogonal<>();
+            return EdgeShape.orthogonal(_graph);
         default:
-            return new EdgeShape.QuadCurve<>();
+            return EdgeShape.quadCurve(_graph);
         }
     }
 
@@ -256,7 +258,7 @@ public class JobGraphTransformers {
         };
     }
 
-    public Transformer<Object, Font> getVertexFontTransformer() {
+    public Function<Object, Font> getVertexFontTransformer() {
         return vertex -> {
             if (_highlighedVertexes.contains(vertex)) {
                 return _boldFont;

--- a/desktop/ui/src/test/java/org/datacleaner/widgets/properties/MultipleMappedColumnsPropertyWidgetTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/widgets/properties/MultipleMappedColumnsPropertyWidgetTest.java
@@ -19,6 +19,7 @@
  */
 package org.datacleaner.widgets.properties;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +39,6 @@ import org.datacleaner.job.builder.TransformerComponentBuilder;
 import org.datacleaner.widgets.DCCheckBox;
 import org.datacleaner.widgets.SourceColumnComboBox;
 
-import cern.colt.Arrays;
 import junit.framework.TestCase;
 
 public class MultipleMappedColumnsPropertyWidgetTest extends TestCase {

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<javax.el.version>2.2.5</javax.el.version>
 		<javax.annotation.version>1.2</javax.annotation.version>
 		<scala.version>2.11.12</scala.version>
+		<jung.version>2.1.1</jung.version>
 		
 		<!-- TODO: The following (inter-dependent) dependencies are due for upgrades before Java 11 -->
 		<jersey.version>1.19.4</jersey.version>
@@ -1207,6 +1208,27 @@
 				<groupId>com.ibm.icu</groupId>
 				<artifactId>icu4j</artifactId>
 				<version>${icu4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sf.jung</groupId>
+				<artifactId>jung-visualization</artifactId>
+				<version>${jung.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sf.jung</groupId>
+				<artifactId>jung-graph-impl</artifactId>
+				<version>${jung.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sf.jung</groupId>
+				<artifactId>jung-io</artifactId>
+				<version>${jung.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>stax</groupId>
+						<artifactId>stax-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.scala-lang</groupId>


### PR DESCRIPTION
This branch extends the branch used in PR #1788 - so please take a look at that one first.

This branch upgrades the JUNG library to the latest release (2.1.1). This release of JUNG now relies on Guava instead of the CERN collections library. Supposedly there are other improvements too, but mostly I just considered it a hygeine update and a chance to consolidate on less common libraries for lambdas etc..