### PR TITLE
Updated xml-config module to use latest Jakarta JAXB generator

### DIFF
--- a/engine/xml-config/pom.xml
+++ b/engine/xml-config/pom.xml
@@ -148,6 +148,10 @@
 			<artifactId>jakarta.xml.bind-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>jakarta.activation</groupId>
 			<artifactId>jakarta.activation-api</artifactId>
 		</dependency>

--- a/engine/xml-config/src/main/bindings/bindings-job.xjb
+++ b/engine/xml-config/src/main/bindings/bindings-job.xjb
@@ -1,5 +1,9 @@
-<bindings xmlns="http://java.sun.com/xml/ns/jaxb" xmlns:xsi="http://www.w3.org/2000/10/XMLSchema-instance"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.1">
+<bindings xmlns="https://jakarta.ee/xml/ns/jaxb"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+          version="3.0">
+
 	<bindings schemaLocation="../resources/job.xsd" version="1.0">
 		<schemaBindings>
 			<package name="org.eobjects.analyzer.job.jaxb" />

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbConfigurationReader.java
@@ -36,11 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.metamodel.csv.CsvConfiguration;
@@ -185,6 +180,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * Configuration reader that uses the JAXB model to read XML file based configurations for DataCleaner.

--- a/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbPojoDatastoreAdaptor.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/configuration/JaxbPojoDatastoreAdaptor.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.xml.bind.JAXBElement;
-
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.data.DataSet;
@@ -64,6 +62,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import jakarta.xml.bind.JAXBElement;
 
 /**
  * Convenient utility class for reading and writing POJO datastores from and to

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobReader.java
@@ -36,9 +36,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.apache.commons.vfs2.FileObject;
@@ -98,6 +95,10 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 public class JaxbJobReader implements JobReader<InputStream> {
 

--- a/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/job/JaxbJobWriter.java
@@ -31,10 +31,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.Schema;
@@ -84,6 +80,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 public class JaxbJobWriter implements JobWriter<OutputStream> {
 

--- a/engine/xml-config/src/main/java/org/datacleaner/util/JaxbValidationEventHandler.java
+++ b/engine/xml-config/src/main/java/org/datacleaner/util/JaxbValidationEventHandler.java
@@ -19,11 +19,11 @@
  */
 package org.datacleaner.util;
 
