### PR TITLE
Feature #1767 - RegexSwap client reimplementation based on JSON endpoint

### DIFF
--- a/desktop/ui/src/main/java/org/datacleaner/regexswap/RegexSwapDialog.java
+++ b/desktop/ui/src/main/java/org/datacleaner/regexswap/RegexSwapDialog.java
@@ -59,7 +59,6 @@ import org.datacleaner.windows.AbstractDialog;
 import org.jdesktop.swingx.JXTree;
 import org.jdesktop.swingx.renderer.DefaultTreeRenderer;
 import org.jdesktop.swingx.renderer.WrappingIconPanel;
-import org.joda.time.DateTime;
 
 /**
  * A dialog for browsing the online RegexSwap repository.
@@ -68,7 +67,7 @@ public class RegexSwapDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Object[] TABLE_HEADERS = new Object[] { "Name", "Good/bad votes", "Author" };
+    private static final Object[] TABLE_HEADERS = new Object[] { "Name" };
     private static final ImageManager imageManager = ImageManager.get();
     private final RegexSwapClient _client;
     private final JXTree _categoryTree;
@@ -224,7 +223,6 @@ public class RegexSwapDialog extends AbstractDialog {
     private void updateCategories() {
         SharedExecutorService.get().submit((Runnable) () -> {
             final DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode("Categories");
-            _client.refreshCategories();
             final Collection<Category> categories = _client.getCategories();
             for (final Category category : categories) {
                 final DefaultMutableTreeNode categoryNode = new DefaultMutableTreeNode(category);
@@ -244,8 +242,6 @@ public class RegexSwapDialog extends AbstractDialog {
             for (int i = 0; i < regexes.size(); i++) {
                 final Regex regex = regexes.get(i);
                 tableModel.setValueAt(regex.getName(), i, 0);
-                tableModel.setValueAt(regex.getPositiveVotes() + "/" + regex.getNegativeVotes(), i, 1);
-                tableModel.setValueAt(regex.getAuthor(), i, 2);
             }
         }
         synchronized (_regexSelectionTable) {
@@ -265,8 +261,6 @@ public class RegexSwapDialog extends AbstractDialog {
             sb.append(regex.getExpression());
             sb.append("\n\n<b>Description</b>:\n");
             sb.append(regex.getDescription());
-            sb.append("\n\n<b>Submission date</b>:\n");
-            sb.append(new DateTime(regex.getTimestamp() * 1000).toString());
 
             _regexDescriptionLabel.setText(sb.toString());
             _importRegexButton.setEnabled(true);

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/Category.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/Category.java
@@ -30,9 +30,9 @@ public final class Category extends BaseObject implements Serializable {
     private final String _name;
     private final String _description;
     private final String _detailsUrl;
-    
+
     public Category(final String name) {
-    	this(name, null, null);
+        this(name, null, null);
     }
 
     @Deprecated

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/Category.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/Category.java
@@ -30,7 +30,12 @@ public final class Category extends BaseObject implements Serializable {
     private final String _name;
     private final String _description;
     private final String _detailsUrl;
+    
+    public Category(final String name) {
+    	this(name, null, null);
+    }
 
+    @Deprecated
     public Category(final String name, final String description, final String detailsUrl) {
         _name = name;
         _description = description;
@@ -45,6 +50,7 @@ public final class Category extends BaseObject implements Serializable {
         return _description;
     }
 
+    @Deprecated
     public String getDetailsUrl() {
         return _detailsUrl;
     }

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/Regex.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/Regex.java
@@ -26,90 +26,98 @@ import org.apache.metamodel.util.BaseObject;
 
 public final class Regex extends BaseObject implements Serializable {
 
-    private static final long serialVersionUID = 1L;
-    private final String _name;
-    private final String _description;
-    private final String _expression;
-    private final String _author;
-    private final long _timestamp;
-    private final int _positiveVotes;
-    private final int _negativeVotes;
-    private final String _detailsUrl;
-    private final List<Category> _categories;
+	private static final long serialVersionUID = 1L;
+	private final String _name;
+	private final String _description;
+	private final String _expression;
+	private final String _author;
+	private final long _timestamp;
+	private final int _positiveVotes;
+	private final int _negativeVotes;
+	private final String _detailsUrl;
+	private final List<Category> _categories;
 
-    public Regex(final String name, final String description, final String expression, final String author,
-            final long timestamp, final int positiveVotes, final int negativeVotes, final String detailsUrl,
-            final List<Category> categories) {
-        _name = name;
-        _description = description;
-        _expression = expression;
-        _author = author;
-        _timestamp = timestamp;
-        _positiveVotes = positiveVotes;
-        _negativeVotes = negativeVotes;
-        _detailsUrl = detailsUrl;
-        _categories = categories;
-    }
+	public Regex(final String name, final String description, final String expression,
+			final List<Category> categories) {
+		this(name, description, expression, null, -1, 0, 0, null, categories);
+	}
 
-    @Override
-    protected void decorateIdentity(final List<Object> identifiers) {
-        identifiers.add(_name);
-        identifiers.add(_description);
-        identifiers.add(_expression);
-        identifiers.add(_author);
-        identifiers.add(_timestamp);
-        identifiers.add(_positiveVotes);
-        identifiers.add(_negativeVotes);
-        identifiers.add(_detailsUrl);
-        identifiers.add(_categories);
-    }
+	@Deprecated
+	public Regex(final String name, final String description, final String expression, final String author,
+			final long timestamp, final int positiveVotes, final int negativeVotes, final String detailsUrl,
+			final List<Category> categories) {
+		_name = name;
+		_description = description;
+		_expression = expression;
+		_author = author;
+		_timestamp = timestamp;
+		_positiveVotes = positiveVotes;
+		_negativeVotes = negativeVotes;
+		_detailsUrl = detailsUrl;
+		_categories = categories;
+	}
 
-    public String getName() {
-        return _name;
-    }
+	@Override
+	protected void decorateIdentity(final List<Object> identifiers) {
+		identifiers.add(_name);
+		identifiers.add(_description);
+		identifiers.add(_expression);
+		identifiers.add(_author);
+		identifiers.add(_timestamp);
+		identifiers.add(_positiveVotes);
+		identifiers.add(_negativeVotes);
+		identifiers.add(_detailsUrl);
+		identifiers.add(_categories);
+	}
 
-    public String getDescription() {
-        return _description;
-    }
+	public String getName() {
+		return _name;
+	}
 
-    public String getExpression() {
-        return _expression;
-    }
+	public String getDescription() {
+		return _description;
+	}
 
-    public String getAuthor() {
-        return _author;
-    }
+	public String getExpression() {
+		return _expression;
+	}
 
-    public long getTimestamp() {
-        return _timestamp;
-    }
+	@Deprecated
+	public String getAuthor() {
+		return _author;
+	}
 
-    public int getPositiveVotes() {
-        return _positiveVotes;
-    }
+	@Deprecated
+	public long getTimestamp() {
+		return _timestamp;
+	}
 
-    public int getNegativeVotes() {
-        return _negativeVotes;
-    }
+	public int getPositiveVotes() {
+		return _positiveVotes;
+	}
 
-    public String getDetailsUrl() {
-        return _detailsUrl;
-    }
+	public int getNegativeVotes() {
+		return _negativeVotes;
+	}
 
-    public List<Category> getCategories() {
-        return _categories;
-    }
+	public String getDetailsUrl() {
+		return _detailsUrl;
+	}
 
-    public boolean containsCategory(final Category category) {
-        return _categories.contains(category);
-    }
+	public List<Category> getCategories() {
+		return _categories;
+	}
 
-    public String createWebsiteUrl() {
-        return "https://datacleaner.org/regex/" + getName().replaceAll(" ", "%20");
-    }
+	public boolean containsCategory(final Category category) {
+		return _categories.contains(category);
+	}
 
-    @Override
-    public String toString() {
-        return "Regex[name=" + _name + ",expression=" + _expression + "]";
-    }
+	public String createWebsiteUrl() {
+		return "https://datacleaner.org/regex/" + getName().replaceAll(" ", "%20");
+	}
+
+	@Override
+	public String toString() {
+		return "Regex[name=" + _name + ",expression=" + _expression + "]";
+	}
 }

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/Regex.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/Regex.java
@@ -26,98 +26,98 @@ import org.apache.metamodel.util.BaseObject;
 
 public final class Regex extends BaseObject implements Serializable {
 
-	private static final long serialVersionUID = 1L;
-	private final String _name;
-	private final String _description;
-	private final String _expression;
-	private final String _author;
-	private final long _timestamp;
-	private final int _positiveVotes;
-	private final int _negativeVotes;
-	private final String _detailsUrl;
-	private final List<Category> _categories;
+    private static final long serialVersionUID = 1L;
+    private final String _name;
+    private final String _description;
+    private final String _expression;
+    private final String _author;
+    private final long _timestamp;
+    private final int _positiveVotes;
+    private final int _negativeVotes;
+    private final String _detailsUrl;
+    private final List<Category> _categories;
 
-	public Regex(final String name, final String description, final String expression,
-			final List<Category> categories) {
-		this(name, description, expression, null, -1, 0, 0, null, categories);
-	}
+    public Regex(final String name, final String description, final String expression,
+            final List<Category> categories) {
+        this(name, description, expression, null, -1, 0, 0, null, categories);
+    }
 
-	@Deprecated
-	public Regex(final String name, final String description, final String expression, final String author,
-			final long timestamp, final int positiveVotes, final int negativeVotes, final String detailsUrl,
-			final List<Category> categories) {
-		_name = name;
-		_description = description;
-		_expression = expression;
-		_author = author;
-		_timestamp = timestamp;
-		_positiveVotes = positiveVotes;
-		_negativeVotes = negativeVotes;
-		_detailsUrl = detailsUrl;
-		_categories = categories;
-	}
+    @Deprecated
+    public Regex(final String name, final String description, final String expression, final String author,
+            final long timestamp, final int positiveVotes, final int negativeVotes, final String detailsUrl,
+            final List<Category> categories) {
+        _name = name;
+        _description = description;
+        _expression = expression;
+        _author = author;
+        _timestamp = timestamp;
+        _positiveVotes = positiveVotes;
+        _negativeVotes = negativeVotes;
+        _detailsUrl = detailsUrl;
+        _categories = categories;
+    }
 
-	@Override
-	protected void decorateIdentity(final List<Object> identifiers) {
-		identifiers.add(_name);
-		identifiers.add(_description);
-		identifiers.add(_expression);
-		identifiers.add(_author);
-		identifiers.add(_timestamp);
-		identifiers.add(_positiveVotes);
-		identifiers.add(_negativeVotes);
-		identifiers.add(_detailsUrl);
-		identifiers.add(_categories);
-	}
+    @Override
+    protected void decorateIdentity(final List<Object> identifiers) {
+        identifiers.add(_name);
+        identifiers.add(_description);
+        identifiers.add(_expression);
+        identifiers.add(_author);
+        identifiers.add(_timestamp);
+        identifiers.add(_positiveVotes);
+        identifiers.add(_negativeVotes);
+        identifiers.add(_detailsUrl);
+        identifiers.add(_categories);
+    }
 
-	public String getName() {
-		return _name;
-	}
+    public String getName() {
+        return _name;
+    }
 
-	public String getDescription() {
-		return _description;
-	}
+    public String getDescription() {
+        return _description;
+    }
 
-	public String getExpression() {
-		return _expression;
-	}
+    public String getExpression() {
+        return _expression;
+    }
 
-	@Deprecated
-	public String getAuthor() {
-		return _author;
-	}
+    @Deprecated
+    public String getAuthor() {
+        return _author;
+    }
 
-	@Deprecated
-	public long getTimestamp() {
-		return _timestamp;
-	}
+    @Deprecated
+    public long getTimestamp() {
+        return _timestamp;
+    }
 
-	public int getPositiveVotes() {
-		return _positiveVotes;
-	}
+    public int getPositiveVotes() {
+        return _positiveVotes;
+    }
 
-	public int getNegativeVotes() {
-		return _negativeVotes;
-	}
+    public int getNegativeVotes() {
+        return _negativeVotes;
+    }
 
-	public String getDetailsUrl() {
-		return _detailsUrl;
-	}
+    public String getDetailsUrl() {
+        return _detailsUrl;
+    }
 
-	public List<Category> getCategories() {
-		return _categories;
-	}
+    public List<Category> getCategories() {
+        return _categories;
+    }
 
-	public boolean containsCategory(final Category category) {
-		return _categories.contains(category);
-	}
+    public boolean containsCategory(final Category category) {
+        return _categories.contains(category);
+    }
 
-	public String createWebsiteUrl() {
-		return "https://datacleaner.org/regex/" + getName().replaceAll(" ", "%20");
-	}
+    public String createWebsiteUrl() {
+        return "https://datacleaner.org/regex/" + getName().replaceAll(" ", "%20");
+    }
 
-	@Override
-	public String toString() {
-		return "Regex[name=" + _name + ",expression=" + _expression + "]";
-	}
+    @Override
+    public String toString() {
+        return "Regex[name=" + _name + ",expression=" + _expression + "]";
+    }
 }

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/RegexSwapClient.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/RegexSwapClient.java
@@ -34,6 +34,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
+import org.datacleaner.util.SystemProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -42,7 +43,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public final class RegexSwapClient {
 
-    private static final URI REGEXES_URI = URI.create("https://datacleaner.github.io/content/regexes.json");
+    private static final URI REGEXES_URI = URI.create(SystemProperties.getString("org.datacleaner.regexswap.url",
+            "https://datacleaner.github.io/content/regexes.json"));
 
     private final Map<String, Category> _categories = new HashMap<>();
     private final Map<String, Regex> _regexes = new HashMap<>();

--- a/engine/core/src/main/java/org/datacleaner/reference/regexswap/RegexSwapClient.java
+++ b/engine/core/src/main/java/org/datacleaner/reference/regexswap/RegexSwapClient.java
@@ -19,150 +19,101 @@
  */
 package org.datacleaner.reference.regexswap;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.datacleaner.util.http.HttpXmlUtils;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Client class for the RegexSwap, which allows for easy retrieval of shared
  * regular expressions.
