### PR TITLE
Various dependency updates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         java-version: '8'

--- a/api/src/main/java/org/datacleaner/api/ExternalDocumentation.java
+++ b/api/src/main/java/org/datacleaner/api/ExternalDocumentation.java
@@ -85,7 +85,7 @@ public @interface ExternalDocumentation {
          *
          * @return
          */
-        DocumentationType type();
+        DocumentationType type() default DocumentationType.REFERENCE;
 
         /**
          * Defines the version of DataCleaner that this documentation item was

--- a/components/html-rendering/src/main/java/org/datacleaner/documentation/ComponentDocumentationBuilder.java
+++ b/components/html-rendering/src/main/java/org/datacleaner/documentation/ComponentDocumentationBuilder.java
@@ -155,7 +155,7 @@ public class ComponentDocumentationBuilder {
             out.flush();
             out.close();
         } catch (final TemplateException e) {
-            throw new IllegalStateException("Unexpected templare exception", e);
+            throw new IllegalStateException("Unexpected template exception", e);
         }
     }
 

--- a/components/html-rendering/src/main/java/org/datacleaner/documentation/ComponentDocumentationWrapper.java
+++ b/components/html-rendering/src/main/java/org/datacleaner/documentation/ComponentDocumentationWrapper.java
@@ -35,6 +35,7 @@ import org.datacleaner.api.AnalyzerResult;
 import org.datacleaner.api.ComponentCategory;
 import org.datacleaner.api.Concurrent;
 import org.datacleaner.api.ExternalDocumentation;
+import org.datacleaner.api.ExternalDocumentation.DocumentationLink;
 import org.datacleaner.api.HasAnalyzerResult;
 import org.datacleaner.api.QueryOptimizedFilter;
 import org.datacleaner.descriptors.AnalyzerDescriptor;
@@ -94,13 +95,19 @@ public class ComponentDocumentationWrapper {
         return ReflectionUtils.is(_componentDescriptor.getComponentClass(), QueryOptimizedFilter.class);
     }
 
-    public ExternalDocumentation.DocumentationLink[] getDocumentationLinks() {
+    public DocumentationLinkWrapper[] getDocumentationLinks() {
         final ExternalDocumentation externalDocumentation =
                 _componentDescriptor.getAnnotation(ExternalDocumentation.class);
-        if (externalDocumentation == null) {
-            return new ExternalDocumentation.DocumentationLink[0];
+        if (externalDocumentation == null || externalDocumentation.value() == null) {
+            return new DocumentationLinkWrapper[0];
         }
-        return externalDocumentation.value();
+        final DocumentationLinkWrapper[] result = new DocumentationLinkWrapper[externalDocumentation.value().length];
+        int i = 0;
+        for (final DocumentationLink link : externalDocumentation.value()) {
+            result[i] = new DocumentationLinkWrapper(link);
+            i++;
+        }
+        return result;
     }
 
     public String[] getAliases() {

--- a/components/html-rendering/src/main/java/org/datacleaner/documentation/DocumentationLinkWrapper.java
+++ b/components/html-rendering/src/main/java/org/datacleaner/documentation/DocumentationLinkWrapper.java
@@ -1,0 +1,57 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Free Software Foundation, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.documentation;
+
+import org.datacleaner.api.ExternalDocumentation;
+import org.datacleaner.api.ExternalDocumentation.DocumentationLink;
+
+/**
+ * A wrapper around the {@link ExternalDocumentation.DocumentationLink} object to make it easier for Freemarker
+ * templates to read its values.
+ */
+public class DocumentationLinkWrapper {
+
+    private final DocumentationLink _link;
+
+    public DocumentationLinkWrapper(DocumentationLink link) {
+        _link = link;
+    }
+
+    public String getTitle() {
+        return _link.title();
+    }
+
+    public String getUrl() {
+        return _link.url();
+    }
+
+    public String getType() {
+        if (_link.type() == null) {
+            return null;
+        }
+        return _link.type().toString();
+    }
+
+    public String getVersion() {
+        return _link.version();
+    }
+
+    
+}

--- a/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
+++ b/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
@@ -86,16 +86,14 @@ h3 {
 					<div>${component.description}</div>
 					
 					<#list component.documentationLinks as link>
-					<#if link.url?? && link.title??>
 					<div>
-						<#if link.type?? && link.type.name == 'VIDEO'>
+						<#if link.type == 'VIDEO'>
 						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
 						<#else>
 						<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
 						</#if>
 						<a href="${link.url}">${link.title}</a>
 					</div>
-					</#if>
 					</#list>
 				</div>
 

--- a/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
+++ b/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
@@ -87,7 +87,7 @@ h3 {
 					
 					<#list component.documentationLinks as link>
 					<div>
-						<#if link.type().name() == 'VIDEO'>
+						<#if link.type() != null && link.type().name() == 'VIDEO'>
 						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
 						<#else>
 						<span class="glyphicon glyphicon-book" aria-hidden="true"></span>

--- a/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
+++ b/components/html-rendering/src/main/resources/org/datacleaner/documentation/template_component.html
@@ -86,14 +86,16 @@ h3 {
 					<div>${component.description}</div>
 					
 					<#list component.documentationLinks as link>
+					<#if link.url?? && link.title??>
 					<div>
-						<#if link.type() != null && link.type().name() == 'VIDEO'>
+						<#if link.type?? && link.type.name == 'VIDEO'>
 						<span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span>
 						<#else>
 						<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
 						</#if>
-						<a href="${link.url()}">${link.title()}</a>
+						<a href="${link.url}">${link.title}</a>
 					</div>
+					</#if>
 					</#list>
 				</div>
 

--- a/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
+++ b/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
@@ -1,0 +1,94 @@
+/**
+ * DataCleaner (community edition)
+ * Copyright (C) 2014 Free Software Foundation, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.datacleaner.documentation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.commons.io.FileUtils;
+import org.datacleaner.api.Concurrent;
+import org.datacleaner.api.Configured;
+import org.datacleaner.api.Description;
+import org.datacleaner.api.ExternalDocumentation;
+import org.datacleaner.api.ExternalDocumentation.DocumentationLink;
+import org.datacleaner.api.ExternalDocumentation.DocumentationType;
+import org.datacleaner.api.InputColumn;
+import org.datacleaner.api.InputRow;
+import org.datacleaner.api.OutputColumns;
+import org.datacleaner.api.Transformer;
+import org.datacleaner.descriptors.ComponentDescriptor;
+import org.datacleaner.descriptors.Descriptors;
+import org.junit.Test;
+
+public class ComponentDocumentationBuilderTest {
+
+    @SuppressWarnings("unused")
+    @Named("NameName")
+    @Description("A transformer for which to generate docs")
+    @ExternalDocumentation({ @DocumentationLink(title = "Internationalization in DataCleaner",
+            url = "https://www.youtube.com/watch?v=ApA-nhtLbhI", type = DocumentationType.VIDEO, version = "3.0") })
+    @Concurrent(true)
+    private static class ExampleTransformer implements Transformer {
+
+        @Inject
+        @Configured
+        String stringProp;
+
+        @Inject
+        @Configured
+        InputColumn<String> columnProp;
+
+        @Override
+        public OutputColumns getOutputColumns() {
+            throw new IllegalStateException("This won't work");
+        }
+
+        @Override
+        public Object[] transform(InputRow inputRow) {
+            throw new IllegalStateException("This won't work");
+        }
+    }
+
+    @Test
+    public void testGenerateSimple() throws Exception {
+        final File directory = new File("target/component_reference_documentation");
+        if (directory.exists()) {
+            FileUtils.deleteDirectory(directory);
+        }
+
+        final ComponentDescriptor<?> componentDescriptor = Descriptors.ofTransformer(ExampleTransformer.class);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final ComponentDocumentationBuilder builder = new ComponentDocumentationBuilder(true);
+        builder.write(componentDescriptor, out);
+
+        final String str = new String(out.toByteArray());
+        assertTrue(str.length() > 100);
+        assertTrue(str.indexOf("<title>NameName</title>") != -1);
+        assertTrue(str.indexOf("String prop") != -1);
+        assertTrue(str.indexOf("Column prop") != -1);
+    }
+}

--- a/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
+++ b/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
@@ -19,16 +19,13 @@
  */
 package org.datacleaner.documentation;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.io.FileUtils;
 import org.datacleaner.api.Concurrent;
 import org.datacleaner.api.Configured;
 import org.datacleaner.api.Description;
@@ -74,11 +71,6 @@ public class ComponentDocumentationBuilderTest {
 
     @Test
     public void testGenerateSimple() throws Exception {
-        final File directory = new File("target/component_reference_documentation");
-        if (directory.exists()) {
-            FileUtils.deleteDirectory(directory);
-        }
-
         final ComponentDescriptor<?> componentDescriptor = Descriptors.ofTransformer(ExampleTransformer.class);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
+++ b/components/html-rendering/src/test/java/org/datacleaner/documentation/ComponentDocumentationBuilderTest.java
@@ -82,5 +82,7 @@ public class ComponentDocumentationBuilderTest {
         assertTrue(str.indexOf("<title>NameName</title>") != -1);
         assertTrue(str.indexOf("String prop") != -1);
         assertTrue(str.indexOf("Column prop") != -1);
+        
+        assertTrue(str.indexOf("Internationalization in DataCleaner") != -1);
     }
 }

--- a/desktop/ui/src/main/java/org/datacleaner/output/datastore/DatastoreOutputUtils.java
+++ b/desktop/ui/src/main/java/org/datacleaner/output/datastore/DatastoreOutputUtils.java
@@ -52,7 +52,7 @@ final class DatastoreOutputUtils {
     }
 
     public static String getJdbcUrl(final File directory, final String dbName) {
-        final String urlSuffix = directory.getPath() + File.separatorChar + safeName(dbName);
+        final String urlSuffix = directory.getAbsolutePath() + File.separatorChar + safeName(dbName);
         return "jdbc:h2:" + urlSuffix + ";FILE_LOCK=FS";
     }
 }

--- a/desktop/ui/src/test/java/org/datacleaner/documentation/builder/ComponentDocumentationBuilderIntegrationTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/documentation/builder/ComponentDocumentationBuilderIntegrationTest.java
@@ -37,7 +37,7 @@ import org.datacleaner.documentation.ComponentDocumentationBuilder;
 import org.datacleaner.util.StringUtils;
 import org.junit.Test;
 
-public class ComponentDocumentationBuilderTest {
+public class ComponentDocumentationBuilderIntegrationTest {
 
     private final ComponentDocumentationBuilder documentationCreator = new ComponentDocumentationBuilder(true);
 

--- a/desktop/ui/src/test/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialogTest.java
+++ b/desktop/ui/src/test/java/org/datacleaner/windows/OpenAnalysisJobAsTemplateDialogTest.java
@@ -50,6 +50,7 @@ import org.datacleaner.job.ImmutableAnalysisJobMetadata;
 import org.datacleaner.test.TestHelper;
 import org.datacleaner.util.VFSUtils;
 import org.datacleaner.widgets.LoadingIcon;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,9 +92,8 @@ public class OpenAnalysisJobAsTemplateDialogTest {
 
     @Test
     public void testGetDialogWidth() throws Exception {
-        if (!GraphicsEnvironment.isHeadless()) {
-            assertEquals(600, getDialog().getDialogWidth());
-        }
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        assertTrue(getDialog().getDialogWidth() >= 600);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<metamodel.version>5.3.4</metamodel.version>
 		<metamodel.extras.version>5.3.4</metamodel.extras.version>
 		<spring.core.version>4.3.26.RELEASE</spring.core.version>
-		<freemarker.version>2.3.30</freemarker.version>
+		<freemarker.version>2.3.31</freemarker.version>
 		<icu4j.version>65.1</icu4j.version>
 		<jackson.version>2.13.1</jackson.version>
 		<javax.servlet.version>3.1.0</javax.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<metamodel.version>5.3.4</metamodel.version>
 		<metamodel.extras.version>5.3.4</metamodel.extras.version>
 		<spring.core.version>4.3.26.RELEASE</spring.core.version>
-		<freemarker.version>2.3.31</freemarker.version>
+		<freemarker.version>2.3.29</freemarker.version>
 		<icu4j.version>65.1</icu4j.version>
 		<jackson.version>2.13.1</jackson.version>
 		<javax.servlet.version>3.1.0</javax.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,23 +10,23 @@
 		<javadoc.version>3.0.1</javadoc.version>
 
 		<!-- Dependency versions -->
-		<slf4j.version>1.7.30</slf4j.version>
+		<slf4j.version>1.7.32</slf4j.version>
 		<junit.version>4.13.1</junit.version>
 		<easymock.version>3.6</easymock.version>
 		<httpcomponents.version>4.5.13</httpcomponents.version>
 		<metamodel.version>5.3.4</metamodel.version>
 		<metamodel.extras.version>5.3.4</metamodel.extras.version>
 		<spring.core.version>4.3.26.RELEASE</spring.core.version>
-		<freemarker.version>2.3.29</freemarker.version>
+		<freemarker.version>2.3.31</freemarker.version>
 		<icu4j.version>65.1</icu4j.version>
-		<jackson.version>2.12.1</jackson.version>
+		<jackson.version>2.13.1</jackson.version>
 		<javax.servlet.version>3.1.0</javax.servlet.version>
 		<javax.el.version>2.2.5</javax.el.version>
 		<javax.annotation.version>1.2</javax.annotation.version>
 		<scala.version>2.12.11</scala.version>
 		<jung.version>2.1.1</jung.version>
-		<guava.version>29.0-jre</guava.version>
-		<hadoop.version>3.1.1</hadoop.version>
+		<guava.version>31.0-jre</guava.version>
+		<hadoop.version>3.3.1</hadoop.version>
 		<spark.version>2.4.4</spark.version>
 		<curator.version>2.13.0</curator.version>
 	</properties>
@@ -1135,12 +1135,12 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.11</version>
+				<version>42.3.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>1.3.176</version>
+				<version>2.0.206</version>
 			</dependency>
 			<dependency>
 				<groupId>hsqldb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<metamodel.version>5.3.4</metamodel.version>
 		<metamodel.extras.version>5.3.4</metamodel.extras.version>
 		<spring.core.version>4.3.26.RELEASE</spring.core.version>
-		<freemarker.version>2.3.29</freemarker.version>
+		<freemarker.version>2.3.30</freemarker.version>
 		<icu4j.version>65.1</icu4j.version>
 		<jackson.version>2.13.1</jackson.version>
 		<javax.servlet.version>3.1.0</javax.servlet.version>


### PR DESCRIPTION
slf4j, freemarker, jackson, guava, hadoop, postgresql, h2

Note that a bit of coding was actually needed for the Freemarker upgrade. This was to ensure that annotation/reflection types would have normal getter methods which is required by newer versions of Freemarker it seems.