### PR TITLE
Updated JAXB plugin & version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,14 @@
 				<plugin>
 					<groupId>org.jvnet.jaxb2.maven2</groupId>
 					<artifactId>maven-jaxb2-plugin</artifactId>
-					<version>0.13.3</version>
+					<version>0.14.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.glassfish.jaxb</groupId>
+							<artifactId>jaxb-runtime</artifactId>
+							<version>2.3.5</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 
 				<plugin>
@@ -845,12 +852,12 @@
 			<dependency>
 				<groupId>javax.xml.bind</groupId>
 				<artifactId>jaxb-api</artifactId>
-				<version>2.3.0</version>
+				<version>2.3.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
-				<version>2.3.0</version>
+				<version>2.3.5</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.activation</groupId>


### PR DESCRIPTION
To improve build compatibility.

The ´xml-config´ module failed on my new latest JDK installation. Seems that it requires that the jaxb-runtime is included at build time and this was not explicit in the POM file.