### PR TITLE
Make scala-library a compile-time dependency

### DIFF
--- a/components/html-rendering/pom.xml
+++ b/components/html-rendering/pom.xml
@@ -37,7 +37,6 @@
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.scala-lang.modules</groupId>


### PR DESCRIPTION
This change makes scala-library a compile-time and transitive dependency of the ´html-rendering´ module. I'm not sure why it was "only" a test dependency before, and it breaks on newer setups of JDK/Maven, so it should be fixed.