### PR TITLE
Updated Netty to v 4.1.73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1305,7 +1305,7 @@
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
-				<version>4.1.42.Final</version>
+				<version>4.1.73.Final</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Seeing as #1903 didn't work (seems we DO have a (transitive) dependency on netty still for Cassandra), this just updates Netty to fix the security vulnerability with it.