- *
- * @author Kasper Sørensen
  */
 public final class RegexSwapClient {
 
-    public static final String CATEGORIES_URL = "https://datacleaner.org/ws/categories";
-    public static final String REGEXES_URL = "https://datacleaner.org/ws/regexes";
+	private static final URI REGEXES_URI = URI.create("https://datacleaner.github.io/content/regexes.json");
 
-    private final Map<String, Category> _categories = new HashMap<>();
-    private final Map<String, Regex> _regexes = new HashMap<>();
-    private final HttpClient _httpClient;
+	private final Map<String, Category> _categories = new HashMap<>();
+	private final Map<String, Regex> _regexes = new HashMap<>();
+	private final HttpClient _httpClient;
 
-    public RegexSwapClient(final HttpClient httpClient) {
-        _httpClient = httpClient;
-    }
+	public RegexSwapClient(final HttpClient httpClient) {
+		_httpClient = httpClient;
+	}
 
-    public Category getCategoryByName(final String name) {
-        Category category = _categories.get(name);
-        if (category == null) {
-            refreshCategories();
-            category = _categories.get(name);
-        }
-        return category;
-    }
+	public Category getCategoryByName(final String name) {
+		if (_regexes.isEmpty()) {
+			refreshRegexes();
+		}
+		return _categories.get(name);
+	}
 
-    public Regex getRegexByName(final String name) {
-        Regex regex = _regexes.get(name);
-        if (regex == null) {
-            refreshRegexes();
-            regex = _regexes.get(name);
-        }
-        return regex;
-    }
+	public Regex getRegexByName(final String name) {
+		if (_regexes.isEmpty()) {
+			refreshRegexes();
+		}
+		return _regexes.get(name);
+	}
 
-    public void refreshRegexes() {
-        final Element rootNode = HttpXmlUtils.getRootNode(_httpClient, REGEXES_URL);
-        final List<Node> regexNodes = HttpXmlUtils.getChildNodesByName(rootNode, "regex");
-        for (final Node node : regexNodes) {
-            createRegex((Element) node);
-        }
-    }
+	@SuppressWarnings("unchecked")
+	public void refreshRegexes() {
+		final HttpUriRequest request = RequestBuilder.get(REGEXES_URI).build();
+		final Map<String, ?> root;
+		try {
+			final HttpResponse response = _httpClient.execute(request);
+			final String json = EntityUtils.toString(response.getEntity());
+			final ObjectMapper objectMapper = new ObjectMapper();
+			root = objectMapper.readValue(json, Map.class);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		final List<?> regexes = (List<?>) root.get("regexes");
+		for (Object node : regexes) {
+			createRegex((Map<String, ?>) node);
+		}
+	}
 
-    public Collection<Category> getCategories() {
-        if (_categories.isEmpty()) {
-            refreshCategories();
-        }
-        return _categories.values();
-    }
+	public Collection<Category> getCategories() {
+		if (_regexes.isEmpty()) {
+			refreshRegexes();
+		}
+		return _categories.values();
+	}
 
-    public void refreshCategories() {
-        final Element rootNode = HttpXmlUtils.getRootNode(_httpClient, CATEGORIES_URL);
-        final List<Node> categoryNodes = HttpXmlUtils.getChildNodesByName(rootNode, "category");
-        for (final Node categoryNode : categoryNodes) {
-            final String name = HttpXmlUtils.getChildNodeText(categoryNode, "name");
-            final String description = HttpXmlUtils.getChildNodeText(categoryNode, "description");
-            final String detailsUrl = HttpXmlUtils.getChildNodeText(categoryNode, "detailsUrl");
+	private Regex createRegex(final Map<String, ?> node) {
+		final String name = (String) node.get("name");
+		final String description = (String) node.get("description");
+		final String expression = (String) node.get("expression");
+		@SuppressWarnings("unchecked")
+		final List<String> tags = (List<String>) node.get("tags");
+		final List<Category> categories = new ArrayList<>();
+		for (final String tag : tags) {
+			Category category = _categories.get(tag);
+			if (category == null) {
+				category = new Category(tag);
+				_categories.put(tag, category);
+			}
+			categories.add(category);
+		}
+		final Regex regex = new Regex(name, description, expression, categories);
+		_regexes.put(name, regex);
+		return regex;
+	}
 
-            final Category category = new Category(name, description, detailsUrl);
-            _categories.put(name, category);
-        }
-    }
-
-    private Regex createRegex(final Element regexNode) {
-        final String name = HttpXmlUtils.getChildNodeText(regexNode, "name");
-        final String description = HttpXmlUtils.getChildNodeText(regexNode, "description");
-        final String expression = HttpXmlUtils.getChildNodeText(regexNode, "expression");
-        final String author = HttpXmlUtils.getChildNodeText(regexNode, "author");
-        final long timestamp = Long.parseLong(HttpXmlUtils.getChildNodeText(regexNode, "timestamp"));
-        final int positiveVotes = Integer.parseInt(HttpXmlUtils.getChildNodeText(regexNode, "positiveVotes"));
-        final int negativeVotes = Integer.parseInt(HttpXmlUtils.getChildNodeText(regexNode, "negativeVotes"));
-        final String detailsUrl = HttpXmlUtils.getChildNodeText(regexNode, "detailsUrl");
-        final List<Category> categories = new ArrayList<>();
-        final List<Node> categoriesNodes = HttpXmlUtils.getChildNodesByName(regexNode, "categories");
-        if (!categoriesNodes.isEmpty()) {
-            final Node categoriesNode = categoriesNodes.get(0);
-            final List<Node> categoryNodes = HttpXmlUtils.getChildNodesByName(categoriesNode, "category");
-            for (final Node categoryNode : categoryNodes) {
-                final String categoryName = HttpXmlUtils.getText(categoryNode);
-                final Category category = getCategoryByName(categoryName);
-                if (category != null) {
-                    categories.add(category);
-                }
-            }
-        }
-        final Regex regex =
-                new Regex(name, description, expression, author, timestamp, positiveVotes, negativeVotes, detailsUrl,
-                        categories);
-        _regexes.put(name, regex);
-        return regex;
-    }
-
-    public Regex refreshRegex(Regex regex) {
-        final String detailsUrl = regex.getDetailsUrl();
-        final Element regexNode = HttpXmlUtils.getRootNode(_httpClient, detailsUrl);
-        regex = createRegex(regexNode);
-        return regex;
-    }
-
-    public List<Regex> getRegexes(final Category category) {
-        final List<Regex> regexes = new ArrayList<>();
-        final Node rootNode = HttpXmlUtils.getRootNode(_httpClient, category.getDetailsUrl());
-        final List<Node> regexNodes = HttpXmlUtils.getChildNodesByName(rootNode, "regex");
-        for (final Node regexNode : regexNodes) {
-
-            final String name = HttpXmlUtils.getChildNodeText(regexNode, "name");
-            final String description = HttpXmlUtils.getChildNodeText(regexNode, "description");
-            final String expression = HttpXmlUtils.getChildNodeText(regexNode, "expression");
-            final String author = HttpXmlUtils.getChildNodeText(regexNode, "author");
-            final long timestamp = Long.parseLong(HttpXmlUtils.getChildNodeText(regexNode, "timestamp"));
-            final int positiveVotes = Integer.parseInt(HttpXmlUtils.getChildNodeText(regexNode, "positiveVotes"));
-            final int negativeVotes = Integer.parseInt(HttpXmlUtils.getChildNodeText(regexNode, "negativeVotes"));
-            final String detailsUrl = HttpXmlUtils.getChildNodeText(regexNode, "detailsUrl");
-
-            final List<Category> categories;
-            Regex regex = _regexes.get(name);
-            if (regex == null) {
-                categories = new ArrayList<>();
-                regex = new Regex(name, description, expression, author, timestamp, positiveVotes, negativeVotes,
-                        detailsUrl, categories);
-            } else {
-                categories = regex.getCategories();
-                if (!categories.contains(category)) {
-                    categories.add(category);
-                }
-            }
-
-            _regexes.put(name, regex);
-
-            regexes.add(regex);
-        }
-        return regexes;
-    }
+	public List<Regex> getRegexes(final Category category) {
+		return _regexes.values().stream().filter(r -> r.getCategories().contains(category))
+				.collect(Collectors.toList());
+	}
 }

--- a/engine/core/src/test/java/org/datacleaner/reference/regexswap/RegexSwapClientTest.java
+++ b/engine/core/src/test/java/org/datacleaner/reference/regexswap/RegexSwapClientTest.java
@@ -33,7 +33,6 @@ public class RegexSwapClientTest {
 
     @Test
     public void testUpdateContent() throws Exception {
-        Assume.assumeTrue(false); // this test is invalid as long as the RegexSwap is not restored
         Assume.assumeTrue(TestHelper.isInternetConnected());
 
         final RegexSwapClient client = new RegexSwapClient(HttpClients.createSystem());
@@ -42,7 +41,7 @@ public class RegexSwapClientTest {
         assertFalse(categories.isEmpty());
         final Category partials = client.getCategoryByName("partials");
         assertEquals("partials", partials.getName());
-        assertNotNull(partials.getDescription());
+        assertNull(partials.getDescription());
 
         final List<Regex> partialsRegexes = client.getRegexes(partials);
 
@@ -61,7 +60,6 @@ public class RegexSwapClientTest {
 
         Regex regex = client.getRegexByName("Integer or rounded decimal");
         assertNotNull(regex);
-        regex = client.refreshRegex(regex);
         final List<Category> regexCategories = regex.getCategories();
         assertFalse(regexCategories.isEmpty());
         for (final Category category : regexCategories) {


### PR DESCRIPTION
As described and discussed in #1767 - this changes the RegexSwapClient class to use https://datacleaner.github.io/content/regexes.json for fetching regexes instead of the decomissioned old XML endpoints.