-import javax.xml.bind.ValidationEvent;
-import javax.xml.bind.ValidationEventHandler;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.xml.bind.ValidationEvent;
+import jakarta.xml.bind.ValidationEventHandler;
 
 public final class JaxbValidationEventHandler implements ValidationEventHandler {
 

--- a/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbPojoDatastoreAdaptorTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/configuration/JaxbPojoDatastoreAdaptorTest.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBContext;
-
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.pojo.ArrayTableDataProvider;
 import org.apache.metamodel.pojo.TableDataProvider;
@@ -45,6 +43,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.xml.bind.JAXBContext;
 import junit.framework.TestCase;
 
 public class JaxbPojoDatastoreAdaptorTest extends TestCase {

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -260,7 +260,7 @@ public class JaxbJobReaderTest extends TestCase {
             fail("Exception expected");
         } catch (final IllegalArgumentException e) {
             final String message = e.getMessage();
-            assertTrue(message, message.startsWith("javax.xml.bind.UnmarshalException"));
+            assertTrue(message, message.startsWith("jakarta.xml.bind.UnmarshalExceptionn"));
             assertTrue(message, message.toLowerCase().contains("uri:\"http://eobjects.org/analyzerbeans/job/1.0\""));
             assertTrue(message, message.contains("\"datacontext\""));
         }

--- a/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
+++ b/engine/xml-config/src/test/java/org/datacleaner/job/JaxbJobReaderTest.java
@@ -260,9 +260,9 @@ public class JaxbJobReaderTest extends TestCase {
             fail("Exception expected");
         } catch (final IllegalArgumentException e) {
             final String message = e.getMessage();
-            assertTrue(message, message.startsWith("jakarta.xml.bind.UnmarshalExceptionn"));
-            assertTrue(message, message.toLowerCase().contains("uri:\"http://eobjects.org/analyzerbeans/job/1.0\""));
-            assertTrue(message, message.contains("\"datacontext\""));
+            assertTrue(message, message.startsWith("jakarta.xml.bind.UnmarshalException: "));
+            TestHelper.assertStringContains(message.toLowerCase(), "uri:\"http://eobjects.org/analyzerbeans/job/1.0\"");
+            TestHelper.assertStringContains(message, "\"datacontext\"");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
 										<exclude>javax.transaction:transaction-api:*</exclude>
 										
 										<!-- prefer jakarta.activation-api over any other activation jar -->
-										<exclude>com.sun.activation:jakarta.activation:*</exclude>
 										<exclude>javax.activation:activation:*</exclude>
 										<exclude>javax.activation:javax.activation-api:*</exclude>
 										
@@ -408,7 +407,6 @@
 										<exclude>commons-beanutils:commons-beanutils-core:*</exclude>
 
 										<!-- prefer jakarta.xml-bind-api over any other jaxb jar -->
-										<exclude>com.sun.xml.bind:jaxb-impl:*</exclude>
 										<exclude>com.sun.xml.bind:jaxb-xjc:*</exclude>
 										<exclude>javax.xml.bind:jaxb-api:*</exclude>
 										<exclude>org.glassfish.jaxb:jaxb-runtime:*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<spark.version>2.4.4</spark.version>
 		<curator.version>2.13.0</curator.version>
 		<log4j.version>2.17.1</log4j.version>
+		<xml.bind.api.version>3.0.1</xml.bind.api.version>
 	</properties>
 	<parent>
 		<!-- Uses the OSS sonatype nexus repository for distribution -->
@@ -591,9 +592,19 @@
 					<version>0.14.0</version>
 					<dependencies>
 						<dependency>
-							<groupId>org.glassfish.jaxb</groupId>
-							<artifactId>jaxb-runtime</artifactId>
-							<version>2.3.5</version>
+							<groupId>com.sun.xml.bind</groupId>
+							<artifactId>jaxb-xjc</artifactId>
+							<version>3.0.2</version>
+						</dependency>
+						<dependency>
+							<groupId>com.sun.xml.bind</groupId>
+							<artifactId>jaxb-impl</artifactId>
+							<version>3.0.2</version>
+						</dependency>
+						<dependency>
+							<groupId>jakarta.xml.bind</groupId>
+							<artifactId>jakarta.xml.bind-api</artifactId>
+							<version>${xml.bind.api.version}</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -870,7 +881,7 @@
 			<dependency>
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>3.0.1</version>
+				<version>${xml.bind.api.version}</version>
 				<exclusions>
 					<exclusion>
 						<groupId>com.sun.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
 		<spark.version>2.4.4</spark.version>
 		<curator.version>2.13.0</curator.version>
 		<log4j.version>2.17.1</log4j.version>
-		<xml.bind.api.version>3.0.1</xml.bind.api.version>
+		<jaxb.api.version>3.0.1</jaxb.api.version>
+		<jaxb.impl.version>3.0.2</jaxb.impl.version>
 	</properties>
 	<parent>
 		<!-- Uses the OSS sonatype nexus repository for distribution -->
@@ -594,17 +595,17 @@
 						<dependency>
 							<groupId>com.sun.xml.bind</groupId>
 							<artifactId>jaxb-xjc</artifactId>
-							<version>3.0.2</version>
+							<version>${jaxb.api.version}</version>
 						</dependency>
 						<dependency>
 							<groupId>com.sun.xml.bind</groupId>
 							<artifactId>jaxb-impl</artifactId>
-							<version>3.0.2</version>
+							<version>${jaxb.api.version}</version>
 						</dependency>
 						<dependency>
 							<groupId>jakarta.xml.bind</groupId>
 							<artifactId>jakarta.xml.bind-api</artifactId>
-							<version>${xml.bind.api.version}</version>
+							<version>${jaxb.api.version}</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -879,9 +880,14 @@
 				<version>1.3</version>
 			</dependency>
 			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-impl</artifactId>
+				<version>${jaxb.api.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>${xml.bind.api.version}</version>
+				<version>${jaxb.api.version}</version>
 				<exclusions>
 					<exclusion>
 						<groupId>com.sun.activation</groupId>


### PR DESCRIPTION
As far as I can tell, the root cause for #1913 is that JAXB is missing at runtime on newer Java versions. And that's because we shouldn't be using the old jaxb namespaces, but the new Jakarta based JAXB namespaces. This PR fixes that.