### PR TITLE
Feature/1843 try professional new url

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/actions/OpenAnalysisJobActionListener.java
+++ b/desktop/ui/src/main/java/org/datacleaner/actions/OpenAnalysisJobActionListener.java
@@ -197,7 +197,7 @@ public class OpenAnalysisJobActionListener implements ActionListener {
             if (Version.EDITION_COMMUNITY.equals(Version.getEdition())) {
                 message = "<html><p>Failed to open job because of a missing component:</p><pre>" + e.getMessage()
                         + "</pre><p>This may happen if the job requires a "
-                        + "<a href=\"https://www.quadient.com/products/quadient-datacleaner#get-started-today\">"
+                        + "<a href=\"https://www.humaninference.com/en/solutions/datacleaner\">"
                         + "Commercial Edition of DataCleaner</a>, or an extension that you do not have installed.</p>"
                         + "</html>";
             } else {

--- a/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
@@ -142,9 +142,8 @@ public class WelcomePanel extends DCSplashPanel {
 
                 final JButton tryProfessionalButton =
                         WidgetFactory.createDefaultButton("Try professional edition", IconUtils.APPLICATION_ICON);
-                tryProfessionalButton.addActionListener(new OpenBrowserAction(
-                        "https://www.quadient.com/products/quadient-datacleaner#get-started-today"));
-
+                tryProfessionalButton
+                        .addActionListener(new OpenBrowserAction("https://www.humaninference.com/en/solutions/datacleaner"));
                 final JButton discussionForumButton =
                         WidgetFactory.createDefaultButton("Visit the discussion forum", "images/menu/forum.png");
                 discussionForumButton

--- a/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
+++ b/desktop/ui/src/main/java/org/datacleaner/panels/WelcomePanel.java
@@ -142,8 +142,8 @@ public class WelcomePanel extends DCSplashPanel {
 
                 final JButton tryProfessionalButton =
                         WidgetFactory.createDefaultButton("Try professional edition", IconUtils.APPLICATION_ICON);
-                tryProfessionalButton
-                        .addActionListener(new OpenBrowserAction("https://www.humaninference.com/en/solutions/datacleaner"));
+                tryProfessionalButton.addActionListener(
+                        new OpenBrowserAction("https://www.humaninference.com/en/solutions/datacleaner"));
                 final JButton discussionForumButton =
                         WidgetFactory.createDefaultButton("Visit the discussion forum", "images/menu/forum.png");
                 discussionForumButton


### PR DESCRIPTION
Resolves https://github.com/datacleaner/DataCleaner/issues/1843. 

Commercial edition URL was changed from `https://www.quadient.com/products/quadient-datacleaner#get-started-today` to `https://www.humaninference.com/en/solutions/datacleaner`. 

![02](https://user-images.githubusercontent.com/13213915/72044511-3309be00-32b4-11ea-8981-470108538b6c.png)
