### PR TITLE
Remove netty dependency, and thereby vulnerability :-O

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -30,11 +30,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1294,11 +1294,6 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-all</artifactId>
-				<version>4.1.42.Final</version>
-			</dependency>
 
 			<dependency>
 				<groupId>commons-lang</groupId>


### PR DESCRIPTION
According to dependabot we have a [vulnerability of using netty](https://github.com/datacleaner/DataCleaner/security/dependabot/pom.xml/io.netty:netty-all/open).

So I took a look to see what we're using it for. And it turns out ... We're not using it!

Thinking back, I recall that Netty was used in the past to power an integration with the extension swap website. So that's probably why it's still in our dependency list. But this PR removes it, finally.