### PR TITLE
Fixed issue where JTextField's value is null (iso. empty) on some JVMs

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SchemaTree.java
+++ b/desktop/ui/src/main/java/org/datacleaner/widgets/tree/SchemaTree.java
@@ -242,6 +242,9 @@ public class SchemaTree extends JXTree implements TreeWillExpandListener, TreeCe
     }
 
     private static String normalizeStringForMatching(final String str) {
+        if (str == null) {
+            return "";
+        }
         return StringUtils.replaceWhitespaces(str, "").toLowerCase();
     }
 


### PR DESCRIPTION
Running on Java 11 I see null pointer exceptions when I search the schema tree. It seems that the `getText()` call on JTextField returns null sometimes. This PR fixes our handling of that situation.