### PR TITLE
Use WindowConstants instead of JFrame for constant ref

### DIFF
--- a/components/visualization/src/test/scala/org/datacleaner/visualization/DensityAnalyzerResultSwingRendererTestApp.scala
+++ b/components/visualization/src/test/scala/org/datacleaner/visualization/DensityAnalyzerResultSwingRendererTestApp.scala
@@ -1,6 +1,7 @@
 package org.datacleaner.visualization
 
 import javax.swing.JFrame
+import javax.swing.WindowConstants
 
 import org.datacleaner.configuration.{DataCleanerConfigurationImpl, DataCleanerEnvironmentImpl}
 import org.datacleaner.descriptors.{Descriptors, SimpleDescriptorProvider}
@@ -37,7 +38,7 @@ object DensityAnalyzerResultSwingRendererTestApp {
     LookAndFeelManager.get().init();
 
     val window = new JFrame("Example window")
-    window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE)
+    window.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
     window.getContentPane().add(panel)
     window.pack();
     window.setVisible(true)

--- a/components/visualization/src/test/scala/org/datacleaner/visualization/StackedAreaAnalyzerResultSwingRendererTestApp.scala
+++ b/components/visualization/src/test/scala/org/datacleaner/visualization/StackedAreaAnalyzerResultSwingRendererTestApp.scala
@@ -1,6 +1,7 @@
 package org.datacleaner.visualization
 
 import javax.swing.JFrame
+import javax.swing.WindowConstants
 
 import org.datacleaner.api.InputColumn
 import org.datacleaner.data.{MockInputColumn, MockInputRow}
@@ -34,7 +35,7 @@ object StackedAreaAnalyzerResultSwingRendererTestApp {
     LookAndFeelManager.get().init();
 
     val window = new JFrame("Example window")
-    window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE)
+    window.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
     window.getContentPane().add(jpanel)
     window.pack();
     window.setVisible(true)


### PR DESCRIPTION
Again, another thing that seems to fail on newer JDKs... And I guess it's much better to refer to the right class containing ´EXIT_ON_CLOSE´.