### PR TITLE
Start using eobjects MetaModel (fork) instead of apache MetaModel

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-core</artifactId>
 		</dependency>
 
@@ -53,7 +53,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-csv</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/datastores/basic-datastores/pom.xml
+++ b/datastores/basic-datastores/pom.xml
@@ -13,63 +13,63 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-csv</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-arff</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-fixedwidth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-pojo</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-neo4j</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-openoffice</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-salesforce</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-sugarcrm</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-xml</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-elasticsearch-rest</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-excel</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-json</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-mongodb-mongo3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-couchdb</artifactId>
 		</dependency>
 		<dependency>
@@ -81,11 +81,11 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-kafka</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-dynamodb</artifactId>
 		</dependency>
 		<dependency>

--- a/datastores/hadoop-datastores/pom.xml
+++ b/datastores/hadoop-datastores/pom.xml
@@ -17,11 +17,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-hbase</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-cassandra</artifactId>
 		</dependency>
 		<dependency>

--- a/engine/env/spark/pom.xml
+++ b/engine/env/spark/pom.xml
@@ -101,7 +101,7 @@
 			<version>${project.version}</version>
 			<exclusions>
 				<exclusion>
-					<groupId>org.apache.metamodel</groupId>
+					<groupId>org.eobjects.metamodel</groupId>
 					<artifactId>MetaModel-hbase</artifactId>
 				</exclusion>
 				<exclusion>
@@ -140,11 +140,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-fixedwidth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-core</artifactId>
 		</dependency>
 		<dependency>
@@ -163,7 +163,7 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-hadoop</artifactId>
 			<exclusions>
 				<exclusion>
@@ -177,11 +177,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-csv</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-json</artifactId>
 			<exclusions>
 				<exclusion>

--- a/engine/utils/pom.xml
+++ b/engine/utils/pom.xml
@@ -18,7 +18,7 @@
 			<artifactId>gentyref</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-csv</artifactId>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -665,12 +665,12 @@
 				<version>3.4</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-core</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-excel</artifactId>
 				<version>${metamodel.version}</version>
 				<exclusions>
@@ -685,7 +685,7 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-hadoop</artifactId>
 				<version>${metamodel.version}</version>
 				<exclusions>
@@ -696,57 +696,57 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-csv</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-arff</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-cassandra</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-fixedwidth</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-pojo</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-openoffice</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-salesforce</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-sugarcrm</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-xml</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-jdbc</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-elasticsearch-rest</artifactId>
 				<version>${metamodel.version}</version>
 				<exclusions>
@@ -757,32 +757,32 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-mongodb-mongo3</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-couchdb</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-dynamodb</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-kafka</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-json</artifactId>
 				<version>${metamodel.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-neo4j</artifactId>
 				<version>${metamodel.version}</version>
 				<exclusions>
@@ -793,7 +793,7 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.metamodel</groupId>
+				<groupId>org.eobjects.metamodel</groupId>
 				<artifactId>MetaModel-hbase</artifactId>
 				<version>${metamodel.version}</version>
 				<exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 		<junit.version>4.13.1</junit.version>
 		<easymock.version>3.6</easymock.version>
 		<httpcomponents.version>4.5.13</httpcomponents.version>
-		<metamodel.version>5.3.2</metamodel.version>
-		<metamodel.extras.version>5.2.0</metamodel.extras.version>
+		<metamodel.version>5.3.4</metamodel.version>
+		<metamodel.extras.version>5.3.4</metamodel.extras.version>
 		<spring.core.version>4.3.26.RELEASE</spring.core.version>
 		<freemarker.version>2.3.29</freemarker.version>
 		<icu4j.version>65.1</icu4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
 										<exclude>org.eclipse.jetty.aggregate:jetty-all:*:jar:compile</exclude>
 										<exclude>org.mortbay.jetty:jetty:*:jar:compile</exclude>
 										<exclude>org.codehaus.jackson:*</exclude>
-										<exclude>org.eobjects.metamodel:*</exclude>
+										<exclude>org.apache.metamodel:*</exclude>
 										<exclude>log4j:apache-log4j-extras:*</exclude>
 										<exclude>org.apache.logging.log4j:*</exclude>
 

--- a/testware/pom.xml
+++ b/testware/pom.xml
@@ -18,11 +18,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.metamodel</groupId>
+			<groupId>org.eobjects.metamodel</groupId>
 			<artifactId>MetaModel-jdbc</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Since Apache MetaModel is no longer an active Apache project, I figure that it is better to have our own fork for it that we can maintain when needed. I've created that, and released a first version of it with no real changes from the previous version.

This PR updated DataCleaner to depend on artifacts in the `org.eobjects.metamodel` group instead of `org.apache.metamodel`.