### PR TITLE
Update hive-jdbc to version 2.3.4, addressing CVE-2018-1314

### DIFF
--- a/engine/core/src/main/java/org/datacleaner/util/ws/SimpleServiceSession.java
+++ b/engine/core/src/main/java/org/datacleaner/util/ws/SimpleServiceSession.java
@@ -22,8 +22,6 @@ package org.datacleaner.util.ws;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.xml.ws.WebServiceException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +45,7 @@ public class SimpleServiceSession<R> implements ServiceSession<R> {
             final R result = callable.call();
             return new ServiceResult<>(result);
         } catch (Throwable e) {
-            if (e instanceof WebServiceException && e.getCause() != null) {
+            if (isWrappedByJaxWsException(e)) {
                 logger.info("Exception thrown was a WebServiceException. Handling cause exception instead.", e);
                 e = e.getCause();
             }
@@ -55,6 +53,15 @@ public class SimpleServiceSession<R> implements ServiceSession<R> {
         } finally {
             _activeRequestsCount.decrementAndGet();
         }
+    }
+
+    private boolean isWrappedByJaxWsException(Throwable e) {
+        if (e.getCause() == null) {
+            return false;
+        }
+        // special exception name comparison to avoid dependency on JAX-WS directly
+        final String exceptionName = e.getClass().getName();
+        return exceptionName.startsWith("javax.xml.ws.");
     }
 
     /**
@@ -81,7 +88,7 @@ public class SimpleServiceSession<R> implements ServiceSession<R> {
         try {
             return callable.call();
         } catch (Throwable e) {
-            if (e instanceof WebServiceException && e.getCause() != null) {
+            if (isWrappedByJaxWsException(e)) {
                 logger.info("Exception thrown was a WebServiceException. Throwing cause exception instead.", e);
                 e = e.getCause();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1070,7 +1070,7 @@
 			<dependency>
 				<groupId>org.apache.hive</groupId>
 				<artifactId>hive-jdbc</artifactId>
-				<version>1.2.1</version>
+				<version>2.3.4</version>
 				<exclusions>
 					<exclusion>
 						<groupId>jdk.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,7 @@
 										<exclude>javax.servlet:servlet-api:*:jar:compile:*</exclude>
 										<exclude>org.glassfish:javax.servlet:*</exclude>
 										<exclude>org.mortbay.jetty:servlet-api:*</exclude>
+										<exclude>org.mortbay.jetty:servlet-api-2.5:*</exclude>
 										<exclude>org.eclipse.jetty.orbit:javax.servlet:*</exclude>
 										<exclude>ant:ant:*</exclude>
 										
@@ -1121,12 +1122,32 @@
 						<artifactId>jsp-api-2.1</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId>org.datanucleaus</groupId>
+						<groupId>org.mortbay.jetty</groupId>
+						<artifactId>jsp-2.1</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.datanucleus</groupId>
 						<artifactId>javax.jdo</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.transaction</groupId>
+						<artifactId>jta</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.transaction</groupId>
+						<artifactId>transaction-api</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>org.eclipse.jetty.orbit</groupId>
 						<artifactId>javax.servlet</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.mortbay.jetty</groupId>
+						<artifactId>servlet-api-2.5</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.eclipse.jetty</groupId>
+						<artifactId>jsp-api-2.1</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>tomcat</groupId>
@@ -1135,6 +1156,10 @@
 					<exclusion>
 						<groupId>tomcat</groupId>
 						<artifactId>jasper-runtime</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>jline</groupId>
+						<artifactId>jline</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,16 +363,25 @@
 							<rules>
 								<bannedDependencies>
 									<excludes>
-										<exclude>commons-logging:commons-logging</exclude>
-										<exclude>com.google.collections:google-collections</exclude>
-										<exclude>javax.servlet:servlet-api:*:jar:compile</exclude>
-										<exclude>org.glassfish:javax.servlet</exclude>
-										<exclude>org.eclipse.jetty.orbit:javax.servlet</exclude>
+										<exclude>commons-logging:commons-logging:*</exclude>
+										<exclude>com.google.collections:google-collections:*</exclude>
+										<exclude>javax.servlet:servlet-api:*:jar:compile:*</exclude>
+										<exclude>org.glassfish:javax.servlet:*</exclude>
+										<exclude>org.mortbay.jetty:servlet-api:*</exclude>
+										<exclude>org.eclipse.jetty.orbit:javax.servlet:*</exclude>
+										<exclude>ant:ant:*</exclude>
+										
+										<exclude>org.datanucleus:javax.jdo:*</exclude>
+										
+										<!-- Prefer javax.transaction:javax.transaction-api over javax.transaction:jta -->
+										<exclude>javax.transaction:jta:*</exclude>
+										<exclude>javax.transaction:transaction-api:*</exclude>
 										
 										<!-- The proper artifact for JSP API is javax.servlet.jsp:javax.servlet.jsp-api, so we're banning the rest -->
 										<exclude>javax.servlet:jsp-api:*</exclude>
 										<exclude>javax.servlet.jsp:jsp-api:*</exclude>
 										<exclude>org.mortbay.jetty:jsp-api-2.1:*</exclude>
+										<exclude>org.mortbay.jetty:jsp-2.1:*</exclude>
 										
 										<!-- The propert artifact for JDO is javax.jdo:jdo-api, so we're banning the rest -->
 										<exclude>org.datanucleaus:javax.jdo</exclude>
@@ -412,7 +421,7 @@
 										<exclude>com.github.stephenc.findbugs:findbugs-annotations:*</exclude>
 
 										<!-- jcip-annotations is overlapping with annotations -->
-										<exclude>net.jcip:jcip-annotations</exclude>
+										<exclude>net.jcip:jcip-annotations:*</exclude>
 										
 										<!-- xml-apis is shipped with the JRE -->
 										<exclude>xml-apis:xml-apis:*</exclude>
@@ -424,7 +433,7 @@
 
 										<!-- stax-api is overlapping with xml-apis -->
 										<exclude>stax:stax-api:*</exclude>
-										<exclude>javax.xml.stream:stax-api</exclude>
+										<exclude>javax.xml.stream:stax-api:*</exclude>
 
 										<!-- standard is overlapping with jstl -->
 										<exclude>taglibs:standard:*</exclude>
@@ -808,6 +817,11 @@
 				<version>1</version>
 			</dependency>
 			<dependency>
+				<groupId>javax.transaction</groupId>
+				<artifactId>javax.transaction-api</artifactId>
+				<version>1.3</version>
+			</dependency>
+			<dependency>
 				<groupId>javax.xml.bind</groupId>
 				<artifactId>jaxb-api</artifactId>
 				<version>2.3.0</version>
@@ -1113,6 +1127,14 @@
 					<exclusion>
 						<groupId>org.eclipse.jetty.orbit</groupId>
 						<artifactId>javax.servlet</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>tomcat</groupId>
+						<artifactId>jasper-compiler</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>tomcat</groupId>
+						<artifactId>jasper-runtime</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1077,6 +1077,18 @@
 						<artifactId>jdk.tools</artifactId>
 					</exclusion>
 					<exclusion>
+						<groupId>com.github.stephenc.findbugs</groupId>
+						<artifactId>findbugs-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>jsp-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.servlet.jsp</groupId>
+						<artifactId>jsp-api</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>commons-logging</groupId>
 						<artifactId>commons-logging</artifactId>
 					</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1113,6 +1113,18 @@
 						<artifactId>log4j</artifactId>
 					</exclusion>
 					<exclusion>
+						<groupId>org.apache.logging.log4j</groupId>
+						<artifactId>log4j-1.2-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.logging.log4j</groupId>
+						<artifactId>log4j-web</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.logging.log4j</groupId>
+						<artifactId>log4j-slf4j-impl</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -366,10 +366,15 @@
 										<exclude>commons-logging:commons-logging</exclude>
 										<exclude>com.google.collections:google-collections</exclude>
 										<exclude>javax.servlet:servlet-api:*:jar:compile</exclude>
+										<exclude>org.eclipse.jetty.orbit:javax.servlet</exclude>
 										
 										<!-- The proper artifact for JSP API is javax.servlet.jsp:javax.servlet.jsp-api, so we're banning the rest -->
 										<exclude>javax.servlet:jsp-api:*</exclude>
 										<exclude>javax.servlet.jsp:jsp-api:*</exclude>
+										<exclude>org.mortbay.jetty:jsp-api-2.1:*</exclude>
+										
+										<!-- The propert artifact for JDO is javax.jdo:jdo-api, so we're banning the rest -->
+										<exclude>org.datanucleaus:javax.jdo</exclude>
 
 										<exclude>org.mortbay.jetty:servlet-api:*:*:compile</exclude>
 										<exclude>org.eclipse.jetty.aggregate:jetty-all:*:jar:compile</exclude>
@@ -1087,6 +1092,18 @@
 					<exclusion>
 						<groupId>javax.servlet.jsp</groupId>
 						<artifactId>jsp-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.mortbay.jetty</groupId>
+						<artifactId>jsp-api-2.1</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.datanucleaus</groupId>
+						<artifactId>javax.jdo</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.eclipse.jetty.orbit</groupId>
+						<artifactId>javax.servlet</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,7 @@
 										<exclude>commons-logging:commons-logging</exclude>
 										<exclude>com.google.collections:google-collections</exclude>
 										<exclude>javax.servlet:servlet-api:*:jar:compile</exclude>
+										<exclude>org.glassfish:javax.servlet</exclude>
 										<exclude>org.eclipse.jetty.orbit:javax.servlet</exclude>
 										
 										<!-- The proper artifact for JSP API is javax.servlet.jsp:javax.servlet.jsp-api, so we're banning the rest -->
@@ -921,6 +922,14 @@
 					<exclusion>
 						<groupId>asm</groupId>
 						<artifactId>asm</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.glassfish</groupId>
+						<artifactId>javax.servlet</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.eclipse.jetty.orbit</groupId>
+						<artifactId>javax.servlet</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1314 for details on the vulnerability in the previous versions.