### PR TITLE
Fixes vulnerabilities with Jackson versions `>= 2.9.0, < 2.9.8`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<spring.core.version>4.3.16.RELEASE</spring.core.version>
 		<freemarker.version>2.3.28</freemarker.version>
 		<icu4j.version>61.1</icu4j.version>
-		<jackson.version>2.9.6</jackson.version>
+		<jackson.version>2.9.8</jackson.version>
 		<javax.servlet.version>3.0.1</javax.servlet.version>
 		<javax.el.version>2.2.5</javax.el.version>
 		<javax.annotation.version>1.2</javax.annotation.version>


### PR DESCRIPTION
From https://github.com/datacleaner/DataCleaner/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open:

Details
CVE-2018-19360 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to
have unspecified impact by leveraging failure to block the
axis2-transport-jms class from polymorphic deserialization.

CVE-2018-19361 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to
have unspecified impact by leveraging failure to block the openjpa class
from polymorphic deserialization.

CVE-2018-19362 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to
have unspecified impact by leveraging failure to block the
jboss-common-core class from polymorphic deserialization.

CVE-2018-14721 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers
to conduct server-side request forgery (SSRF) attacks by leveraging
failure to block the axis2-jaxws class from polymorphic deserialization.

CVE-2018-14718 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers
to execute arbitrary code by leveraging failure to block the slf4j-ext
class from polymorphic deserialization.

CVE-2018-14719 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers
to execute arbitrary code by leveraging failure to block the
blaze-ds-opt and blaze-ds-core classes from polymorphic deserialization.

CVE-2018-14720 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow attackers to
conduct external XML entity (XXE) attacks by leveraging failure to block
unspecified JDK classes from polymorphic deserialization.