### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
 					<source>1.8</source>
 					<target>1.8</target>
 					<encoding>utf-8</encoding>
+					<fork>true</fork>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
